### PR TITLE
feat: Add full-screen Sell the Wall page and update Target Net IRR to…

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -239,7 +239,25 @@ export default function Hero() {
               <VStack align="stretch" spacing={5}>
                 <VStack align="stretch" spacing={4}>
                   <Text fontSize="20px" fontWeight="450" color="#0B1120" lineHeight="1.35">
-                    Targeting <Text as="span" fontWeight="500">18-23% net IRR</Text>* with our "Sell the Wall" approach.
+                    Targeting <Text as="span" fontWeight="500">18-23% net IRR</Text>* with our{" "}
+                    <Text 
+                      as="a"
+                      href="/sell-the-wall"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      display="inline"
+                      color="#00A9E0"
+                      textDecoration="underline"
+                      cursor="pointer"
+                      transition="all 0.2s"
+                      _hover={{
+                        color: "#4BC0C8",
+                        textDecoration: "none"
+                      }}
+                    >
+                      "Sell the Wall"
+                    </Text>
+                    {" "}approach.
                   </Text>
                   <Text fontSize="17px" color="#111827" lineHeight="1.6">
                     AI-first, systematic income investing.

--- a/src/pages/discover-fund-a/index.tsx
+++ b/src/pages/discover-fund-a/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Box, Container, Heading, Text, Flex, SimpleGrid, Stack, Grid, GridItem, Table, Tbody, Tr, Td, VStack, HStack, Button } from "@chakra-ui/react"
+import { Link as RouterLink } from 'react-router-dom'
 
 const FundA = () => {
   return (
@@ -67,7 +68,7 @@ const FundA = () => {
               fontWeight="500"
               mb={2}
             >
-              69%
+              18-23%
             </Heading>
             
             <Text
@@ -223,7 +224,25 @@ const FundA = () => {
             textAlign="center"
             color="#1D1D1F"
           >
-            Our Edge: The "Sell the Wall" Options Framework
+            Our Edge: The{" "}
+            <Text 
+              as="a"
+              href="/sell-the-wall"
+              target="_blank"
+              rel="noopener noreferrer"
+              display="inline"
+              color="#00A9E0"
+              textDecoration="underline"
+              cursor="pointer"
+              transition="all 0.2s"
+              _hover={{
+                color: "#4BC0C8",
+                textDecoration: "none"
+              }}
+            >
+              "Sell the Wall"
+            </Text>
+            {" "}Options Framework
           </Heading>
           
           <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={8}>
@@ -578,7 +597,7 @@ const FundA = () => {
                     Target Net IRR (Post-Fees & Expenses)
                   </Td>
                   <Td fontSize={{ base: "xl", md: "2xl" }} fontWeight="500" color="#00A9E0" textAlign="right" py={6} whiteSpace="nowrap">
-                    69%
+                    18-23%
                   </Td>
                 </Tr>
               </Tbody>

--- a/src/pages/sell-the-wall/index.tsx
+++ b/src/pages/sell-the-wall/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Box } from "@chakra-ui/react";
+import { Helmet } from "react-helmet";
+
+const SellTheWallPage = () => {
+  return (
+    <>
+      <Helmet>
+        <title>Sell the Wall Options Framework | Hushh Fund A</title>
+        <meta name="description" content="Discover our proprietary Sell the Wall options framework - a systematic approach to generating alpha through volatility harvesting and time decay." />
+      </Helmet>
+
+      <Box 
+        position="fixed"
+        top="64px"
+        left="0"
+        right="0"
+        bottom="0"
+        width="100vw"
+        height="calc(100vh - 64px)"
+        overflow="hidden"
+        margin="0"
+        padding="0"
+      >
+        <iframe 
+          src="https://gamma.app/embed/ya0impa0panawof" 
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            margin: 0,
+            padding: 0,
+            display: 'block',
+          }}
+          allow="fullscreen" 
+          title="Sell the Wall Options Framework Presentation"
+        />
+      </Box>
+    </>
+  );
+};
+
+export default SellTheWallPage;


### PR DESCRIPTION
… 18-23%

- Implemented full-screen edge-to-edge Gamma iframe embed for /sell-the-wall
- Updated Target Net IRR from 69% to 18-23% across discover-fund-a page (stats card + table)
- Made 'Sell the Wall' text clickable with new tab behavior on home page and discover-fund-a
- All links open in new tab with target='_blank' and rel='noopener noreferrer'
- Removed all unnecessary content from sell-the-wall page for clean presentation
- Fixed positioning to fill viewport from header bottom to page bottom