### PR TITLE
Fix 405 Method Not Allowed error by removing conflicting rewrites

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,5 @@
 {
-    "rewrites": [
-      { "source": "/(.*)", "destination": "/" },
-      { "source": "/api/(.*)", "destination": "/api/$1" }
-    ],
-    "builds": [
+  "builds": [
     {
       "src": "package.json",
       "use": "@vercel/static-build",


### PR DESCRIPTION
- Removed rewrites array from vercel.json
- Catch-all rewrite was intercepting API requests before serverless functions
- Vercel automatically handles /api routes without rewrites
- This fixes the 405 error on production for /api/generate-investor-profile

Issue: Rewrites were in wrong order, causing all requests to redirect to /
Solution: Remove rewrites entirely - Vercel handles routing automatically