### PR TITLE
feat: add URL sharing & MCP endpoints display

### DIFF
--- a/src/components/DeveloperSettings.tsx
+++ b/src/components/DeveloperSettings.tsx
@@ -1,0 +1,233 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Heading,
+  Text,
+  VStack,
+  HStack,
+  Icon,
+  IconButton,
+  useClipboard,
+  Collapse,
+  Code,
+  Divider,
+} from "@chakra-ui/react";
+import { ChevronDown, ChevronUp, Copy, Check, Terminal, Code as CodeIcon } from "lucide-react";
+import resources from "../resources/resources";
+
+interface EndpointCardProps {
+  title: string;
+  description: string;
+  endpoint: string;
+  method?: string;
+}
+
+const EndpointCard: React.FC<EndpointCardProps> = ({ title, description, endpoint, method = "GET" }) => {
+  const { hasCopied, onCopy } = useClipboard(endpoint);
+
+  return (
+    <Box
+      bg="#F8FAFC"
+      border="1px solid #E2E8F0"
+      borderRadius="12px"
+      p={4}
+      transition="all 0.2s ease"
+      _hover={{
+        borderColor: "#CBD5E1",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
+      }}
+    >
+      <VStack align="stretch" spacing={3}>
+        <HStack justify="space-between" align="flex-start">
+          <VStack align="flex-start" spacing={1} flex={1}>
+            <HStack spacing={2}>
+              <Box
+                px={2}
+                py={0.5}
+                bg={method === "POST" ? "#FEF3C7" : "#DBEAFE"}
+                color={method === "POST" ? "#92400E" : "#1E40AF"}
+                borderRadius="6px"
+                fontSize="11px"
+                fontWeight="700"
+                letterSpacing="0.05em"
+              >
+                {method}
+              </Box>
+              <Text fontSize="15px" fontWeight="700" color="#0B1120">
+                {title}
+              </Text>
+            </HStack>
+            <Text fontSize="13px" color="#64748B" lineHeight="1.5">
+              {description}
+            </Text>
+          </VStack>
+        </HStack>
+
+        <Box
+          bg="white"
+          border="1px solid #E2E8F0"
+          borderRadius="8px"
+          p={3}
+          fontFamily="'Monaco', 'Menlo', monospace"
+        >
+          <HStack spacing={2} justify="space-between">
+            <Code
+              fontSize="12px"
+              color="#0F172A"
+              bg="transparent"
+              p={0}
+              flex={1}
+              wordBreak="break-all"
+              whiteSpace="pre-wrap"
+            >
+              {endpoint}
+            </Code>
+            <IconButton
+              aria-label="Copy endpoint"
+              icon={<Icon as={hasCopied ? Check : Copy} boxSize={4} />}
+              onClick={onCopy}
+              size="sm"
+              variant="ghost"
+              colorScheme={hasCopied ? "green" : "gray"}
+              minW="32px"
+              h="32px"
+              _hover={{ bg: "#F1F5F9" }}
+            />
+          </HStack>
+        </Box>
+      </VStack>
+    </Box>
+  );
+};
+
+interface DeveloperSettingsProps {
+  investorSlug?: string;
+}
+
+const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ investorSlug }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Get Supabase URL - use the actual deployed URL
+  const supabaseUrl = "https://ibsisfnjxeowvdtvgzff.supabase.co";
+  
+  const endpoints = [
+    {
+      title: "MCP Discovery Endpoint",
+      description: "Get available MCP tools and resources for agent-to-agent communication",
+      endpoint: `${supabaseUrl}/functions/v1/investor-agent-mcp`,
+      method: "GET",
+    },
+    {
+      title: "Chat Endpoint",
+      description: "Public chat endpoint for conversing with investor profiles",
+      endpoint: investorSlug
+        ? `${supabaseUrl}/functions/v1/investor-chat?slug=${investorSlug}`
+        : `${supabaseUrl}/functions/v1/investor-chat?slug={investor-slug}`,
+      method: "POST",
+    },
+    {
+      title: "AgentCard Endpoint",
+      description: "Get structured agent card data for LLM-to-LLM discovery",
+      endpoint: investorSlug
+        ? `${supabaseUrl}/functions/v1/investor-agent-mcp/agentcard?slug=${investorSlug}`
+        : `${supabaseUrl}/functions/v1/investor-agent-mcp/agentcard?slug={investor-slug}`,
+      method: "GET",
+    },
+  ];
+
+  return (
+    <Box
+      bg="white"
+      border="1px solid #E2E8F0"
+      borderRadius="16px"
+      overflow="hidden"
+      boxShadow="0 1px 3px rgba(0,0,0,0.04)"
+    >
+      <Button
+        w="full"
+        onClick={() => setIsExpanded(!isExpanded)}
+        variant="ghost"
+        justifyContent="space-between"
+        p={5}
+        h="auto"
+        borderRadius={0}
+        _hover={{ bg: "#F8FAFC" }}
+        _active={{ bg: "#F1F5F9" }}
+      >
+        <HStack spacing={3}>
+          <Box
+            bg="linear-gradient(135deg, #6366F1 0%, #8B5CF6 100%)"
+            p={2}
+            borderRadius="10px"
+          >
+            <Icon as={Terminal} color="white" boxSize={5} />
+          </Box>
+          <VStack align="flex-start" spacing={0.5}>
+            <Text fontSize="16px" fontWeight="700" color="#0B1120">
+              Developer Settings
+            </Text>
+            <Text fontSize="13px" color="#64748B" fontWeight="500">
+              API endpoints for MCP integration
+            </Text>
+          </VStack>
+        </HStack>
+        <Icon
+          as={isExpanded ? ChevronUp : ChevronDown}
+          boxSize={5}
+          color="#64748B"
+          transition="transform 0.2s ease"
+        />
+      </Button>
+
+      <Collapse in={isExpanded} animateOpacity>
+        <Box p={5} pt={0}>
+          <Divider mb={4} />
+          
+          <VStack align="stretch" spacing={4}>
+            <Box
+              bg="#F0F9FF"
+              border="1px solid #BAE6FD"
+              borderRadius="10px"
+              p={4}
+            >
+              <HStack spacing={2} mb={2}>
+                <Icon as={CodeIcon} color="#0369A1" boxSize={4} />
+                <Text fontSize="14px" fontWeight="700" color="#0369A1">
+                  About MCP (Model Context Protocol)
+                </Text>
+              </HStack>
+              <Text fontSize="13px" color="#075985" lineHeight="1.6">
+                These endpoints enable AI agents to discover and interact with investor profiles.
+                The MCP standard allows agents to access structured data and tools for agent-to-agent
+                communication.
+              </Text>
+            </Box>
+
+            {endpoints.map((endpoint, index) => (
+              <EndpointCard key={index} {...endpoint} />
+            ))}
+
+            <Box
+              bg="#FEF3C7"
+              border="1px solid #FDE68A"
+              borderRadius="10px"
+              p={4}
+              mt={2}
+            >
+              <Text fontSize="12px" fontWeight="600" color="#92400E" mb={2}>
+                📝 Note:
+              </Text>
+              <Text fontSize="12px" color="#92400E" lineHeight="1.6">
+                All endpoints are public and don't require authentication. The chat endpoint accepts
+                POST requests with a JSON body containing: <Code fontSize="11px">{"{ message: string }"}</Code>
+              </Text>
+            </Box>
+          </VStack>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+};
+
+export default DeveloperSettings;

