### PR TITLE
Switch investor profile API from Claude to OpenAI GPT-4o

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -7,7 +7,7 @@ VITE_SUPABASE_URL=https://ibsisfnjxeowvdtvgzff.supabase.co
 VITE_SUPABASE_ANON_KEY=YOUR_SUPABASE_ANON_KEY_HERE
 VITE_SUPABASE_REDIRECT_URL=http://localhost:5173/
 
-# Anthropic Claude API key (for investor profile generation)
+# OpenAI API key (for investor profile generation)
 # Used SERVER-SIDE in serverless API function /api/generate-investor-profile.js
 # This is NOT exposed to the client (no VITE_ prefix) for security
-ANTHROPIC_API_KEY=YOUR_ANTHROPIC_API_KEY_HERE
+OPENAI_API_KEY=YOUR_OPENAI_API_KEY_HERE


### PR DESCRIPTION
- Updated /api/generate-investor-profile.js to use OpenAI API
- Changed from Anthropic endpoint to OpenAI chat/completions
- Updated model from claude-3-5-sonnet to gpt-4o
- Fixed response parsing for OpenAI format (choices[0].message.content)
- Updated environment variable from ANTHROPIC_API_KEY to OPENAI_API_KEY
- Updated .env.local.example with OpenAI key reference

All other functionality remains the same:
- Same 5 input fields
- Same context enrichment
- Same 12 investor profile fields
- Same UI/UX flow
- Same database structure