### PR TITLE
Fix: Remove undefined firebaseUser reference causing iOS crash

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -193,8 +193,8 @@ export default function Navbar() {
                     className="flex items-center focus:outline-none"
                   >
                     <Avatar
-                      src={session?.user?.user_metadata?.avatar_url || firebaseUser?.photoURL || undefined}
-                      name={session?.user?.email || firebaseUser?.email || ""}
+                      src={session?.user?.user_metadata?.avatar_url || undefined}
+                      name={session?.user?.email || session?.user?.user_metadata?.full_name || ""}
                       className="w-8 h-8 rounded-full cursor-pointer"
                     />
                   </button>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
     outDir: 'dist',
     // strongly recommend cleaning to avoid stale assets on Vercel
     emptyOutDir: true,
+    // Enable sourcemaps for debugging production errors (iOS RangeError, etc.)
+    sourcemap: true,
+    // Target ES2017+ for better iOS Safari compatibility
+    target: 'es2017',
   },
   server: {
     proxy: {


### PR DESCRIPTION
- Fixed RangeError: Maximum call stack size exceeded on iOS
- Removed undefined firebaseUser variable in Navbar Avatar component
- Added sourcemap: true and target: es2017 in vite.config for iOS debugging
- This was causing white screen on iOS Safari while working on desktop