### PR TITLE
fix: Update tagline to 'invest in' instead of 'build'

### DIFF
--- a/scripts/update-tagline-invest.cjs
+++ b/scripts/update-tagline-invest.cjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+// File to update
+const heroPath = path.join(__dirname, '..', 'src', 'components', 'Hero.tsx');
+
+// Read the file
+let content = fs.readFileSync(heroPath, 'utf8');
+
+// Replace "build exceptional businesses" with "invest in exceptional businesses"
+const updated = content.replace(
+  /build exceptional businesses/g,
+  'invest in exceptional businesses'
+);
+
+// Write back
+fs.writeFileSync(heroPath, updated, 'utf8');
+
+console.log('✅ Updated tagline in Hero.tsx');
+console.log('   Changed: "build exceptional businesses"');
+console.log('   To:      "invest in exceptional businesses"');

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -106,7 +106,7 @@ export default function Hero() {
                     fontFamily="Inter, -apple-system, system-ui, 'SF Pro Text', sans-serif"
                     mb="8"
                   >
-                    We combine AI and human expertise to build exceptional businesses for long-term value creation.
+                    We combine AI and human expertise to invest in exceptional businesses for long-term value creation.
                   </Text>
 
                   {/* Blue Divider Line */}


### PR DESCRIPTION
- Changed 'build exceptional businesses' to 'invest in exceptional businesses'
- Created script to automate the change
- Updates company tagline to better reflect investment focus