### PR TITLE
Migrate Investor Profile from OpenAI to Claude 3.5 Sonnet

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,9 +7,6 @@ VITE_SUPABASE_URL=https://ibsisfnjxeowvdtvgzff.supabase.co
 VITE_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY_HERE
 VITE_SUPABASE_REDIRECT_URL=http://localhost:5173/
 
-# OpenAI keys
-# Prefer using `OPENAI_API_KEY` only from server-side / backend code.
-OPENAI_API_KEY=YOUR_SERVER_SIDE_OPENAI_KEY_HERE
-
-# For any client-side usage via Vite (if absolutely necessary):
-VITE_OPENAI_API_KEY=YOUR_CLIENT_SIDE_OPENAI_KEY_HERE
+# Anthropic Claude API key (for investor profile generation)
+# Used client-side via Vite to generate AI-powered investor profiles
+VITE_ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY_HERE

--- a/INVESTOR_PROFILE_IMPLEMENTATION.md
+++ b/INVESTOR_PROFILE_IMPLEMENTATION.md
@@ -8,7 +8,7 @@ This document describes the complete implementation of the AI-powered Investor P
 ### Flow
 1. **User Input (5 fields)** → Form Component
 2. **Context Enrichment** → Phone → Country/Currency, Email → Type, Age → Life Stage
-3. **AI Profile Generation** → OpenAI GPT-4o generates 12 fields with confidence scores
+3. **AI Profile Generation** → Claude 3.5 Sonnet generates 12 fields with confidence scores
 4. **Review & Edit** → User reviews AI suggestions and can edit any field
 5. **Confirmation** → Profile saved to Supabase with user confirmation
 
@@ -44,11 +44,11 @@ This document describes the complete implementation of the AI-powered Investor P
 
 #### AI Profile Generation Service
 **File:** `src/services/investorProfile/generateProfile.ts`
-- Uses OpenAI GPT-4o model (temperature 0.3 for consistency)
+- Uses Anthropic Claude 3.5 Sonnet model (temperature 0.3 for consistency)
 - Comprehensive system prompt with all 12 field schemas
 - Validates all required fields in AI response
 - Returns structured InvestorProfile with confidence scores
-- **Status:** ✅ Complete
+- **Status:** ✅ Complete (Updated to Claude API)
 
 #### Main Service Functions
 **File:** `src/services/investorProfile/index.ts`


### PR DESCRIPTION
…laude 3.5 Sonnet

- Updated generateProfile.ts to use Anthropic API instead of OpenAI
- Changed endpoint from OpenAI v1/chat/completions to Anthropic v1/messages
- Updated headers: Authorization Bearer → x-api-key with anthropic-version
- Changed response parsing: choices[0].message.content → content[0].text
- Using claude-3-5-sonnet-20241022 model with max_tokens: 4096
- Updated .env.local.example: VITE_OPENAI_API_KEY → VITE_ANTHROPIC_API_KEY
- Updated documentation to reflect Claude API usage
- Improved error messages for Anthropic API failures

Reason: OpenAI API quota exceeded (429 error), migrating to Claude for better reliability