### PR TITLE
feat: Integrate DM Sans font across entire application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emailjs/browser": "^4.4.1",
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@fontsource/dm-sans": "^5.2.8",
         "@headlessui/react": "^1.7.17",
         "@mdx-js/react": "^3.1.0",
         "@supabase/supabase-js": "^2.46.1",
@@ -2818,6 +2819,15 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emailjs/browser": "^4.4.1",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@fontsource/dm-sans": "^5.2.8",
     "@headlessui/react": "^1.7.17",
     "@mdx-js/react": "^3.1.0",
     "@supabase/supabase-js": "^2.46.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Footer from './components/Footer';
 import Login from './pages/Login'
 import Contact from './pages/Contact';
 import { ChakraProvider } from '@chakra-ui/react';
+import theme from './theme';
 import Consumers from './pages/services/consumers';
 import Business from './pages/services/business';
 import Signup from './pages/Signup';
@@ -109,7 +110,7 @@ function App() {
   }, []);
   
   return (
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
       <Router>
         <div className="min-h-screen flex flex-col">
           <Navbar />

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,23 @@
-@import url('https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --font-main: "DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
 html, body {
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, sans-serif !important;
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-main) !important;
+  line-height: 1.5;
+}
+
+/* Enhanced typography for headings */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-main);
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 .gradient-bg {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,12 @@ import App from './App.tsx'
 import './index.css'
 import config from './resources/config/config.ts'
 
+// Import DM Sans font weights
+import "@fontsource/dm-sans/400.css";
+import "@fontsource/dm-sans/500.css";
+import "@fontsource/dm-sans/600.css";
+import "@fontsource/dm-sans/700.css";
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,10 @@
+import { extendTheme } from "@chakra-ui/react";
+
+const theme = extendTheme({
+  fonts: {
+    heading: `"DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`,
+    body: `"DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`,
+  },
+});
+
+export default theme;


### PR DESCRIPTION
- Install @fontsource/dm-sans package with weights 400, 500, 600, 700
- Create custom Chakra UI theme with DM Sans for headings and body
- Update main.tsx to import all DM Sans font weights
- Update App.tsx to use custom Chakra theme
- Update index.css with DM Sans as global font with enhanced typography
- Remove unused Figtree font import
- Self-hosted fonts for better performance and privacy