--- a/src/pages/hushh-user-profile/index.tsx
+++ b/src/pages/hushh-user-profile/index.tsx
@@ -41,12 +41,17 @@ import {
   Zap,
   Clock3,
   Circle,
+  Share2,
+  Mail,
+  MessageCircle,
 } from "lucide-react";
+import { FaWhatsapp, FaTwitter } from "react-icons/fa";
 import { CheckIcon, LinkIcon } from "@chakra-ui/icons";
 import { keyframes } from "@emotion/react";
 import resources from "../../resources/resources";
 import { generateInvestorProfile } from "../../services/investorProfile/apiClient";
 import { InvestorProfile, FIELD_LABELS, VALUE_LABELS } from "../../types/investorProfile";
+import DeveloperSettings from "../../components/DeveloperSettings";
 
 interface FormState {
   name: string;
@@ -671,6 +676,171 @@ const HushhUserProfilePage: React.FC = () => {
           </Box>
         </Box>
 
+        {/* Profile URL Share Card - Shows when profile is created */}
+        {profileSlug && profileUrl && (
+          <Box 
+            px={{ base: 0, md: 2 }} 
+            mt={6}
+            animation={prefersReducedMotion ? undefined : `${fadeUp} 0.3s ease-out 0.1s both`}
+          >
+            <Box
+              bg="linear-gradient(135deg, #00A9E0 0%, #6DD3EF 100%)"
+              borderRadius="20px"
+              p={{ base: 5, md: 6 }}
+              boxShadow="0 10px 40px rgba(0, 169, 224, 0.25)"
+              position="relative"
+              overflow="hidden"
+            >
+              {/* Background Pattern */}
+              <Box
+                position="absolute"
+                top={0}
+                right={0}
+                bottom={0}
+                left={0}
+                opacity={0.1}
+                bgImage="radial-gradient(circle at 20px 20px, white 2px, transparent 0)"
+                bgSize="40px 40px"
+                pointerEvents="none"
+              />
+
+              <VStack align="stretch" spacing={4} position="relative">
+                <HStack justify="space-between" align="flex-start">
+                  <VStack align="flex-start" spacing={1}>
+                    <HStack spacing={2}>
+                      <Icon as={Share2} color="white" boxSize={5} />
+                      <Text
+                        fontSize="18px"
+                        fontWeight="700"
+                        color="white"
+                        letterSpacing="-0.01em"
+                      >
+                        Your Investor Profile
+                      </Text>
+                    </HStack>
+                    <Text fontSize="14px" color="rgba(255,255,255,0.9)">
+                      Share this link to let others view your profile
+                    </Text>
+                  </VStack>
+                  <IconButton
+                    aria-label="Open profile in new tab"
+                    icon={<Icon as={ExternalLink} />}
+                    onClick={handleOpenProfile}
+                    size="sm"
+                    bg="rgba(255,255,255,0.2)"
+                    color="white"
+                    _hover={{ bg: "rgba(255,255,255,0.3)" }}
+                    _active={{ transform: "scale(0.95)" }}
+                    borderRadius="10px"
+                  />
+                </HStack>
+
+                {/* URL Display Box */}
+                <Box
+                  bg="white"
+                  borderRadius="14px"
+                  p={4}
+                  boxShadow="0 4px 12px rgba(0,0,0,0.08)"
+                >
+                  <HStack spacing={3} justify="space-between">
+                    <HStack spacing={2} flex={1} minW={0}>
+                      <Icon as={LinkIcon} color="#00A9E0" boxSize={4} />
+                      <Text
+                        fontSize="14px"
+                        fontWeight="600"
+                        color="#0B1120"
+                        noOfLines={1}
+                        flex={1}
+                      >
+                        {profileUrl}
+                      </Text>
+                    </HStack>
+                    <IconButton
+                      aria-label="Copy link"
+                      icon={<Icon as={hasCopied ? Check : Copy} boxSize={4} />}
+                      onClick={triggerCopy}
+                      size="sm"
+                      colorScheme={hasCopied ? "green" : "gray"}
+                      bg={hasCopied ? "#34C759" : "#F3F4F6"}
+                      color={hasCopied ? "white" : "#111827"}
+                      _hover={{ bg: hasCopied ? "#34C759" : "#E5E7EB" }}
+                      _active={{ transform: "scale(0.95)" }}
+                      borderRadius="10px"
+                      transition="all 0.2s ease"
+                    />
+                  </HStack>
+                </Box>
+
+                {/* Share Buttons */}
+                <VStack align="stretch" spacing={2}>
+                  <Text fontSize="13px" fontWeight="600" color="white">
+                    Share via
+                  </Text>
+                  <HStack spacing={2} flexWrap="wrap">
+                    <Button
+                      leftIcon={<Icon as={FaWhatsapp} boxSize={5} />}
+                      onClick={() => {
+                        const text = encodeURIComponent("Check out my Hushh Investor Profile");
+                        const url = encodeURIComponent(profileUrl);
+                        window.open(`https://wa.me/?text=${text}%20${url}`, "_blank");
+                      }}
+                      size="md"
+                      bg="rgba(255,255,255,0.2)"
+                      color="white"
+                      _hover={{ bg: "rgba(255,255,255,0.3)" }}
+                      _active={{ transform: "scale(0.98)" }}
+                      borderRadius="12px"
+                      fontWeight="600"
+                      flex={{ base: "1", md: "0" }}
+                      minW="140px"
+                    >
+                      WhatsApp
+                    </Button>
+                    <Button
+                      leftIcon={<Icon as={FaTwitter} boxSize={5} />}
+                      onClick={() => {
+                        const text = encodeURIComponent("Check out my Hushh Investor Profile");
+                        const url = encodeURIComponent(profileUrl);
+                        window.open(`https://twitter.com/intent/tweet?text=${text}&url=${url}`, "_blank");
+                      }}
+                      size="md"
+                      bg="rgba(255,255,255,0.2)"
+                      color="white"
+                      _hover={{ bg: "rgba(255,255,255,0.3)" }}
+                      _active={{ transform: "scale(0.98)" }}
+                      borderRadius="12px"
+                      fontWeight="600"
+                      flex={{ base: "1", md: "0" }}
+                      minW="140px"
+                    >
+                      Twitter
+                    </Button>
+                    <Button
+                      leftIcon={<Icon as={Mail} boxSize={5} />}
+                      onClick={() => {
+                        const subject = encodeURIComponent("My Hushh Investor Profile");
+                        const body = encodeURIComponent(`Check out my investor profile: ${profileUrl}`);
+                        window.location.href = `mailto:?subject=${subject}&body=${body}`;
+                      }}
+                      size="md"
+                      bg="rgba(255,255,255,0.2)"
+                      color="white"
+                      _hover={{ bg: "rgba(255,255,255,0.3)" }}
+                      _active={{ transform: "scale(0.98)" }}
+                      borderRadius="12px"
+                      fontWeight="600"
+                      flex={{ base: "1", md: "0" }}
+                      minW="140px"
+                    >
+                      Email
+                    </Button>
+                  </HStack>
+                </VStack>
+              </VStack>
+            </Box>
+          </Box>
+        )}
+
         <Box animation={headingAnimation} px={{ base: 1, md: 2 }} mt={2}>
           <Heading fontSize="24px" fontWeight="700" lineHeight="1.2" color="#0B1120" mb={4}>
             Basic Information
@@ -1145,6 +1315,17 @@ const HushhUserProfilePage: React.FC = () => {
             </HStack>
           </HStack>
         </Box>
+
+        {/* Developer Settings - Shows MCP endpoints when profile is created */}
+        {profileSlug && (
+          <Box 
+            px={{ base: 0, md: 2 }} 
+            mt={6}
+            animation={prefersReducedMotion ? undefined : `${fadeUp} 0.35s ease-out 0.15s both`}
+          >
+            <DeveloperSettings investorSlug={profileSlug} />
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/pages/investor-profile/index.tsx
+++ b/src/pages/investor-profile/index.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
-import { Box, Container, Spinner, Center, Text, VStack } from "@chakra-ui/react";
+import { Box, Container, Spinner, Center, Text, VStack, HStack, IconButton, useToast, Button, Icon } from "@chakra-ui/react";
 import { useNavigate } from "react-router-dom";
+import { CheckCircleIcon, CopyIcon } from "@chakra-ui/icons";
+import { Share2 } from "lucide-react";
 import { InvestorProfileForm } from "../../components/investorProfile/InvestorProfileForm";
 import { InvestorProfileReview } from "../../components/investorProfile/InvestorProfileReview";
 import { 
@@ -24,6 +26,7 @@ function InvestorProfilePage() {
   const [error, setError] = useState<string | null>(null);
   const [userData, setUserData] = useState<{ name: string; email: string } | null>(null);
   const navigate = useNavigate();
+  const toast = useToast();
 
   // Check if user is authenticated and if profile already exists
   useEffect(() => {
@@ -140,17 +143,114 @@ function InvestorProfilePage() {
 
   // Complete state
   if (step === "complete") {
+    const profileUrl = `https://hushhtech.com/investor/${profile?.slug}`;
+    
+    const handleCopyURL = () => {
+      navigator.clipboard.writeText(profileUrl);
+      toast({
+        title: "Link copied!",
+        description: "Share it with anyone",
+        status: "success",
+        duration: 2000,
+      });
+    };
+
+    const handleShare = async () => {
+      if (navigator.share) {
+        try {
+          await navigator.share({
+            title: `${profile?.name}'s Investor Profile`,
+            text: "Check out my investor profile on Hushh",
+            url: profileUrl,
+          });
+        } catch (err) {
+          // User cancelled or share failed
+          handleCopyURL();
+        }
+      } else {
+        handleCopyURL();
+      }
+    };
+
     return (
-      <Container maxW="container.xl" py={20}>
+      <Container maxW="container.md" py={12}>
         <Center>
-          <VStack spacing={4}>
-            <Text fontSize="2xl" fontWeight="bold" color="green.500">
+          <VStack spacing={6} w="full">
+            <CheckCircleIcon boxSize={16} color="green.500" />
+            
+            <Text fontSize="2xl" fontWeight="bold" color="green.500" textAlign="center">
               ✓ Profile Created Successfully!
             </Text>
-            <Text color="gray.600">
-              Redirecting to your dashboard...
+            
+            <Text fontSize="md" color="gray.600" textAlign="center">
+              Your public profile is now live and ready to share!
             </Text>
-            <Spinner size="lg" color="blue.500" />
+
+            {/* URL Display Box */}
+            <Box
+              w="full"
+              bg="gray.50"
+              border="1px solid"
+              borderColor="gray.200"
+              borderRadius="lg"
+              p={6}
+            >
+              <Text fontSize="sm" color="gray.600" mb={2} fontWeight="medium">
+                📍 Your Public Profile URL:
+              </Text>
+              
+              <HStack
+                bg="white"
+                p={3}
+                borderRadius="md"
+                border="1px solid"
+                borderColor="gray.300"
+                spacing={2}
+              >
+                <Text
+                  fontSize="sm"
+                  color="blue.600"
+                  fontWeight="medium"
+                  flex={1}
+                  isTruncated
+                >
+                  {profileUrl}
+                </Text>
+                <IconButton
+                  icon={<CopyIcon />}
+                  onClick={handleCopyURL}
+                  size="sm"
+                  colorScheme="blue"
+                  variant="ghost"
+                  aria-label="Copy URL"
+                />
+              </HStack>
+
+              <HStack mt={4} spacing={2}>
+                <Button
+                  leftIcon={<Icon as={Share2} />}
+                  onClick={handleShare}
+                  colorScheme="blue"
+                  size="sm"
+                  flex={1}
+                >
+                  Share Profile
+                </Button>
+                <Button
+                  onClick={handleCopyURL}
+                  variant="outline"
+                  size="sm"
+                  flex={1}
+                >
+                  Copy Link
+                </Button>
+              </HStack>
+            </Box>
+
+            <HStack spacing={2} color="gray.500">
+              <Spinner size="sm" />
+              <Text fontSize="sm">Redirecting to your dashboard...</Text>
+            </HStack>
           </VStack>
         </Center>
       </Container>

--- a/src/types/investorProfile.ts
+++ b/src/types/investorProfile.ts
@@ -126,6 +126,8 @@ export interface InvestorProfileRecord {
   phone_country_code: string;
   phone_number: string;
   organisation?: string;
+  slug?: string;
+  is_public?: boolean;
   derived_context: DerivedContext;
   investor_profile: InvestorProfile;
   is_ai_prefilled: boolean;

--- a/supabase/functions/investor-chat/config.json
+++ b/supabase/functions/investor-chat/config.json
@@ -1,0 +1,3 @@
+{
+  "verify_jwt": false
+}


### PR DESCRIPTION
- Fix 401 error on investor-chat endpoint (add config.json with verify_jwt: false)
- Add URL display with copy/share buttons on profile confirmation screen
- Add prominent URL share card to dashboard with WhatsApp, Twitter, Email buttons
- Create DeveloperSettings component showing MCP endpoints
- Add slug and is_public fields to InvestorProfileRecord type
- Display developer settings with collapsible MCP endpoint documentation

All endpoints now properly configured for public access and sharing