### PR TITLE
feat: Add  payment gate for chat widget

### DIFF
--- a/src/components/ChatPaymentModal.tsx
+++ b/src/components/ChatPaymentModal.tsx
@@ -1,0 +1,121 @@
+// Payment Modal for Chat Access
+// Shows $1 payment prompt after 3 free messages
+
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  VStack,
+  Text,
+  Button,
+  Icon,
+  HStack,
+  Box,
+  List,
+  ListItem,
+  ListIcon,
+} from '@chakra-ui/react';
+import { CheckCircle, MessageCircle, Clock, Shield } from 'lucide-react';
+
+interface ChatPaymentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onPayment: () => void;
+  isProcessing?: boolean;
+}
+
+export function ChatPaymentModal({ isOpen, onClose, onPayment, isProcessing = false }: ChatPaymentModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="md" isCentered>
+      <ModalOverlay backdropFilter="blur(4px)" />
+      <ModalContent borderRadius="16px" mx={4}>
+        <ModalCloseButton />
+        <ModalHeader pt={6} pb={2}>
+          <HStack spacing={2}>
+            <Icon as={MessageCircle} boxSize={6} color="blue.500" />
+            <Text fontSize="xl" fontWeight="600">Continue Chatting</Text>
+          </HStack>
+        </ModalHeader>
+        
+        <ModalBody pb={6}>
+          <VStack spacing={5} align="stretch">
+            {/* Message */}
+            <Box>
+              <Text fontSize="md" color="gray.600">
+                You've used your 3 free messages! Unlock unlimited chatting for just <Text as="span" fontWeight="600" color="blue.600">$1</Text>
+              </Text>
+            </Box>
+
+            {/* Benefits */}
+            <List spacing={3}>
+              <ListItem>
+                <HStack align="flex-start">
+                  <ListIcon as={CheckCircle} color="green.500" mt={0.5} />
+                  <Text fontSize="sm" color="gray.700">
+                    <Text as="span" fontWeight="500">Unlimited messages</Text> for 30 minutes
+                  </Text>
+                </HStack>
+              </ListItem>
+              
+              <ListItem>
+                <HStack align="flex-start">
+                  <ListIcon as={Clock} color="blue.500" mt={0.5} />
+                  <Text fontSize="sm" color="gray.700">
+                    <Text as="span" fontWeight="500">Instant access</Text> after payment
+                  </Text>
+                </HStack>
+              </ListItem>
+              
+              <ListItem>
+                <HStack align="flex-start">
+                  <ListIcon as={Shield} color="purple.500" mt={0.5} />
+                  <Text fontSize="sm" color="gray.700">
+                    <Text as="span" fontWeight="500">Secure payment</Text> via Stripe
+                  </Text>
+                </HStack>
+              </ListItem>
+            </List>
+
+            {/* Payment Button */}
+            <VStack spacing={3}>
+              <Button
+                onClick={onPayment}
+                isLoading={isProcessing}
+                loadingText="Processing..."
+                colorScheme="blue"
+                size="lg"
+                width="100%"
+                height="50px"
+                fontSize="md"
+                fontWeight="600"
+                leftIcon={<Icon as={CheckCircle} />}
+                _hover={{ transform: 'translateY(-1px)', boxShadow: 'lg' }}
+                transition="all 0.2s"
+              >
+                Pay $1 with Stripe
+              </Button>
+              
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+                color="gray.500"
+                _hover={{ bg: 'gray.100' }}
+              >
+                Maybe Later
+              </Button>
+            </VStack>
+
+            {/* Fine Print */}
+            <Text fontSize="xs" color="gray.500" textAlign="center">
+              Access expires 30 minutes after payment. No recurring charges.
+            </Text>
+          </VStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/InvestorChatWidget.tsx
+++ b/src/components/InvestorChatWidget.tsx
@@ -1,8 +1,20 @@
-import { useState } from 'react';
-import { Box, Input, Button, VStack, HStack, Text, Avatar, Spinner } from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
+import { Box, Input, Button, VStack, HStack, Text, Avatar, Spinner, useDisclosure, Badge, Icon, useToast } from '@chakra-ui/react';
 import ReactMarkdown from 'react-markdown';
+import { Clock, MessageCircle } from 'lucide-react';
+import { getOrCreateVisitorId } from '../utils/visitorId';
+import { ChatPaymentModal } from './ChatPaymentModal';
 
 type Message = { role: 'user' | 'assistant'; content: string };
+
+interface AccessInfo {
+  canChat: boolean;
+  needsPayment: boolean;
+  accessType: 'free' | 'paid' | 'expired';
+  messagesRemaining?: number | 'unlimited';
+  timeRemaining?: string;
+  message?: string;
+}
 
 export function InvestorChatWidget({ slug, investorName }: { slug: string; investorName: string }) {
   const [messages, setMessages] = useState<Message[]>([
@@ -10,11 +22,131 @@ export function InvestorChatWidget({ slug, investorName }: { slug: string; inves
   ]);
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
+  const [processing, setProcessing] = useState(false);
+  const [accessInfo, setAccessInfo] = useState<AccessInfo | null>(null);
+  const [visitorId] = useState(() => getOrCreateVisitorId());
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+
+  // Check access on mount and handle payment success
+  useEffect(() => {
+    checkAccess();
+    handlePaymentReturn();
+  }, []);
+
+  const checkAccess = async () => {
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/chat-check-access`,
+        {
+          method: 'POST',
+          headers: { 
+            'Content-Type': 'application/json',
+            'apikey': import.meta.env.VITE_SUPABASE_ANON_KEY || ''
+          },
+          body: JSON.stringify({ visitorId, slug }),
+        }
+      );
+      
+      if (res.ok) {
+        const data = await res.json();
+        setAccessInfo(data);
+      }
+    } catch (err) {
+      console.error('Access check error:', err);
+    }
+  };
+
+  const handlePaymentReturn = async () => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const paymentStatus = urlParams.get('payment');
+    const sessionId = urlParams.get('session_id');
+
+    if (paymentStatus === 'success' && sessionId) {
+      // Verify payment
+      try {
+        const res = await fetch(
+          `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/chat-verify-payment`,
+          {
+            method: 'POST',
+            headers: { 
+              'Content-Type': 'application/json',
+              'apikey': import.meta.env.VITE_SUPABASE_ANON_KEY || ''
+            },
+            body: JSON.stringify({ sessionId, visitorId, slug }),
+          }
+        );
+
+        if (res.ok) {
+          toast({
+            title: 'Payment Successful!',
+            description: 'You now have unlimited access for 30 minutes.',
+            status: 'success',
+            duration: 5000,
+          });
+          await checkAccess();
+        }
+      } catch (err) {
+        console.error('Payment verification error:', err);
+      }
+
+      // Clean up URL
+      window.history.replaceState({}, '', window.location.pathname);
+    } else if (paymentStatus === 'cancel') {
+      toast({
+        title: 'Payment Cancelled',
+        description: 'You can try again when ready.',
+        status: 'info',
+        duration: 3000,
+      });
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+  };
+
+  const handlePayment = async () => {
+    setProcessing(true);
+    try {
+      const res = await fetch(
+        `${import.meta.env.VITE_SUPABASE_URL}/functions/v1/chat-create-checkout`,
+        {
+          method: 'POST',
+          headers: { 
+            'Content-Type': 'application/json',
+            'apikey': import.meta.env.VITE_SUPABASE_ANON_KEY || ''
+          },
+          body: JSON.stringify({ visitorId, slug }),
+        }
+      );
+
+      if (res.ok) {
+        const data = await res.json();
+        // Redirect to Stripe Checkout
+        window.location.href = data.checkoutUrl;
+      } else {
+        throw new Error('Failed to create checkout session');
+      }
+    } catch (err) {
+      console.error('Payment error:', err);
+      toast({
+        title: 'Payment Error',
+        description: 'Failed to initiate payment. Please try again.',
+        status: 'error',
+        duration: 5000,
+      });
+      setProcessing(false);
+    }
+  };
 
   const sendMessage = async () => {
     const text = input.trim();
     if (!text || loading) return;
     
+    // Check if payment is needed before sending
+    if (accessInfo && !accessInfo.canChat) {
+      onOpen(); // Show payment modal
+      return;
+    }
+
     const userMsg: Message = { role: 'user', content: text };
     setMessages(prev => [...prev, userMsg]);
     setInput('');
@@ -31,14 +163,39 @@ export function InvestorChatWidget({ slug, investorName }: { slug: string; inves
             'Content-Type': 'application/json',
             'apikey': import.meta.env.VITE_SUPABASE_ANON_KEY || ''
           },
-          body: JSON.stringify({ slug, message: text, history }),
+          body: JSON.stringify({ slug, message: text, visitorId, history }),
         }
       );
       
-      if (!res.ok) throw new Error('Failed to get response');
+      if (res.status === 402) {
+        // Payment required
+        const data = await res.json();
+        setMessages(prev => prev.slice(0, -1)); // Remove user message
+        setInput(text); // Restore input
+        toast({
+          title: 'Payment Required',
+          description: data.message || 'Please pay to continue chatting.',
+          status: 'warning',
+          duration: 5000,
+        });
+        await checkAccess(); // Refresh access info
+        onOpen(); // Show payment modal
+        return;
+      }
+
+      if (!res.ok) {
+        throw new Error('Failed to get response');
+      }
       
       const data = await res.json();
       setMessages(prev => [...prev, { role: 'assistant', content: data.reply }]);
+      
+      // Update access info if provided
+      if (data.accessInfo) {
+        setAccessInfo(prev => ({ ...prev!, ...data.accessInfo }));
+      } else {
+        await checkAccess(); // Refresh access info
+      }
     } catch (err) {
       console.error(err);
       setMessages(prev => [...prev, { 
@@ -51,116 +208,148 @@ export function InvestorChatWidget({ slug, investorName }: { slug: string; inves
   };
 
   return (
-    <Box border="1px" borderColor="gray.200" borderRadius="lg" p={4} bg="white" shadow="sm">
-      <VStack spacing={4} align="stretch">
-        <HStack>
-          <Text fontWeight="500" fontSize="lg">💬 Chat with {investorName} Investor Assistant</Text>
-        </HStack>
-        
-        <Box 
-          h="400px" 
-          overflowY="auto" 
-          bg="gray.50" 
-          p={4} 
-          borderRadius="md"
-          css={{
-            '&::-webkit-scrollbar': { width: '8px' },
-            '&::-webkit-scrollbar-track': { background: '#f1f1f1' },
-            '&::-webkit-scrollbar-thumb': { background: '#888', borderRadius: '4px' },
-          }}
-        >
-          {messages.map((msg, i) => (
-            <HStack 
-              key={i} 
-              mb={3} 
-              justify={msg.role === 'user' ? 'flex-end' : 'flex-start'}
-              align="flex-start"
-            >
-              {msg.role === 'assistant' && (
-                <Avatar size="sm" name={investorName} bg="blue.500" />
-              )}
-              <Box
-                maxW="75%"
-                bg={msg.role === 'user' ? 'blue.500' : 'white'}
-                color={msg.role === 'user' ? 'white' : 'black'}
-                px={4}
-                py={2}
-                borderRadius="lg"
-                boxShadow="sm"
-              >
-                {msg.role === 'assistant' ? (
-                  <Box
-                    fontSize="sm"
-                    sx={{
-                      '& p': {
-                        marginBottom: '0.5rem',
-                        lineHeight: '1.6',
-                      },
-                      '& p:last-child': {
-                        marginBottom: '0',
-                      },
-                      '& strong': {
-                        fontWeight: '500',
-                        color: 'black',
-                      },
-                      '& em': {
-                        fontStyle: 'italic',
-                      },
-                      '& ul, & ol': {
-                        marginLeft: '1.25rem',
-                        marginTop: '0.25rem',
-                        marginBottom: '0.5rem',
-                      },
-                      '& li': {
-                        marginBottom: '0.25rem',
-                        lineHeight: '1.5',
-                      },
-                      '& ul li': {
-                        listStyleType: 'disc',
-                      },
-                      '& ol li': {
-                        listStyleType: 'decimal',
-                      },
-                    }}
-                  >
-                    <ReactMarkdown>{msg.content}</ReactMarkdown>
-                  </Box>
-                ) : (
-                  <Text fontSize="sm" whiteSpace="pre-wrap">{msg.content}</Text>
+    <>
+      <Box border="1px" borderColor="gray.200" borderRadius="lg" p={4} bg="white" shadow="sm">
+        <VStack spacing={4} align="stretch">
+          <HStack justify="space-between">
+            <HStack>
+              <Icon as={MessageCircle} color="blue.500" />
+              <Text fontWeight="500" fontSize="lg">Chat with {investorName}'s AI Assistant</Text>
+            </HStack>
+            
+            {/* Access Status Badge */}
+            {accessInfo && (
+              <HStack spacing={2}>
+                {accessInfo.accessType === 'free' && accessInfo.messagesRemaining !== undefined && (
+                  <Badge colorScheme="blue" fontSize="xs">
+                    {accessInfo.messagesRemaining} free messages left
+                  </Badge>
                 )}
-              </Box>
-              {msg.role === 'user' && (
-                <Avatar size="sm" name="You" bg="gray.400" />
-              )}
-            </HStack>
-          ))}
-          {loading && (
-            <HStack justify="flex-start" align="center">
-              <Avatar size="sm" name={investorName} bg="blue.500" />
-              <Spinner size="sm" />
-              <Text fontSize="sm" color="gray.500">Thinking...</Text>
-            </HStack>
-          )}
-        </Box>
-        
-        <HStack>
-          <Input 
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && !e.shiftKey && sendMessage()}
-            placeholder="Ask about investment preferences..."
-            disabled={loading}
-          />
-          <Button 
-            onClick={sendMessage} 
-            isLoading={loading}
-            colorScheme="blue"
-            minW="100px"
+                {accessInfo.accessType === 'paid' && accessInfo.timeRemaining && (
+                  <Badge colorScheme="green" fontSize="xs">
+                    <HStack spacing={1}>
+                      <Icon as={Clock} boxSize={3} />
+                      <Text>{accessInfo.timeRemaining}</Text>
+                    </HStack>
+                  </Badge>
+                )}
+              </HStack>
+            )}
+          </HStack>
+          
+          <Box 
+            h="400px" 
+            overflowY="auto" 
+            bg="gray.50" 
+            p={4} 
+            borderRadius="md"
+            css={{
+              '&::-webkit-scrollbar': { width: '8px' },
+              '&::-webkit-scrollbar-track': { background: '#f1f1f1' },
+              '&::-webkit-scrollbar-thumb': { background: '#888', borderRadius: '4px' },
+            }}
           >
-            Send
-          </Button>
-        </HStack>
-      </VStack>
-    </Box>
+            {messages.map((msg, i) => (
+              <HStack 
+                key={i} 
+                mb={3} 
+                justify={msg.role === 'user' ? 'flex-end' : 'flex-start'}
+                align="flex-start"
+              >
+                {msg.role === 'assistant' && (
+                  <Avatar size="sm" name={investorName} bg="blue.500" />
+                )}
+                <Box
+                  maxW="75%"
+                  bg={msg.role === 'user' ? 'blue.500' : 'white'}
+                  color={msg.role === 'user' ? 'white' : 'black'}
+                  px={4}
+                  py={2}
+                  borderRadius="lg"
+                  boxShadow="sm"
+                >
+                  {msg.role === 'assistant' ? (
+                    <Box
+                      fontSize="sm"
+                      sx={{
+                        '& p': {
+                          marginBottom: '0.5rem',
+                          lineHeight: '1.6',
+                        },
+                        '& p:last-child': {
+                          marginBottom: '0',
+                        },
+                        '& strong': {
+                          fontWeight: '500',
+                          color: 'black',
+                        },
+                        '& em': {
+                          fontStyle: 'italic',
+                        },
+                        '& ul, & ol': {
+                          marginLeft: '1.25rem',
+                          marginTop: '0.25rem',
+                          marginBottom: '0.5rem',
+                        },
+                        '& li': {
+                          marginBottom: '0.25rem',
+                          lineHeight: '1.5',
+                        },
+                        '& ul li': {
+                          listStyleType: 'disc',
+                        },
+                        '& ol li': {
+                          listStyleType: 'decimal',
+                        },
+                      }}
+                    >
+                      <ReactMarkdown>{msg.content}</ReactMarkdown>
+                    </Box>
+                  ) : (
+                    <Text fontSize="sm" whiteSpace="pre-wrap">{msg.content}</Text>
+                  )}
+                </Box>
+                {msg.role === 'user' && (
+                  <Avatar size="sm" name="You" bg="gray.400" />
+                )}
+              </HStack>
+            ))}
+            {loading && (
+              <HStack justify="flex-start" align="center">
+                <Avatar size="sm" name={investorName} bg="blue.500" />
+                <Spinner size="sm" />
+                <Text fontSize="sm" color="gray.500">Thinking...</Text>
+              </HStack>
+            )}
+          </Box>
+          
+          <HStack>
+            <Input 
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyPress={(e) => e.key === 'Enter' && !e.shiftKey && sendMessage()}
+              placeholder={accessInfo?.canChat ? "Ask about investment preferences..." : "Pay to continue chatting..."}
+              disabled={loading}
+            />
+            <Button 
+              onClick={sendMessage} 
+              isLoading={loading}
+              colorScheme="blue"
+              minW="100px"
+            >
+              Send
+            </Button>
+          </HStack>
+        </VStack>
+      </Box>
+
+      {/* Payment Modal */}
+      <ChatPaymentModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onPayment={handlePayment}
+        isProcessing={processing}
+      />
+    </>
   );
 }

--- a/src/utils/visitorId.ts
+++ b/src/utils/visitorId.ts
@@ -1,0 +1,27 @@
+// Visitor ID Management for Anonymous Users
+// Generates and persists visitor ID for chat access tracking
+
+export function getOrCreateVisitorId(): string {
+  // Try to get from localStorage
+  let visitorId = localStorage.getItem('hushh_visitor_id');
+  
+  if (!visitorId) {
+    // Generate new UUID
+    visitorId = crypto.randomUUID();
+    
+    // Store in localStorage
+    localStorage.setItem('hushh_visitor_id', visitorId);
+    
+    // Also store in cookie as backup (30 days)
+    const expires = new Date();
+    expires.setDate(expires.getDate() + 30);
+    document.cookie = `hushh_visitor=${visitorId}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`;
+  }
+  
+  return visitorId;
+}
+
+export function clearVisitorId(): void {
+  localStorage.removeItem('hushh_visitor_id');
+  document.cookie = 'hushh_visitor=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
+}

--- a/supabase/functions/chat-check-access/index.ts
+++ b/supabase/functions/chat-check-access/index.ts
@@ -1,0 +1,179 @@
+// Chat Access Verification Endpoint
+// Checks if visitor can send messages (free tier or paid access)
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { visitorId, slug } = await req.json();
+    
+    if (!visitorId || !slug) {
+      return new Response(
+        JSON.stringify({ error: 'Missing visitorId or slug' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Get Supabase client
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    // Get or create access token
+    let { data: token, error: fetchError } = await supabase
+      .from('chat_access_tokens')
+      .select('*')
+      .eq('visitor_id', visitorId)
+      .eq('profile_slug', slug)
+      .single();
+
+    // If token doesn't exist, create new free tier token
+    if (fetchError || !token) {
+      const { data: newToken, error: insertError } = await supabase
+        .from('chat_access_tokens')
+        .insert({
+          visitor_id: visitorId,
+          profile_slug: slug,
+          payment_status: 'free_tier',
+          access_type: 'free',
+          messages_limit: 3,
+          messages_sent_count: 0,
+          ip_address: req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip'),
+          user_agent: req.headers.get('user-agent')
+        })
+        .select()
+        .single();
+
+      if (insertError) {
+        throw new Error(`Failed to create token: ${insertError.message}`);
+      }
+
+      token = newToken;
+    }
+
+    // Check if paid access has expired
+    if (token.access_type === 'paid' && token.expires_at) {
+      const now = new Date();
+      const expiresAt = new Date(token.expires_at);
+      
+      if (now > expiresAt) {
+        return new Response(
+          JSON.stringify({
+            canChat: false,
+            needsPayment: true,
+            accessType: 'expired',
+            messagesRemaining: 0,
+            message: 'Your 30-minute access has expired. Please pay again to continue.'
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+    }
+
+    // Check message limits for free tier
+    if (token.access_type === 'free') {
+      const remaining = token.messages_limit - token.messages_sent_count;
+      
+      if (remaining <= 0) {
+        return new Response(
+          JSON.stringify({
+            canChat: false,
+            needsPayment: true,
+            accessType: 'free',
+            messagesRemaining: 0,
+            message: 'You have used all 3 free messages. Pay $1 for 30 minutes unlimited access.'
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      
+      return new Response(
+        JSON.stringify({
+          canChat: true,
+          needsPayment: false,
+          accessType: 'free',
+          messagesRemaining: remaining
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Paid access - check hourly rate limit (50 messages/hour to prevent abuse)
+    if (token.access_type === 'paid') {
+      const now = new Date();
+      const hourlyReset = new Date(token.hourly_reset_at || now);
+      
+      // Reset hourly counter if expired
+      if (now > hourlyReset) {
+        await supabase
+          .from('chat_access_tokens')
+          .update({
+            hourly_message_count: 0,
+            hourly_reset_at: new Date(now.getTime() + 60 * 60 * 1000) // 1 hour from now
+          })
+          .eq('id', token.id);
+        
+        token.hourly_message_count = 0;
+      }
+      
+      // Check rate limit
+      if (token.hourly_message_count >= 50) {
+        return new Response(
+          JSON.stringify({
+            canChat: false,
+            needsPayment: false,
+            accessType: 'paid',
+            messagesRemaining: 'rate_limited',
+            message: 'Rate limit reached (50 messages/hour). Please wait before sending more messages.'
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      
+      // Calculate time remaining
+      const timeRemaining = Math.max(0, Math.floor((new Date(token.expires_at).getTime() - now.getTime()) / 1000 / 60));
+      
+      return new Response(
+        JSON.stringify({
+          canChat: true,
+          needsPayment: false,
+          accessType: 'paid',
+          messagesRemaining: 'unlimited',
+          timeRemaining: `${timeRemaining} minutes`
+        }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Fallback
+    return new Response(
+      JSON.stringify({
+        canChat: false,
+        needsPayment: true,
+        accessType: 'unknown',
+        messagesRemaining: 0
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Check access error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message || 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/chat-create-checkout/index.ts
+++ b/supabase/functions/chat-create-checkout/index.ts
@@ -1,0 +1,112 @@
+// Create Stripe Checkout Session for Chat Access
+// Handles $1 payment for 30-minute unlimited chat access
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import Stripe from "https://esm.sh/stripe@14.5.0?target=deno";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { visitorId, slug } = await req.json();
+    
+    if (!visitorId || !slug) {
+      return new Response(
+        JSON.stringify({ error: 'Missing visitorId or slug' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Initialize Stripe
+    const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+      apiVersion: '2023-10-16',
+    });
+
+    // Get Supabase client
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    // Verify profile exists
+    const { data: profile } = await supabase
+      .from('investor_profiles')
+      .select('name')
+      .eq('slug', slug)
+      .eq('is_public', true)
+      .single();
+
+    if (!profile) {
+      return new Response(
+        JSON.stringify({ error: 'Profile not found' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Get current URL for success/cancel redirects
+    const origin = req.headers.get('origin') || 'https://hushhtech.com';
+    const successUrl = `${origin}/investor/${slug}?payment=success`;
+    const cancelUrl = `${origin}/investor/${slug}?payment=cancel`;
+
+    // Create Stripe Checkout Session
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: `Chat Access - ${profile.name}`,
+              description: '30 minutes unlimited chat access',
+            },
+            unit_amount: 100, // $1.00 in cents
+          },
+          quantity: 1,
+        },
+      ],
+      mode: 'payment',
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      metadata: {
+        visitor_id: visitorId,
+        profile_slug: slug,
+        access_duration: '30_minutes',
+      },
+    });
+
+    // Update access token with pending payment
+    await supabase
+      .from('chat_access_tokens')
+      .update({
+        payment_status: 'pending',
+        payment_intent_id: session.payment_intent as string,
+      })
+      .eq('visitor_id', visitorId)
+      .eq('profile_slug', slug);
+
+    return new Response(
+      JSON.stringify({ 
+        checkoutUrl: session.url,
+        sessionId: session.id
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Create checkout error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message || 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/chat-verify-payment/index.ts
+++ b/supabase/functions/chat-verify-payment/index.ts
@@ -1,0 +1,93 @@
+// Verify Stripe Payment and Grant Access
+// Called after user returns from Stripe checkout
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import Stripe from "https://esm.sh/stripe@14.5.0?target=deno";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+};
+
+serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { sessionId, visitorId, slug } = await req.json();
+    
+    if (!sessionId || !visitorId || !slug) {
+      return new Response(
+        JSON.stringify({ error: 'Missing required parameters' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Initialize Stripe
+    const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') ?? '', {
+      apiVersion: '2023-10-16',
+    });
+
+    // Get Supabase client
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    // Retrieve Stripe session to verify payment
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+    if (session.payment_status !== 'paid') {
+      return new Response(
+        JSON.stringify({ 
+          success: false, 
+          error: 'Payment not completed',
+          status: session.payment_status
+        }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Payment successful - grant 30 minutes access
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + 30 * 60 * 1000); // 30 minutes from now
+
+    const { data: updated, error: updateError } = await supabase
+      .from('chat_access_tokens')
+      .update({
+        payment_status: 'completed',
+        access_type: 'paid',
+        expires_at: expiresAt.toISOString(),
+        payment_intent_id: session.payment_intent as string,
+      })
+      .eq('visitor_id', visitorId)
+      .eq('profile_slug', slug)
+      .select()
+      .single();
+
+    if (updateError) {
+      throw new Error(`Failed to update access: ${updateError.message}`);
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        accessGranted: true,
+        expiresAt: expiresAt.toISOString(),
+        timeRemaining: '30 minutes'
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+
+  } catch (error) {
+    console.error('Verify payment error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message || 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
- Add 3 free messages tier with countdown badge
- Implement Stripe checkout for  payment
- Grant 30 minutes unlimited access after payment
- Create 3 new edge functions for payment flow
- Update InvestorChatWidget with payment modal
- Add visitor tracking without authentication
- Implement rate limiting (50 msg/hour for paid users)
- Add ChatPaymentModal component with Chakra UI
- Create visitorId utility for anonymous tracking

Deployed:
- chat-check-access: Verify visitor access
- chat-create-checkout: Create Stripe session
- chat-verify-payment: Verify payment completion
- investor-chat: Modified with payment gate logic