### PR TITLE
fix: show United States first in country dropdown

### DIFF
--- a/src/pages/onboarding/Step6.tsx
+++ b/src/pages/onboarding/Step6.tsx
@@ -2,7 +2,9 @@
 import { useNavigate } from 'react-router-dom';
 import config from '../../resources/config/config';
 
+// United States first, then all other countries alphabetically
 const countries = [
+  'United States',
   'Afghanistan', 'Albania', 'Algeria', 'Andorra', 'Angola', 'Argentina', 'Armenia', 'Australia',
   'Austria', 'Azerbaijan', 'Bahamas', 'Bahrain', 'Bangladesh', 'Barbados', 'Belarus', 'Belgium',
   'Belize', 'Benin', 'Bhutan', 'Bolivia', 'Bosnia and Herzegovina', 'Botswana', 'Brazil', 'Brunei',
@@ -26,7 +28,7 @@ const countries = [
   'Slovenia', 'Solomon Islands', 'Somalia', 'South Africa', 'South Sudan', 'Spain', 'Sri Lanka',
   'Sudan', 'Suriname', 'Swaziland', 'Sweden', 'Switzerland', 'Syria', 'Taiwan', 'Tajikistan',
   'Tanzania', 'Thailand', 'Togo', 'Tonga', 'Trinidad and Tobago', 'Tunisia', 'Turkey', 'Turkmenistan',
-  'Tuvalu', 'Uganda', 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'United States', 'Uruguay',
+  'Tuvalu', 'Uganda', 'Ukraine', 'United Arab Emirates', 'United Kingdom', 'Uruguay',
   'Uzbekistan', 'Vanuatu', 'Vatican City', 'Venezuela', 'Vietnam', 'Yemen', 'Zambia', 'Zimbabwe'
 ];
 


### PR DESCRIPTION
- Move United States to top of countries list in Step 6
- Ensures USA appears first instead of Afghanistan
- Improves UX for US-focused onboarding flow