### PR TITLE
Update A2A Playground to Apple-style white background design

### DIFF
--- a/src/components/a2aPlayground/A2AConversationScreen.tsx
+++ b/src/components/a2aPlayground/A2AConversationScreen.tsx
@@ -62,11 +62,11 @@ const AgentCard: React.FC<AgentCardProps> = ({ type, name, subtitle, isActive })
   
   return (
     <Box
-      bg={isBank ? 'rgba(66, 153, 225, 0.1)' : 'rgba(159, 122, 234, 0.1)'}
+      bg={isBank ? 'rgba(66, 153, 225, 0.05)' : 'rgba(159, 122, 234, 0.05)'}
       border="2px solid"
       borderColor={isActive 
-        ? (isBank ? 'blue.400' : 'purple.400') 
-        : 'whiteAlpha.200'
+        ? (isBank ? 'blue.500' : 'purple.500') 
+        : 'gray.200'
       }
       borderRadius="xl"
       p={4}
@@ -75,17 +75,17 @@ const AgentCard: React.FC<AgentCardProps> = ({ type, name, subtitle, isActive })
       transition="all 0.3s"
       transform={isActive ? 'scale(1.05)' : 'scale(1)'}
       boxShadow={isActive 
-        ? `0 0 20px ${isBank ? 'rgba(66, 153, 225, 0.4)' : 'rgba(159, 122, 234, 0.4)'}`
-        : 'none'
+        ? `0 4px 12px ${isBank ? 'rgba(66, 153, 225, 0.2)' : 'rgba(159, 122, 234, 0.2)'}`
+        : 'sm'
       }
     >
       <Text fontSize="2xl" mb={1}>
         {isBank ? '🏦' : '🔐'}
       </Text>
-      <Text color="white" fontSize="sm" fontWeight="600">
+      <Text color="black" fontSize="sm" fontWeight="600">
         {name}
       </Text>
-      <Text color="gray.500" fontSize="xs">
+      <Text color="gray.600" fontSize="xs">
         {subtitle}
       </Text>
       {isActive && (
@@ -120,10 +120,10 @@ const AgentStrip: React.FC<AgentStripProps> = ({ bankName, activeAgent, isRunnin
       gap={4}
       py={4}
       px={6}
-      bg="whiteAlpha.50"
+      bg="gray.50"
       borderRadius="2xl"
       border="1px solid"
-      borderColor="whiteAlpha.100"
+      borderColor="gray.200"
     >
       {/* Bank Agent */}
       <AgentCard
@@ -138,7 +138,7 @@ const AgentStrip: React.FC<AgentStripProps> = ({ bankName, activeAgent, isRunnin
         position="relative" 
         w="100px" 
         h="4px" 
-        bg="whiteAlpha.200"
+        bg="gray.200"
         borderRadius="full"
         overflow="hidden"
       >
@@ -208,16 +208,16 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message, bankName }) => {
       
       {/* Message bubble */}
       <Box
-        bg={isBank ? 'rgba(66, 153, 225, 0.15)' : 'rgba(159, 122, 234, 0.15)'}
+        bg={isBank ? 'rgba(66, 153, 225, 0.08)' : 'rgba(159, 122, 234, 0.08)'}
         border="1px solid"
-        borderColor={isBank ? 'blue.800' : 'purple.800'}
+        borderColor={isBank ? 'blue.200' : 'purple.200'}
         borderRadius="xl"
         borderTopLeftRadius={isBank ? '4px' : 'xl'}
         borderTopRightRadius={isBank ? 'xl' : '4px'}
         px={4}
         py={3}
       >
-        <Text color="gray.100" fontSize="sm" lineHeight="1.6">
+        <Text color="black" fontSize="sm" lineHeight="1.6">
           {message.message}
         </Text>
         
@@ -229,9 +229,9 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message, bankName }) => {
               size="xs"
               colorScheme={isBank ? 'blue' : 'purple'}
               borderRadius="full"
-              bg="whiteAlpha.100"
+              bg="gray.200"
             />
-            <Text fontSize="xs" color="gray.500" mt={1}>
+            <Text fontSize="xs" color="gray.600" mt={1}>
               {message.progressPercent}% complete
             </Text>
           </Box>
@@ -241,7 +241,7 @@ const MessageBubble: React.FC<MessageBubbleProps> = ({ message, bankName }) => {
       {/* Timestamp */}
       <Text 
         fontSize="xs" 
-        color="gray.600" 
+        color="gray.500" 
         mt={1}
         textAlign={isBank ? 'left' : 'right'}
       >
@@ -264,46 +264,46 @@ interface StatusPanelProps {
 const StatusPanel: React.FC<StatusPanelProps> = ({ isRunning, messageCount, result }) => {
   return (
     <Box
-      bg="whiteAlpha.50"
+      bg="gray.50"
       border="1px solid"
-      borderColor="whiteAlpha.100"
+      borderColor="gray.200"
       borderRadius="xl"
       p={4}
     >
-      <Text fontSize="xs" color="gray.500" fontWeight="600" mb={3} textTransform="uppercase">
+      <Text fontSize="xs" color="gray.600" fontWeight="600" mb={3} textTransform="uppercase">
         Status
       </Text>
       
       <VStack align="stretch" spacing={2}>
         <HStack justify="space-between">
-          <Text fontSize="sm" color="gray.400">State</Text>
+          <Text fontSize="sm" color="gray.600">State</Text>
           <Badge colorScheme={isRunning ? 'yellow' : (result ? 'green' : 'gray')}>
             {isRunning ? 'Running...' : (result ? 'Complete' : 'Idle')}
           </Badge>
         </HStack>
         
         <HStack justify="space-between">
-          <Text fontSize="sm" color="gray.400">Messages</Text>
-          <Text fontSize="sm" color="white">{messageCount}</Text>
+          <Text fontSize="sm" color="gray.600">Messages</Text>
+          <Text fontSize="sm" color="black">{messageCount}</Text>
         </HStack>
         
         {result && (
           <>
             <HStack justify="space-between">
-              <Text fontSize="sm" color="gray.400">KYC Status</Text>
+              <Text fontSize="sm" color="gray.600">KYC Status</Text>
               <Badge colorScheme={result.kycDecision.status === 'PASS' ? 'green' : 'yellow'}>
                 {result.kycDecision.status}
               </Badge>
             </HStack>
             
             <HStack justify="space-between">
-              <Text fontSize="sm" color="gray.400">Risk</Text>
-              <Text fontSize="sm" color="white">{result.kycDecision.verifiedVia.riskBand}</Text>
+              <Text fontSize="sm" color="gray.600">Risk</Text>
+              <Text fontSize="sm" color="black">{result.kycDecision.verifiedVia.riskBand}</Text>
             </HStack>
             
             {result.keyMatchResult !== undefined && (
               <HStack justify="space-between">
-                <Text fontSize="sm" color="gray.400">Key Match</Text>
+                <Text fontSize="sm" color="gray.600">Key Match</Text>
                 <Badge colorScheme={result.keyMatchResult ? 'green' : 'red'}>
                   {result.keyMatchResult ? 'Match ✓' : 'No Match'}
                 </Badge>
@@ -311,8 +311,8 @@ const StatusPanel: React.FC<StatusPanelProps> = ({ isRunning, messageCount, resu
             )}
             
             <HStack justify="space-between">
-              <Text fontSize="sm" color="gray.400">Duration</Text>
-              <Text fontSize="sm" color="white">{(result.totalDurationMs / 1000).toFixed(1)}s</Text>
+              <Text fontSize="sm" color="gray.600">Duration</Text>
+              <Text fontSize="sm" color="black">{(result.totalDurationMs / 1000).toFixed(1)}s</Text>
             </HStack>
           </>
         )}
@@ -347,19 +347,19 @@ export const A2AConversationScreen: React.FC<A2AConversationProps> = ({
   return (
     <Box
       minH="100vh"
-      bg="linear-gradient(180deg, #0A0A0A 0%, #1A1A2E 100%)"
+      bg="white"
       py={6}
     >
       <Container maxW="6xl">
         {/* Header */}
         <VStack spacing={2} mb={6} textAlign="center">
-          <Text color="gray.400" fontSize="sm">
-            Verifying <Text as="span" color="white" fontWeight="600">{config.user.fullName}</Text> with two AI agents
+          <Text color="gray.600" fontSize="sm">
+            Verifying <Text as="span" color="black" fontWeight="600">{config.user.fullName}</Text> with two AI agents
           </Text>
           <Text
             fontSize={{ base: 'lg', md: 'xl' }}
             fontWeight="600"
-            color="white"
+            color="black"
           >
             {config.relyingParty.name} • KYC Copilot × Hushh • KYC Network Agent
           </Text>
@@ -379,9 +379,9 @@ export const A2AConversationScreen: React.FC<A2AConversationProps> = ({
           {/* Conversation Log */}
           <Box flex={1}>
             <Box
-              bg="whiteAlpha.50"
+              bg="gray.50"
               border="1px solid"
-              borderColor="whiteAlpha.100"
+              borderColor="gray.200"
               borderRadius="2xl"
               p={4}
               minH="400px"
@@ -393,7 +393,7 @@ export const A2AConversationScreen: React.FC<A2AConversationProps> = ({
                   <Skeleton height="40px" width="80%" borderRadius="xl" />
                   <Skeleton height="40px" width="60%" borderRadius="xl" alignSelf="flex-end" />
                   <Skeleton height="40px" width="70%" borderRadius="xl" />
-                  <Text color="gray.500" fontSize="sm">
+                  <Text color="gray.600" fontSize="sm">
                     Waiting for conversation to start...
                   </Text>
                 </VStack>
@@ -440,19 +440,19 @@ export const A2AConversationScreen: React.FC<A2AConversationProps> = ({
 
               {/* A2A Protocol Info */}
               <Box
-                bg="rgba(159, 122, 234, 0.05)"
+                bg="purple.50"
                 border="1px solid"
-                borderColor="purple.900"
+                borderColor="purple.200"
                 borderRadius="xl"
                 p={4}
               >
                 <HStack spacing={3}>
                   <Text fontSize="lg">🔗</Text>
                   <VStack align="start" spacing={0}>
-                    <Text fontSize="xs" color="purple.300" fontWeight="500">
+                    <Text fontSize="xs" color="purple.600" fontWeight="500">
                       A2A Protocol
                     </Text>
-                    <Text fontSize="xs" color="gray.500">
+                    <Text fontSize="xs" color="gray.600">
                       JSON-RPC 2.0 over HTTPS
                     </Text>
                   </VStack>

--- a/src/components/a2aPlayground/A2AResultSummaryScreen.tsx
+++ b/src/components/a2aPlayground/A2AResultSummaryScreen.tsx
@@ -123,7 +123,7 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
   return (
     <Box
       minH="100vh"
-      bg="linear-gradient(180deg, #0a0a0a 0%, #111111 100%)"
+      bg="white"
       py={8}
       px={{ base: 4, md: 8 }}
     >
@@ -132,12 +132,12 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
         <VStack spacing={2} textAlign="center" animation={`${fadeIn} 0.5s ease-out`}>
           <Text
             fontSize={{ base: '2xl', md: '3xl' }}
-            fontWeight="500"
-            color="white"
+            fontWeight="600"
+            color="black"
           >
             A2A KYC Result Summary
           </Text>
-          <Text fontSize="md" color="whiteAlpha.600">
+          <Text fontSize="md" color="gray.600">
             Privacy-preserving verification complete in {totalDurationMs}ms
           </Text>
         </VStack>
@@ -145,12 +145,13 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
         {/* Main Status Card */}
         <Box
           w="full"
-          bg="whiteAlpha.50"
+          bg="gray.50"
           borderRadius="2xl"
           border="1px solid"
-          borderColor="whiteAlpha.100"
+          borderColor="gray.200"
           overflow="hidden"
           animation={`${fadeIn} 0.6s ease-out`}
+          boxShadow="sm"
         >
           {/* Status Banner */}
           <Box
@@ -175,29 +176,29 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
           {/* Status Details */}
           <SimpleGrid columns={{ base: 1, md: 3 }} gap={0}>
             {/* Verified Via */}
-            <Box p={6} borderRight={{ md: '1px solid' }} borderColor="whiteAlpha.100">
+            <Box p={6} borderRight={{ md: '1px solid' }} borderColor="gray.200">
               <VStack spacing={3} align="flex-start">
                 <HStack spacing={2}>
-                  <Icon as={FiShield} color="purple.400" />
-                  <Text fontSize="sm" color="whiteAlpha.500" textTransform="uppercase">
+                  <Icon as={FiShield} color="purple.500" />
+                  <Text fontSize="sm" color="gray.600" textTransform="uppercase">
                     Verified Via
                   </Text>
                 </HStack>
-                <Text fontSize="lg" color="white" fontWeight="500">
+                <Text fontSize="lg" color="black" fontWeight="500">
                   {kycDecision.verifiedVia.providerName}
                 </Text>
-                <Text fontSize="xs" color="whiteAlpha.500">
+                <Text fontSize="xs" color="gray.600">
                   {kycDecision.verifiedVia.providerType} • No raw PII shared
                 </Text>
               </VStack>
             </Box>
 
             {/* Risk Band */}
-            <Box p={6} borderRight={{ md: '1px solid' }} borderColor="whiteAlpha.100">
+            <Box p={6} borderRight={{ md: '1px solid' }} borderColor="gray.200">
               <VStack spacing={3} align="flex-start">
                 <HStack spacing={2}>
-                  <Icon as={FiAlertTriangle} color="yellow.400" />
-                  <Text fontSize="sm" color="whiteAlpha.500" textTransform="uppercase">
+                  <Icon as={FiAlertTriangle} color="yellow.500" />
+                  <Text fontSize="sm" color="gray.600" textTransform="uppercase">
                     Risk Assessment
                   </Text>
                 </HStack>
@@ -218,12 +219,12 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
             <Box p={6}>
               <VStack spacing={3} align="flex-start">
                 <HStack spacing={2}>
-                  <Icon as={FiCheckCircle} color="green.400" />
-                  <Text fontSize="sm" color="whiteAlpha.500" textTransform="uppercase">
+                  <Icon as={FiCheckCircle} color="green.500" />
+                  <Text fontSize="sm" color="gray.600" textTransform="uppercase">
                     Verified Attributes
                   </Text>
                 </HStack>
-                <Text fontSize="2xl" color="white" fontWeight="600">
+                <Text fontSize="2xl" color="black" fontWeight="600">
                   {kycDecision.verifiedAttributes.length}
                 </Text>
                 <Flex wrap="wrap" gap={1}>
@@ -247,12 +248,13 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
         <SimpleGrid columns={{ base: 1, lg: 2 }} gap={6} w="full">
           {/* Data Export Card */}
           <Box
-            bg="whiteAlpha.50"
+            bg="gray.50"
             borderRadius="2xl"
             border="1px solid"
-            borderColor="whiteAlpha.100"
+            borderColor="gray.200"
             p={6}
             animation={`${fadeIn} 0.7s ease-out`}
+            boxShadow="sm"
           >
             <VStack spacing={5} align="stretch">
               <HStack spacing={3}>
@@ -268,35 +270,35 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
                   <Icon as={FiDatabase} boxSize={5} color="white" />
                 </Box>
                 <VStack spacing={0} align="flex-start">
-                  <Text fontSize="lg" fontWeight="500" color="white">
+                  <Text fontSize="lg" fontWeight="500" color="black">
                     Data Export
                   </Text>
-                  <Text fontSize="xs" color="whiteAlpha.500">
+                  <Text fontSize="xs" color="gray.600">
                     Normalized JSON profile
                   </Text>
                 </VStack>
               </HStack>
 
-              <Divider borderColor="whiteAlpha.100" />
+              <Divider borderColor="gray.200" />
 
               {exportResult ? (
                 <>
                   <HStack justify="space-between">
-                    <Text fontSize="sm" color="whiteAlpha.600">Exported To</Text>
+                    <Text fontSize="sm" color="gray.600">Exported To</Text>
                     <Badge colorScheme="purple" borderRadius="full" px={3}>
                       {exportResult.exportedTo}
                     </Badge>
                   </HStack>
 
                   <HStack justify="space-between">
-                    <Text fontSize="sm" color="whiteAlpha.600">Schema</Text>
-                    <Text fontSize="sm" color="white" fontFamily="mono">
+                    <Text fontSize="sm" color="gray.600">Schema</Text>
+                    <Text fontSize="sm" color="black" fontFamily="mono">
                       {exportResult.profileSchema}
                     </Text>
                   </HStack>
 
                   <Box>
-                    <Text fontSize="sm" color="whiteAlpha.600" mb={2}>
+                    <Text fontSize="sm" color="gray.600" mb={2}>
                       Fields Included ({exportResult.includedFields.length})
                     </Text>
                     <Flex wrap="wrap" gap={2}>
@@ -321,7 +323,7 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
 
                   {exportResult.excludedFields.length > 0 && (
                     <Box>
-                      <Text fontSize="sm" color="whiteAlpha.600" mb={2}>
+                      <Text fontSize="sm" color="gray.600" mb={2}>
                         Fields Excluded (Privacy Protected)
                       </Text>
                       <Flex wrap="wrap" gap={2}>
@@ -346,19 +348,19 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
                   )}
 
                   <Box
-                    bg="blackAlpha.400"
+                    bg="purple.50"
                     borderRadius="lg"
                     p={4}
                     border="1px solid"
-                    borderColor="whiteAlpha.100"
+                    borderColor="purple.200"
                   >
                     <HStack spacing={2} mb={2}>
-                      <Icon as={FiLock} color="purple.400" boxSize={4} />
-                      <Text fontSize="xs" color="purple.400" fontWeight="500">
+                      <Icon as={FiLock} color="purple.600" boxSize={4} />
+                      <Text fontSize="xs" color="purple.600" fontWeight="500">
                         Privacy Guarantee
                       </Text>
                     </HStack>
-                    <Text fontSize="xs" color="whiteAlpha.600" lineHeight="tall">
+                    <Text fontSize="xs" color="gray.700" lineHeight="tall">
                       Raw SSN was never shared. Only attestation-based verification 
                       (yes/no match) was used. Bank receives normalized profile, 
                       not raw secrets.
@@ -366,7 +368,7 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
                   </Box>
                 </>
               ) : (
-                <Text fontSize="sm" color="whiteAlpha.500" textAlign="center" py={4}>
+                <Text fontSize="sm" color="gray.600" textAlign="center" py={4}>
                   Export not requested for this scenario
                 </Text>
               )}
@@ -375,12 +377,13 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
 
           {/* Audit Trail Card */}
           <Box
-            bg="whiteAlpha.50"
+            bg="gray.50"
             borderRadius="2xl"
             border="1px solid"
-            borderColor="whiteAlpha.100"
+            borderColor="gray.200"
             p={6}
             animation={`${fadeIn} 0.8s ease-out`}
+            boxShadow="sm"
           >
             <VStack spacing={5} align="stretch">
               <HStack spacing={3}>
@@ -396,29 +399,29 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
                   <Icon as={FiClock} boxSize={5} color="white" />
                 </Box>
                 <VStack spacing={0} align="flex-start">
-                  <Text fontSize="lg" fontWeight="500" color="white">
+                  <Text fontSize="lg" fontWeight="500" color="black">
                     Audit Trail
                   </Text>
-                  <Text fontSize="xs" color="whiteAlpha.500">
+                  <Text fontSize="xs" color="gray.600">
                     Verification record
                   </Text>
                 </VStack>
               </HStack>
 
-              <Divider borderColor="whiteAlpha.100" />
+              <Divider borderColor="gray.200" />
 
               <HStack justify="space-between">
-                <Text fontSize="sm" color="whiteAlpha.600">Check ID</Text>
+                <Text fontSize="sm" color="gray.600">Check ID</Text>
                 <HStack spacing={2}>
-                  <Text fontSize="sm" color="white" fontFamily="mono">
+                  <Text fontSize="sm" color="black" fontFamily="mono">
                     {checkId.slice(0, 8)}...{checkId.slice(-4)}
                   </Text>
                   <Tooltip label={hasCopied ? 'Copied!' : 'Copy full ID'}>
                     <Box
                       as="button"
                       onClick={onCopy}
-                      color="purple.400"
-                      _hover={{ color: 'purple.300' }}
+                      color="purple.500"
+                      _hover={{ color: 'purple.600' }}
                     >
                       <Icon as={FiCopy} boxSize={4} />
                     </Box>
@@ -427,37 +430,37 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
               </HStack>
 
               <HStack justify="space-between">
-                <Text fontSize="sm" color="whiteAlpha.600">Timestamp</Text>
-                <Text fontSize="sm" color="white">
+                <Text fontSize="sm" color="gray.600">Timestamp</Text>
+                <Text fontSize="sm" color="black">
                   {new Date(audit.loggedAt).toLocaleString()}
                 </Text>
               </HStack>
 
               <HStack justify="space-between">
-                <Text fontSize="sm" color="whiteAlpha.600">Relying Party</Text>
-                <Text fontSize="sm" color="white">
+                <Text fontSize="sm" color="gray.600">Relying Party</Text>
+                <Text fontSize="sm" color="black">
                   {config.relyingParty.name}
                 </Text>
               </HStack>
 
               <HStack justify="space-between">
-                <Text fontSize="sm" color="whiteAlpha.600">User</Text>
+                <Text fontSize="sm" color="gray.600">User</Text>
                 <HStack spacing={2}>
-                  <Icon as={FiUser} color="whiteAlpha.600" boxSize={4} />
-                  <Text fontSize="sm" color="white">
+                  <Icon as={FiUser} color="gray.600" boxSize={4} />
+                  <Text fontSize="sm" color="black">
                     {config.user.fullName}
                   </Text>
                 </HStack>
               </HStack>
 
               <Box
-                bg="blackAlpha.400"
+                bg="purple.50"
                 borderRadius="lg"
                 p={4}
                 border="1px solid"
-                borderColor="whiteAlpha.100"
+                borderColor="purple.200"
               >
-                <Text fontSize="xs" color="whiteAlpha.600" mb={2}>
+                <Text fontSize="xs" color="gray.600" mb={2}>
                   Operations Performed
                 </Text>
                 <Flex wrap="wrap" gap={2}>
@@ -496,9 +499,9 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
             size="lg"
             leftIcon={<FiMessageSquare />}
             variant="outline"
-            borderColor="whiteAlpha.300"
-            color="white"
-            _hover={{ bg: 'whiteAlpha.100' }}
+            borderColor="gray.300"
+            color="black"
+            _hover={{ bg: 'gray.50' }}
             borderRadius="xl"
             px={8}
             onClick={onViewConversation}
@@ -510,9 +513,9 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
               size="lg"
               leftIcon={<FiDownload />}
               variant="outline"
-              borderColor="whiteAlpha.300"
-              color="white"
-              _hover={{ bg: 'whiteAlpha.100' }}
+              borderColor="gray.300"
+              color="black"
+              _hover={{ bg: 'gray.50' }}
               borderRadius="xl"
               px={8}
               onClick={() => {
@@ -536,14 +539,16 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
 
         {/* Footer Note */}
         <Box
-          bg="whiteAlpha.50"
+          bg="gray.50"
           borderRadius="xl"
           p={4}
           w="full"
           textAlign="center"
           animation={`${fadeIn} 1s ease-out`}
+          border="1px solid"
+          borderColor="gray.200"
         >
-          <Text fontSize="sm" color="whiteAlpha.600">
+          <Text fontSize="sm" color="gray.600">
             🔒 This demo showcases privacy-preserving A2A verification. 
             In production, attestations are cryptographically signed and 
             verifiable on-chain.

--- a/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
+++ b/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
@@ -107,7 +107,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
   return (
     <Box
       minH="100vh"
-      bg="linear-gradient(180deg, #0A0A0A 0%, #1A1A2E 100%)"
+      bg="white"
       py={8}
     >
       <Container maxW="lg">
@@ -124,12 +124,12 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
           </Badge>
           <Text
             fontSize={{ base: '2xl', md: '3xl' }}
-            fontWeight="700"
-            color="white"
+            fontWeight="600"
+            color="black"
           >
             Agent-to-Agent KYC Playground
           </Text>
-          <Text color="gray.400" fontSize="sm" maxW="md">
+          <Text color="gray.600" fontSize="sm" maxW="md">
             Watch Bank KYC Copilot and Hushh KYC Agent collaborate 
             in real-time to verify identity and export KYC data.
           </Text>
@@ -137,12 +137,12 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
 
         {/* Main Form Card */}
         <Box
-          bg="whiteAlpha.50"
+          bg="gray.50"
           border="1px solid"
-          borderColor="whiteAlpha.100"
+          borderColor="gray.200"
           borderRadius="2xl"
           p={6}
-          animation={`${pulseGlow} 3s ease-in-out infinite`}
+          boxShadow="sm"
         >
           <VStack spacing={6} align="stretch">
             {/* Section 1: Relying Party */}
@@ -150,7 +150,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
               <Text
                 fontSize="sm"
                 fontWeight="600"
-                color="purple.300"
+                color="purple.600"
                 mb={3}
                 textTransform="uppercase"
                 letterSpacing="wide"
@@ -159,24 +159,23 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
               </Text>
               
               <FormControl>
-                <FormLabel color="gray.300" fontSize="sm">
+                <FormLabel color="gray.700" fontSize="sm">
                   Bank or Financial Institution
                 </FormLabel>
                 <Select
                   value={selectedPartyId}
                   onChange={(e) => setSelectedPartyId(e.target.value)}
-                  bg="whiteAlpha.100"
+                  bg="white"
                   border="1px solid"
-                  borderColor="whiteAlpha.200"
-                  color="white"
-                  _hover={{ borderColor: 'purple.400' }}
-                  _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                  borderColor="gray.300"
+                  color="black"
+                  _hover={{ borderColor: 'purple.500' }}
+                  _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                 >
                   {DEMO_RELYING_PARTIES.map((party) => (
                     <option 
                       key={party.id} 
                       value={party.id}
-                      style={{ background: '#1A1A2E' }}
                     >
                       {party.name} {party.description ? `– ${party.description}` : ''}
                     </option>
@@ -185,14 +184,14 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
               </FormControl>
             </Box>
 
-            <Divider borderColor="whiteAlpha.100" />
+            <Divider borderColor="gray.200" />
 
             {/* Section 2: User to Verify */}
             <Box>
               <Text
                 fontSize="sm"
                 fontWeight="600"
-                color="purple.300"
+                color="purple.600"
                 mb={3}
                 textTransform="uppercase"
                 letterSpacing="wide"
@@ -203,45 +202,44 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
               <VStack spacing={4}>
                 {/* Full Name */}
                 <FormControl>
-                  <FormLabel color="gray.300" fontSize="sm">
+                  <FormLabel color="gray.700" fontSize="sm">
                     Full Name
                   </FormLabel>
                   <Input
                     value={user.fullName}
                     onChange={(e) => setUser({ ...user, fullName: e.target.value })}
                     placeholder="Enter full name"
-                    bg="whiteAlpha.100"
+                    bg="white"
                     border="1px solid"
-                    borderColor="whiteAlpha.200"
-                    color="white"
-                    _placeholder={{ color: 'gray.500' }}
-                    _hover={{ borderColor: 'purple.400' }}
-                    _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                    borderColor="gray.300"
+                    color="black"
+                    _placeholder={{ color: 'gray.400' }}
+                    _hover={{ borderColor: 'purple.500' }}
+                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                   />
                 </FormControl>
 
                 {/* Phone */}
                 <FormControl>
-                  <FormLabel color="gray.300" fontSize="sm">
+                  <FormLabel color="gray.700" fontSize="sm">
                     Phone Number
                   </FormLabel>
                   <HStack>
                     <Select
                       value={user.phoneCountryCode}
                       onChange={(e) => setUser({ ...user, phoneCountryCode: e.target.value })}
-                      bg="whiteAlpha.100"
+                      bg="white"
                       border="1px solid"
-                      borderColor="whiteAlpha.200"
-                      color="white"
+                      borderColor="gray.300"
+                      color="black"
                       w="140px"
-                      _hover={{ borderColor: 'purple.400' }}
-                      _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                      _hover={{ borderColor: 'purple.500' }}
+                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     >
                       {PHONE_CODES.map((code) => (
                         <option 
                           key={code.value} 
                           value={code.value}
-                          style={{ background: '#1A1A2E' }}
                         >
                           {code.label}
                         </option>
@@ -251,37 +249,36 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                       value={user.phoneNumber}
                       onChange={(e) => setUser({ ...user, phoneNumber: e.target.value })}
                       placeholder="Phone number"
-                      bg="whiteAlpha.100"
+                      bg="white"
                       border="1px solid"
-                      borderColor="whiteAlpha.200"
-                      color="white"
-                      _placeholder={{ color: 'gray.500' }}
-                      _hover={{ borderColor: 'purple.400' }}
-                      _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                      borderColor="gray.300"
+                      color="black"
+                      _placeholder={{ color: 'gray.400' }}
+                      _hover={{ borderColor: 'purple.500' }}
+                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     />
                   </HStack>
                 </FormControl>
 
                 {/* Country */}
                 <FormControl>
-                  <FormLabel color="gray.300" fontSize="sm">
+                  <FormLabel color="gray.700" fontSize="sm">
                     Country
                   </FormLabel>
                   <Select
                     value={user.country}
                     onChange={(e) => setUser({ ...user, country: e.target.value })}
-                    bg="whiteAlpha.100"
+                    bg="white"
                     border="1px solid"
-                    borderColor="whiteAlpha.200"
-                    color="white"
-                    _hover={{ borderColor: 'purple.400' }}
-                    _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                    borderColor="gray.300"
+                    color="black"
+                    _hover={{ borderColor: 'purple.500' }}
+                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                   >
                     {COUNTRY_OPTIONS.map((country) => (
                       <option 
                         key={country.value} 
                         value={country.value}
-                        style={{ background: '#1A1A2E' }}
                       >
                         {country.label}
                       </option>
@@ -291,7 +288,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
 
                 {/* Email (Optional) */}
                 <FormControl>
-                  <FormLabel color="gray.300" fontSize="sm">
+                  <FormLabel color="gray.700" fontSize="sm">
                     Email (Optional)
                   </FormLabel>
                   <Input
@@ -299,20 +296,20 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                     onChange={(e) => setUser({ ...user, email: e.target.value })}
                     placeholder="email@example.com"
                     type="email"
-                    bg="whiteAlpha.100"
+                    bg="white"
                     border="1px solid"
-                    borderColor="whiteAlpha.200"
-                    color="white"
-                    _placeholder={{ color: 'gray.500' }}
-                    _hover={{ borderColor: 'purple.400' }}
-                    _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                    borderColor="gray.300"
+                    color="black"
+                    _placeholder={{ color: 'gray.400' }}
+                    _hover={{ borderColor: 'purple.500' }}
+                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                   />
                 </FormControl>
 
                 {/* SSN Last 4 (for key match demo) */}
                 {operations.confirmKeyMatch && (
                   <FormControl>
-                    <FormLabel color="gray.300" fontSize="sm">
+                    <FormLabel color="gray.700" fontSize="sm">
                       SSN Last 4 Digits (for key match demo)
                     </FormLabel>
                     <Input
@@ -320,15 +317,15 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                       onChange={(e) => setUser({ ...user, ssnLast4: e.target.value })}
                       placeholder="1234"
                       maxLength={4}
-                      bg="whiteAlpha.100"
+                      bg="white"
                       border="1px solid"
-                      borderColor="whiteAlpha.200"
-                      color="white"
-                      _placeholder={{ color: 'gray.500' }}
-                      _hover={{ borderColor: 'purple.400' }}
-                      _focus={{ borderColor: 'purple.400', boxShadow: 'none' }}
+                      borderColor="gray.300"
+                      color="black"
+                      _placeholder={{ color: 'gray.400' }}
+                      _hover={{ borderColor: 'purple.500' }}
+                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     />
-                    <Text fontSize="xs" color="gray.500" mt={1}>
+                    <Text fontSize="xs" color="gray.600" mt={1}>
                       🔒 This is only used to demo VerifyFieldMatch – never shared in clear
                     </Text>
                   </FormControl>
@@ -336,14 +333,14 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
               </VStack>
             </Box>
 
-            <Divider borderColor="whiteAlpha.100" />
+            <Divider borderColor="gray.200" />
 
             {/* Section 3: Operations */}
             <Box>
               <Text
                 fontSize="sm"
                 fontWeight="600"
-                color="purple.300"
+                color="purple.600"
                 mb={3}
                 textTransform="uppercase"
                 letterSpacing="wide"
@@ -362,10 +359,10 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                   size="lg"
                 >
                   <VStack align="start" spacing={0}>
-                    <Text color="white" fontSize="sm" fontWeight="500">
+                    <Text color="black" fontSize="sm" fontWeight="500">
                       Verify KYC Status
                     </Text>
-                    <Text color="gray.500" fontSize="xs">
+                    <Text color="gray.600" fontSize="xs">
                       CheckKYCStatus – Is this user verified?
                     </Text>
                   </VStack>
@@ -381,10 +378,10 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                   size="lg"
                 >
                   <VStack align="start" spacing={0}>
-                    <Text color="white" fontSize="sm" fontWeight="500">
+                    <Text color="black" fontSize="sm" fontWeight="500">
                       Confirm Key Match
                     </Text>
-                    <Text color="gray.500" fontSize="xs">
+                    <Text color="gray.600" fontSize="xs">
                       VerifyFieldMatch – Does SSN last4 match?
                     </Text>
                   </VStack>
@@ -400,10 +397,10 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                   size="lg"
                 >
                   <VStack align="start" spacing={0}>
-                    <Text color="white" fontSize="sm" fontWeight="500">
+                    <Text color="black" fontSize="sm" fontWeight="500">
                       Export KYC Profile
                     </Text>
-                    <Text color="gray.500" fontSize="xs">
+                    <Text color="gray.600" fontSize="xs">
                       ExportKYCProfile – Get normalized JSON profile
                     </Text>
                   </VStack>
@@ -411,7 +408,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
               </VStack>
             </Box>
 
-            <Divider borderColor="whiteAlpha.100" />
+            <Divider borderColor="gray.200" />
 
             {/* Run Button */}
             <Button
@@ -435,7 +432,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
             {/* Help Text */}
             <Text 
               fontSize="xs" 
-              color="gray.500" 
+              color="gray.600" 
               textAlign="center"
             >
               This will simulate a real A2A conversation between {selectedParty.name} 
@@ -447,7 +444,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
         {/* Footer */}
         <Text 
           fontSize="xs" 
-          color="gray.600" 
+          color="gray.500" 
           textAlign="center" 
           mt={6}
         >


### PR DESCRIPTION
- Changed all 3 screens (Setup, Conversation, Result) from dark gradients to clean white backgrounds
- Updated text colors from white/gray.400 to black/gray.600 for better readability
- Changed borders from whiteAlpha to gray.200/gray.300 for subtle Apple-style definition
- Updated input fields, selects, and form controls to white backgrounds with gray borders
- Modified agent cards and message bubbles to light backgrounds (gray.50, rgba opacity)
- Updated status panels and info boxes to use gray.50 instead of dark backgrounds
- Changed action buttons to use proper contrast (outlined buttons now have gray borders)
- Maintained purple accent colors for branding consistency
- Removed dark gradients and pulseGlow animations that didn't fit white background
- Added subtle boxShadow='sm' for depth on cards
- Follows Apple minimalist design: white bg, black text, subtle shadows, clean lines