### PR TITLE
Fix API 405 error by using routes with proper precedence

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,13 @@
 {
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/$1"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
+    }
   ],
   "builds": [
     {


### PR DESCRIPTION
- Changed from rewrites to routes for explicit order control
- API routes (/api/*) handled first
- SPA fallback (/*) handled second
- This ensures serverless functions execute instead of returning HTML

Previous issue: rewrites don't guarantee order, causing SPA fallback to intercept API requests on production