### PR TITLE
fix: Add session_id to Stripe redirect URL for payment verification

### DIFF
--- a/supabase/functions/chat-create-checkout/index.ts
+++ b/supabase/functions/chat-create-checkout/index.ts
@@ -55,7 +55,7 @@ serve(async (req) => {
 
     // Get current URL for success/cancel redirects
     const origin = req.headers.get('origin') || 'https://hushhtech.com';
-    const successUrl = `${origin}/investor/${slug}?payment=success`;
+    const successUrl = `${origin}/investor/${slug}?payment=success&session_id={CHECKOUT_SESSION_ID}`;
     const cancelUrl = `${origin}/investor/${slug}?payment=cancel`;
 
     // Create Stripe Checkout Session


### PR DESCRIPTION
Critical fix: Payment was not persisting because Stripe redirect URL was missing the session_id parameter needed for verification.

Added {CHECKOUT_SESSION_ID} placeholder which Stripe automatically replaces with actual session ID on redirect.

Now payment verification works correctly and grants 30 minutes access.