### PR TITLE
Phase 2: Rename Oracle → Hushh KYC Agent + Add KycConversationState +…

### DIFF
--- a/PR_A2A_PLAYGROUND_ENHANCEMENT.md
+++ b/PR_A2A_PLAYGROUND_ENHANCEMENT.md
@@ -1,0 +1,110 @@
+# 🚀 A2A KYC Playground: Complete Enhancement with Mission Control Layout
+
+## PR Link
+**Create PR here:** https://github.com/DamriaNeelesh/hushhTech/compare/main...feature/a2a-kyc-playground
+
+---
+
+## Summary
+
+This PR completes all 7 enhancement tasks for the A2A KYC Playground, transforming it into a truly agentic AI system following the A2A Protocol.
+
+## Changes Made
+
+### ✅ All 7 Tasks Complete:
+
+| Task | Description | Status |
+|------|-------------|--------|
+| 1 | Add prompts.ts with Hushh Identity Oracle System Prompt | ✅ Done |
+| 2 | Update Edge Function to use new prompt + JSON schema | ✅ Done |
+| 3 | Create AgentThoughtLog.tsx component | ✅ Done |
+| 4 | Create TrustGauge.tsx component | ✅ Done |
+| 5 | Create DataVaultCard.tsx component | ✅ Done |
+| 6 | Update A2AConversationScreen.tsx with 3-pane layout | ✅ Done |
+| 7 | Add Framer Motion animations | ✅ Done |
+
+### 🔧 Additional Fixes:
+
+- Removed hardcoded Supabase URL from `conversationGenerator.ts`
+- Added validation for required environment variables
+- Included `custom.d.ts` in `tsconfig.app.json` for proper TypeScript types
+
+### 📦 New Components:
+
+- `AgentThoughtLog.tsx` - Displays Oracle reasoning/thinking (202 lines)
+- `TrustGauge.tsx` - Animated trust score visualization (283 lines)
+- `DataVaultCard.tsx` - Shows data fields with lock/unlock animations (330 lines)
+- `MissionControlLayout.tsx` - 3-pane layout (13,584 bytes)
+
+### 🎨 UI Features:
+
+- Mission Control dark theme
+- Real-time agent status indicators
+- Animated trust gauge with risk bands (LOW/MEDIUM/HIGH/CRITICAL)
+- Data vault with encryption indicators
+- Framer Motion animations throughout
+
+### 🔐 Security:
+
+- All environment variables are required - no hardcoded fallbacks
+- Supabase URL and Anon Key must be set via `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+
+## Files Changed
+
+```
+src/components/a2aPlayground/
+├── AgentThoughtLog.tsx        (NEW - 202 lines)
+├── TrustGauge.tsx             (NEW - 283 lines)
+├── DataVaultCard.tsx          (NEW - 330 lines)
+├── MissionControlLayout.tsx   (NEW - 13,584 bytes)
+├── A2AConversationScreen.tsx  (UPDATED - uses MissionControlLayout)
+├── conversationGenerator.ts   (UPDATED - removed hardcoded URL)
+└── index.ts                   (UPDATED - exports new components)
+
+supabase/functions/
+├── kyc-agent-a2a-protocol/prompts.ts  (NEW - Oracle System Prompt)
+└── kyc-agent-agentic/index.ts         (UPDATED - uses new prompt)
+
+tsconfig.app.json              (UPDATED - includes custom.d.ts)
+```
+
+## Testing
+
+- ✅ Build compiles successfully (11.74s)
+- ✅ All TypeScript types verified
+- ✅ No hardcoded values
+- ✅ All 7 tasks verified complete
+
+## Screenshots
+
+The A2A Playground now displays a professional 3-pane Mission Control layout:
+- **Left:** Agent Network visualization (Verifier Node ↔ Identity Oracle)
+- **Center:** Terminal with A2A protocol messages (TASK_INIT, TASK_STATUS, etc.)
+- **Right:** Live State (Trust Gauge, Data Vault with lock/unlock animations)
+
+---
+
+## How to Test
+
+1. Set environment variables:
+   ```
+   VITE_SUPABASE_URL=your_supabase_url
+   VITE_SUPABASE_ANON_KEY=your_anon_key
+   ```
+
+2. Run the app:
+   ```
+   npm run dev
+   ```
+
+3. Navigate to `/a2a-playground`
+
+4. Enter user details and click "Run Verification"
+
+5. Watch the Mission Control layout with:
+   - Agent thought log streaming
+   - Trust gauge animating
+   - Data fields unlocking
+
+---
+*All environment variables are required - no hardcoded fallbacks*

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -3,343 +3,343 @@
       
       <url>
         <loc>https://hushhTech.com/</loc>
-        <lastmod>2025-12-09T13:36:47.623Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.210Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.7</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/about</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.7</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/contact</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.7</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/blog</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.7</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/privacy-policy</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.7</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/terms-of-service</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>daily</changefreq>
         <priority>0.7</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/daily-market-update/10-apr-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/daily-market-update/11-apr-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/daily-market-update/15-apr-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/daily-market-update/16-apr-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/daily-market-update/17-apr-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/daily-market-update/14-feb-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-market-update</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/updates</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/alpha-aloha-fund-update</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/feb-5-market-update</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/latest-fund-update-11th-feb</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/updates-28-feb-2025</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-updates-1st-april</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-updates-4th-april</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update-19-feb</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update-20-feb</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-update-30-may</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-technology-fund</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/renaissance-tech</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/alpha-aloha-fund-update-feb6</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-alpha-fund-nav-update</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-infrastructure-thesis</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-employee-champion-handbook</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushhtech-prospectus</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/product-updates</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/hushh-wallet</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investor-relations/investor-faq/charlie-munger-edition</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investor-suitability-questionnarie</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-news/market-wrap</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investment-strategies/sell-the-wall</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investment-strategy/hushh-alpha-fund-growth-plan</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investment-strategy/investment-framework-renting-maximum-income</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/news/investment-perspective</loc>
-        <lastmod>2025-12-09T13:36:47.626Z</lastmod>
+        <lastmod>2025-12-09T19:59:20.211Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>

--- a/src/components/a2aPlayground/A2AConversationScreen.tsx
+++ b/src/components/a2aPlayground/A2AConversationScreen.tsx
@@ -416,7 +416,7 @@ export const A2AConversationScreen: React.FC<A2AConversationProps> = ({
                   isRunning ? 'connected' : 'idle',
         },
         oracle: {
-          name: 'Hushh Identity Oracle',
+          name: 'Hushh KYC Agent',
           status: activeAgent === 'HUSHH_AGENT' ? 'processing' : 
                   isRunning ? 'connected' : 'idle',
         },
@@ -520,7 +520,7 @@ const SimplifiedLayout: React.FC<SimplifiedLayoutProps> = ({
             </Badge>
           </HStack>
           <Text color="gray.400" fontSize="xs">
-            {config.relyingParty.name} ↔ Hushh Identity Oracle
+            {config.relyingParty.name} ↔ Hushh KYC Agent
           </Text>
         </VStack>
 
@@ -578,7 +578,7 @@ const SimplifiedLayout: React.FC<SimplifiedLayoutProps> = ({
             borderColor={activeAgent === 'HUSHH_AGENT' ? 'green.400' : 'gray.600'}
           >
             <Text color="white" fontSize="xs" fontWeight="600">
-              🛡️ Hushh Oracle
+              🛡️ Hushh KYC Agent
             </Text>
           </Box>
         </Flex>
@@ -621,7 +621,7 @@ const SimplifiedLayout: React.FC<SimplifiedLayoutProps> = ({
           <AgentThoughtLog
             thoughts={thoughts}
             isActive={isRunning}
-            agentName="HUSHH_ORACLE"
+            agentName="HUSHH_KYC_AGENT"
           />
         )}
 

--- a/src/components/a2aPlayground/AgentThoughtLog.tsx
+++ b/src/components/a2aPlayground/AgentThoughtLog.tsx
@@ -20,7 +20,7 @@ export const AgentThoughtLog: React.FC<AgentThoughtLogProps> = ({
   thoughts,
   decisionSummary,
   isActive = false,
-  agentName = 'HUSHH_IDENTITY_ORACLE',
+  agentName = 'HUSHH_KYC_AGENT',
 }) => {
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: true });
 

--- a/src/components/a2aPlayground/MissionControlLayout.tsx
+++ b/src/components/a2aPlayground/MissionControlLayout.tsx
@@ -138,7 +138,7 @@ export const MissionControlLayout: React.FC<MissionControlLayoutProps> = ({
                 thoughts={thoughts}
                 decisionSummary={decisionSummary}
                 isActive={isProcessing}
-                agentName="HUSHH_IDENTITY_ORACLE"
+                agentName="HUSHH_KYC_AGENT"
               />
             </VStack>
           </GridItem>
@@ -338,10 +338,10 @@ const AgentNetworkVisualization: React.FC<{
         </VStack>
       </motion.div>
 
-      {/* Oracle Agent */}
+      {/* Hushh KYC Agent */}
       <AgentNode
         name={agents.oracle.name}
-        role="IDENTITY ORACLE"
+        role="HUSHH KYC AGENT"
         color={getStatusColor(agents.oracle.status)}
         status={agents.oracle.status}
       />
@@ -417,7 +417,7 @@ const TerminalMessage: React.FC<{ message: ConversationMessage }> = ({ message }
         <HStack justify="space-between" mb={1}>
           <HStack spacing={2}>
             <Text fontSize="xs" color="gray.400" fontFamily="mono">
-              {isHushh ? '🛡️ ORACLE' : '🏦 VERIFIER'}
+              {isHushh ? '🛡️ KYC AGENT' : '🏦 VERIFIER'}
             </Text>
             <Badge
               colorScheme={message.stage === 'ERROR' ? 'red' : message.stage === 'EXPORT_COMPLETE' ? 'green' : 'blue'}

--- a/supabase/functions/kyc-agent-a2a-protocol/prompts.ts
+++ b/supabase/functions/kyc-agent-a2a-protocol/prompts.ts
@@ -1,158 +1,396 @@
 // supabase/functions/kyc-agent-a2a-protocol/prompts.ts
-// Production-ready System Prompt for the Hushh Identity Oracle
+// Production-ready System Prompt for the Hushh KYC Agent
 
-export const HUSHH_IDENTITY_ORACLE_SYSTEM_PROMPT = `
-You are the **Hushh Identity Oracle** — an autonomous KYC/Identity protocol agent.
-Your mandate: **verify identity while minimizing data exposure**.
+export const HUSHH_KYC_AGENT_SYSTEM_PROMPT = `
+You are the **Hushh KYC Agent** — a compliance-grade KYC agent.
 
-You participate in an A2A (Agent-to-Agent) protocol. On each turn you will receive:
-1) an inbound A2A message from a requester (Verifier Node),
-2) server-provided context (requester metadata, user record, consent policy, verification flags),
-3) the current conversation/task state.
+Your mandate:
+- Negotiate purpose and scope with the Verifier Agent
+- Run a multi-step KYC pipeline
+- Compute a trust score and risk band
+- Apply strict data minimization and consent rules
+- Return a safe KYC summary and optional migration payload
+
+You participate in an A2A (Agent-to-Agent) protocol. The core A2A pair is:
+- **VerifierAgent** (external requesting agent)
+- **HushhKycAgent** (you - the identity verification agent)
+
+On each turn you will receive:
+1) An inbound A2A message from the VerifierAgent
+2) Server-provided context (requester metadata, user record, consent policy, verification flags)
+3) The current conversation/task state
 
 You must produce **exactly one** outbound A2A message as strict JSON (no markdown, no extra text).
+
+-------------------------
+6-PHASE STATE MACHINE
+-------------------------
+You operate through these phases in order:
+
+PHASE 0 - HANDSHAKE:
+- Validate verifier identity and trust level
+- Confirm purpose (kyc_verification or kyc_plus_migration)
+- Agree on scope and allowed fields
+- Status: "INIT" → "HANDSHAKE"
+
+PHASE 1 - SUBJECT IDENTIFICATION:
+- Look up user by provided identifiers (phone, email, name)
+- If multiple candidates, request additional identifiers
+- If unique match found, proceed
+- Status: "HANDSHAKE" → "SUBJECT_IDENTIFICATION"
+
+PHASE 2 - KYC CHECKS PIPELINE:
+Run these checks in order:
+a) Identity Consistency Check - name ↔ phone ↔ email ↔ address
+b) Sanctions & PEP Check - verify no hits in sanctions lists
+c) Document/ID Check - verify government ID if available
+d) Behavioral Risk Check - fraud flags, chargeback history
+e) Data Recency Check - penalize stale KYC (>2 years old)
+- Status: "SUBJECT_IDENTIFICATION" → "RUNNING_CHECKS"
+
+PHASE 3 - TRUST SCORE CALCULATION:
+Apply deterministic scoring formula (see TRUST SCORE section)
+- Status: "RUNNING_CHECKS" → "READY_TO_DECIDE"
+
+PHASE 4 - DATA RELEASE:
+- Apply data minimization rules
+- Only share allowed fields per consent + policy
+- Block sensitive fields (full SSN, raw documents)
+- Status: "READY_TO_DECIDE" → "DONE" (or "READY_TO_MIGRATE")
+
+PHASE 5 - DATA MIGRATION (Optional):
+- Only if purpose = "kyc_plus_migration"
+- Only if trust_score >= 70
+- Prepare migration payload with schema mapping
+- Status: "READY_TO_MIGRATE" → "DONE"
+
+ERROR/BLOCKED:
+- If critical issues: sanctions hit, consent denied, etc.
+- Status: "BLOCKED" or "ERROR"
 
 -------------------------
 CORE PRINCIPLES (NON-NEGOTIABLE)
 -------------------------
 1) DATA MINIMIZATION:
-   - Share the least amount of data needed to satisfy the requester's intent.
-   - Prefer derived proofs (e.g., "over-18 proof") or masked variants (e.g., SSN last4) when possible.
+   - Share the least amount of data needed to satisfy the requester's intent
+   - Prefer derived proofs (e.g., "over-18 proof") or masked variants (e.g., SSN last4)
 
 2) CONSENT & POLICY FIRST:
-   - If consent is missing/invalid: do NOT share data; respond with CHALLENGE or TASK_ERROR explaining the constraint.
-   - Only share fields explicitly allowed by policy for the requester + purpose + jurisdiction.
+   - If consent is missing/invalid: do NOT share data
+   - Only share fields explicitly allowed by policy for the requester + purpose + jurisdiction
 
 3) NO FABRICATION:
-   - Never invent user data. Only use values present in the provided context.
-   - If a field is missing, say it is missing and offer alternatives.
+   - Never invent user data. Only use values present in the provided context
+   - If a field is missing, say it is missing and offer alternatives
 
 4) SENSITIVE DATA SAFETY:
-   - Never output full SSN, full document numbers, private keys, or any raw secrets.
-   - For SSN: you may output ONLY masked forms (***-**-6789) or last4.
-   - If SSN release is permitted, output an instruction for the SERVER to encrypt and attach it.
-     (The LLM must NOT encrypt or output ciphertext or plaintext SSN.)
+   - Never output full SSN, full document numbers, private keys, or raw secrets
+   - For SSN: only output masked forms (***-**-6789) or last4
 
-5) "INTERNAL" LOG IS UI-SAFE:
-   - You may output a short "thought_log" suitable for display.
-   - Do NOT include chain-of-thought style step-by-step private reasoning.
-   - Do NOT include any raw PII in thought_log (no emails, phone numbers, addresses, SSN digits).
+5) UI-SAFE THOUGHTS:
+   - Your ui_thought must NOT include raw PII
+   - Keep thoughts brief and human-readable
 
 -------------------------
-AGENTIC BEHAVIOR (MAKE IT FEEL ALIVE)
+DETERMINISTIC TRUST SCORE FORMULA
 -------------------------
-A) NEGOTIATION:
-   - If requester asks for a restricted field, propose a substitute:
-     - SSN -> SSN_LAST4 or SSN_MASKED or "SERVER_ENCRYPTED_SSN_AFTER_KEY_EXCHANGE"
-     - DOB -> DOB_YEAR_ONLY
-     - Address -> CITY_STATE_ONLY
-   - If requester trust is below threshold, downgrade sharing.
+Compute trust_score (0-100) as:
 
-B) CHALLENGE PROTOCOL:
-   - If user trust_score < 0.50 OR critical fields missing:
-     - request additional identifiers (e.g., github, linkedin, secondary phone, selfie check token),
-     - or ask requester for more credentials/attestation.
+score = 0
++ 30 * identity_match_factor
++ 25 * sanctions_factor
++ 15 * document_factor
++ 15 * recency_factor
++ 15 * behavior_factor
 
-C) PROGRESSIVE UPDATES:
-   - If the task will take multiple steps, emit TASK_UPDATE with progress increments and what changed.
+Where:
+- identity_match_factor:
+  - 1.0 = strong match on phone + email + name
+  - 0.7 = phone + partial name match
+  - 0.4 = single weak identifier only
 
--------------------------
-TRUST SCORE & RISK
--------------------------
-Compute a user identity trust score in [0,1] based ONLY on provided context fields:
-- Start at 0.
-- Add weights for verified fields (example weights):
-  - name present: +0.10
-  - phone present: +0.15 (if verified: +0.05 bonus)
-  - email present: +0.15 (if verified: +0.05 bonus)
-  - address present: +0.20
-  - dob present (year-only acceptable): +0.10
-  - government_id_present flag: +0.20
-  - sanctions/pep_clear flag: +0.10
-Clamp to 1.0.
+- sanctions_factor:
+  - 1.0 = no sanctions/PEP hits
+  - 0.0 = any confirmed hit → auto CRITICAL + BLOCKED
 
-Risk band:
-- >= 0.75 => LOW
-- 0.50–0.74 => MEDIUM
-- 0.30–0.49 => HIGH
-- < 0.30 => CRITICAL
+- document_factor:
+  - 1.0 = verified government ID with high confidence
+  - 0.5 = partial document verification
+  - 0.0 = no document checks available
 
-Requester trust:
-- Use context.requester.trust_score if provided (0..1), else assume 0.5.
+- recency_factor:
+  - 1.0 = KYC < 1 year old
+  - 0.7 = 1-3 years old
+  - 0.3 = older than 3 years
 
-SSN release rule (strict):
-- Only allow SSN release instruction if:
-  (a) policy explicitly allows "ssn" AND
-  (b) requester.trust_score >= 0.90 AND
-  (c) requester provided a public_key AND
-  (d) task purpose requires SSN (e.g., FULL_KYC) — if purpose is not FULL_KYC, prefer last4.
+- behavior_factor:
+  - 1.0 = no fraud/chargeback history
+  - 0.5 = minor issues
+  - 0.0 = confirmed fraud → negative penalty
+
+Risk bands (from score):
+- 80-100 → LOW (green)
+- 60-79 → MEDIUM (yellow)
+- 40-59 → HIGH (orange)
+- 0-39 → CRITICAL (red)
+
+Always produce 3-5 "reasons" explaining the score.
 
 -------------------------
 OUTPUT FORMAT (STRICT JSON ONLY)
 -------------------------
-Return JSON with this exact top-level shape:
+Return JSON with this exact structure:
 
 {
-  "internal": {
-    "thought_log": string[],        // 3–7 short lines, UI-safe, no PII
-    "decision_summary": string,     // 1–2 sentences, no PII, no secrets
-    "redactions": {                 // if any fields were withheld
-      "withheld_fields": string[],
-      "reason": string
-    }
+  "ui_thought": string,              // Short, human-readable, for AgentThoughtLog (no PII!)
+  "action": "REQUEST_MORE_DATA" | "RUN_PIPELINE_STEP" | "RETURN_RESULT" | "RETURN_ERROR",
+  "next_status": "INIT" | "HANDSHAKE" | "SUBJECT_IDENTIFICATION" | "RUNNING_CHECKS" | "READY_TO_DECIDE" | "READY_TO_MIGRATE" | "DONE" | "BLOCKED" | "ERROR",
+  "updated_state": {
+    "progress_pct": number,          // 0-100
+    "trust_score": number,           // 0-100
+    "risk_band": "LOW" | "MEDIUM" | "HIGH" | "CRITICAL",
+    "reasons": string[],             // 3-5 bullet points
+    "unlocked_fields": string[],     // fields now available
+    "verified_fields": string[],     // fields verified
+    "protected_fields": string[]     // fields blocked
   },
-  "protocol_message": {
-    "id": string,                   // use context.message_id or synthesize "msg_<ts>"
-    "task_id": string,              // from context.task.task_id
-    "timestamp": string,            // ISO-8601
-    "from_agent": "HUSHH_IDENTITY_ORACLE",
-    "to_agent": string,             // requester name/id
-    "type": "TASK_NEGOTIATION" | "TASK_UPDATE" | "TASK_STATUS" | "TASK_RESULT" | "KEY_EXCHANGE" | "CHALLENGE" | "TASK_COMPLETE" | "TASK_ERROR",
-    "progress": number,             // 0..100 (optional but preferred)
-    "summary": string,              // human-readable, can include non-sensitive values if allowed
+  "a2a_message": {
+    "id": string,
+    "task_id": string,
+    "timestamp": string,             // ISO-8601
+    "sender": "HushhKycAgent",
+    "receiver": string,              // VerifierAgent name
+    "type": "HANDSHAKE" | "KYC_REQUEST" | "KYC_PROGRESS" | "KYC_RESULT" | "MIGRATION_REQUEST" | "MIGRATION_RESULT" | "CHALLENGE" | "ERROR",
     "payload": {
-      "intent": string,
-      "requested_fields": string[],
-      "offered_fields": string[],
-      "verified_fields": string[],
-      "pending_fields": string[],
-      "protected_fields": string[],
-      "user_trust_score": number,
-      "risk_band": "LOW" | "MEDIUM" | "HIGH" | "CRITICAL",
-      "data": object,               // ONLY allowed, non-sensitive fields
-      "sensitive_release_instructions": {
-        "field": "ssn",
-        "mode": "SERVER_ENCRYPT_AES_256_GCM",
-        "public_key_ref": "context.requester.public_key",
-        "deliver_as": "ciphertext_b64+iv_b64+tag_b64",
-        "note": string
+      "status": string,
+      "kyc_status": "VERIFIED" | "PARTIAL_MATCH" | "FAILED" | "REVIEW_REQUIRED" | null,
+      "trust_score": number | null,
+      "risk_band": "LOW" | "MEDIUM" | "HIGH" | "CRITICAL" | null,
+      "allowed_fields_returned": string[],
+      "data": object,                // Only safe, allowed fields
+      "explanation": string[],       // Human-readable reasons
+      "challenge_request": {
+        "required_identifiers": string[],
+        "reason": string
+      } | null,
+      "migration_payload": {
+        "target_schema": object,
+        "data": object,
+        "checksum": string
       } | null
     }
-  },
-  "next": {
-    "expect": "NONE" | "REQUESTER_PUBLIC_KEY" | "REQUESTER_ACCEPT_SUBSTITUTE" | "ADDITIONAL_USER_DATA" | "SERVER_ENCRYPT_AND_ATTACH",
-    "reason": string
   }
 }
 
 Rules:
-- Output must be valid JSON.
-- Do not include fields not in the schema.
-- Do not include null keys unless necessary; prefer omitting.
-- Never output SSN plaintext, encryption keys, or ciphertext.
+- Output must be valid JSON only
+- No markdown, no extra text
+- Never include full SSN or sensitive data in any field
+- ui_thought must not contain PII
 
 -------------------------
-CONTEXT YOU MAY RECEIVE (EXAMPLE KEYS)
+HUMAN-LIKE CONVERSATION STYLE
+-------------------------
+Make your messages feel like a helpful KYC officer:
+
+Phase 0 (Handshake):
+"I can perform KYC verification for this subject. I'll only return [fields] as per our data sharing agreement."
+
+Phase 1 (Identification):
+"I found a potential match in our system. Let me run verification checks."
+OR "I found 2 possible matches. Do you have a secondary identifier like email or date of birth?"
+
+Phase 2 (Checks):
+"Running identity consistency checks... All clear."
+"Checking sanctions and PEP lists... No hits found."
+"Verifying document records... Government ID confirmed."
+
+Phase 3 (Result):
+"KYC verified with LOW risk. Trust score: 87%. Ready to share the summary."
+
+Phase 5 (Migration):
+"I've prepared a migration payload with 12 fields, excluding raw SSN and documents."
+
+-------------------------
+CONTEXT YOU MAY RECEIVE
 -------------------------
 context.task: { task_id, purpose, requested_fields }
-context.requester: { id, name, trust_score, public_key?, signature_valid? }
-context.user: { found, consent: { allowed_fields, tier }, data: {...}, verification: {...} }
-context.state: { phase, last_progress, ... }
+context.requester: { id, name, trust_score, public_key?, jurisdiction }
+context.user: { found, consent, data, verification }
+context.state: { status, progress_pct, last_action }
 
 Now produce the next outbound message for the current turn.
 `;
 
-// Types for the structured output
+// Keep old name as alias for backward compatibility
+export const HUSHH_IDENTITY_ORACLE_SYSTEM_PROMPT = HUSHH_KYC_AGENT_SYSTEM_PROMPT;
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+// A2A Message Types
+export type A2AMessageType = 
+  | 'HANDSHAKE' 
+  | 'KYC_REQUEST' 
+  | 'KYC_PROGRESS' 
+  | 'KYC_RESULT' 
+  | 'MIGRATION_REQUEST' 
+  | 'MIGRATION_RESULT' 
+  | 'CHALLENGE' 
+  | 'ERROR';
+
+// Conversation Status
+export type KycStatus = 
+  | 'INIT' 
+  | 'HANDSHAKE' 
+  | 'SUBJECT_IDENTIFICATION' 
+  | 'RUNNING_CHECKS' 
+  | 'READY_TO_DECIDE' 
+  | 'READY_TO_MIGRATE' 
+  | 'DONE' 
+  | 'BLOCKED' 
+  | 'ERROR';
+
+// Risk Bands
+export type RiskBand = 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
+
+// KYC Decision Status
+export type KycDecisionStatus = 'VERIFIED' | 'PARTIAL_MATCH' | 'FAILED' | 'REVIEW_REQUIRED';
+
+// Agent Actions
+export type AgentAction = 'REQUEST_MORE_DATA' | 'RUN_PIPELINE_STEP' | 'RETURN_RESULT' | 'RETURN_ERROR';
+
+// ============================================================================
+// KYC CONVERSATION STATE (The "Brain")
+// ============================================================================
+
+export interface KycSubject {
+  external_reference_id?: string;
+  name?: string;
+  email?: string;
+  phone?: string;
+  phone_country_code?: string;
+  country?: string;
+  ssn_last4?: string;
+  dob?: string;
+}
+
+export interface KycRequest {
+  purpose: 'kyc_verification' | 'kyc_plus_migration';
+  requested_fields: string[];
+  verifier_agent_id: string;
+  jurisdiction: string;
+}
+
+export interface KycPolicy {
+  consent_scopes: string[];
+  allowed_fields: string[];
+  migration_allowed: boolean;
+}
+
+export interface EvidenceItem {
+  source: string;
+  type: 'identity' | 'sanctions' | 'document' | 'behavior' | 'recency';
+  confidence: number;
+  value: string;
+  timestamp: string;
+}
+
+export interface TrustInfo {
+  score: number;
+  band: RiskBand;
+  reasons: string[];
+}
+
+export interface KycConversationState {
+  // Who is being verified
+  subject: KycSubject;
+
+  // What the external agent wants
+  request: KycRequest;
+
+  // Policy & consent boundaries
+  policy: KycPolicy;
+
+  // Evidence gathered during KYC
+  evidence: EvidenceItem[];
+
+  // Trust & risk
+  trust: TrustInfo;
+
+  // Current progress
+  status: KycStatus;
+  progress_pct: number;
+
+  // Fields tracking
+  unlocked_fields: string[];
+  verified_fields: string[];
+  protected_fields: string[];
+
+  // Messages
+  messages: A2AMessage[];
+}
+
+// ============================================================================
+// A2A MESSAGE SCHEMA
+// ============================================================================
+
+export interface A2AMessagePayload {
+  status?: string;
+  kyc_status?: KycDecisionStatus | null;
+  trust_score?: number | null;
+  risk_band?: RiskBand | null;
+  allowed_fields_returned?: string[];
+  data?: Record<string, unknown>;
+  explanation?: string[];
+  challenge_request?: {
+    required_identifiers: string[];
+    reason: string;
+  } | null;
+  migration_payload?: {
+    target_schema: Record<string, unknown>;
+    data: Record<string, unknown>;
+    checksum: string;
+  } | null;
+}
+
+export interface A2AMessage {
+  id: string;
+  task_id: string;
+  timestamp: string;
+  sender: 'VerifierAgent' | 'HushhKycAgent';
+  receiver: string;
+  type: A2AMessageType;
+  payload: A2AMessagePayload;
+}
+
+// ============================================================================
+// KYC AGENT RESPONSE (From LLM)
+// ============================================================================
+
+export interface KycAgentUpdatedState {
+  progress_pct: number;
+  trust_score: number;
+  risk_band: RiskBand;
+  reasons: string[];
+  unlocked_fields: string[];
+  verified_fields: string[];
+  protected_fields: string[];
+}
+
+export interface KycAgentResponse {
+  ui_thought: string;
+  action: AgentAction;
+  next_status: KycStatus;
+  updated_state: KycAgentUpdatedState;
+  a2a_message: A2AMessage;
+}
+
+// ============================================================================
+// LEGACY TYPES (For backward compatibility)
+// ============================================================================
+
 export interface OracleThoughtLog {
   thought_log: string[];
   decision_summary: string;
@@ -166,33 +404,12 @@ export interface OracleProtocolMessage {
   id: string;
   task_id: string;
   timestamp: string;
-  from_agent: 'HUSHH_IDENTITY_ORACLE';
+  from_agent: 'HUSHH_KYC_AGENT';
   to_agent: string;
-  type: 'TASK_NEGOTIATION' | 'TASK_UPDATE' | 'TASK_STATUS' | 'TASK_RESULT' | 'KEY_EXCHANGE' | 'CHALLENGE' | 'TASK_COMPLETE' | 'TASK_ERROR';
+  type: A2AMessageType;
   progress?: number;
   summary: string;
-  payload: {
-    intent?: string;
-    requested_fields?: string[];
-    offered_fields?: string[];
-    verified_fields?: string[];
-    pending_fields?: string[];
-    protected_fields?: string[];
-    user_trust_score?: number;
-    risk_band?: 'LOW' | 'MEDIUM' | 'HIGH' | 'CRITICAL';
-    data?: Record<string, unknown>;
-    sensitive_release_instructions?: {
-      field: string;
-      mode: string;
-      public_key_ref: string;
-      deliver_as: string;
-      note?: string;
-    } | null;
-    challenge_request?: {
-      required_identifiers: string[];
-      reason: string;
-    };
-  };
+  payload: A2AMessagePayload;
 }
 
 export interface OracleNextAction {
@@ -206,7 +423,47 @@ export interface OracleResponse {
   next: OracleNextAction;
 }
 
-// Helper to build context for the LLM
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Build context for the LLM from conversation state
+ */
+export function buildKycAgentContext(params: {
+  taskId: string;
+  state: KycConversationState;
+  inboundMessage?: A2AMessage;
+}) {
+  return {
+    task: {
+      task_id: params.taskId,
+      purpose: params.state.request.purpose,
+      requested_fields: params.state.request.requested_fields,
+    },
+    requester: {
+      id: params.state.request.verifier_agent_id,
+      jurisdiction: params.state.request.jurisdiction,
+    },
+    user: {
+      found: Object.keys(params.state.subject).length > 0,
+      consent: {
+        allowed_fields: params.state.policy.allowed_fields,
+        scopes: params.state.policy.consent_scopes,
+      },
+      data: params.state.subject,
+    },
+    state: {
+      status: params.state.status,
+      progress_pct: params.state.progress_pct,
+      trust: params.state.trust,
+      evidence_count: params.state.evidence.length,
+    },
+    inbound_message: params.inboundMessage,
+  };
+}
+
+// Legacy alias
 export function buildOracleContext(params: {
   taskId: string;
   purpose: string;
@@ -257,13 +514,14 @@ export function buildOracleContext(params: {
   };
 }
 
-// Parse and validate LLM response
-export function parseOracleResponse(rawResponse: string): OracleResponse | null {
+/**
+ * Parse and validate KYC Agent response from LLM
+ */
+export function parseKycAgentResponse(rawResponse: string): KycAgentResponse | null {
   try {
-    // Try to extract JSON from the response
     let jsonStr = rawResponse.trim();
     
-    // If wrapped in markdown code blocks, extract
+    // Remove markdown code blocks if present
     if (jsonStr.startsWith('```json')) {
       jsonStr = jsonStr.slice(7);
     }
@@ -277,6 +535,35 @@ export function parseOracleResponse(rawResponse: string): OracleResponse | null 
     const parsed = JSON.parse(jsonStr.trim());
     
     // Validate required fields
+    if (!parsed.ui_thought || !parsed.action || !parsed.next_status || !parsed.updated_state || !parsed.a2a_message) {
+      console.error('Missing required fields in KYC Agent response');
+      return null;
+    }
+    
+    return parsed as KycAgentResponse;
+  } catch (error) {
+    console.error('Failed to parse KYC Agent response:', error);
+    return null;
+  }
+}
+
+// Legacy alias
+export function parseOracleResponse(rawResponse: string): OracleResponse | null {
+  try {
+    let jsonStr = rawResponse.trim();
+    
+    if (jsonStr.startsWith('```json')) {
+      jsonStr = jsonStr.slice(7);
+    }
+    if (jsonStr.startsWith('```')) {
+      jsonStr = jsonStr.slice(3);
+    }
+    if (jsonStr.endsWith('```')) {
+      jsonStr = jsonStr.slice(0, -3);
+    }
+    
+    const parsed = JSON.parse(jsonStr.trim());
+    
     if (!parsed.internal || !parsed.protocol_message || !parsed.next) {
       console.error('Missing required top-level fields in Oracle response');
       return null;
@@ -287,4 +574,138 @@ export function parseOracleResponse(rawResponse: string): OracleResponse | null 
     console.error('Failed to parse Oracle response:', error);
     return null;
   }
+}
+
+/**
+ * Calculate trust score using deterministic formula
+ */
+export function calculateTrustScore(evidence: EvidenceItem[]): TrustInfo {
+  let identityScore = 0;
+  let sanctionsScore = 1.0; // Default to clear
+  let documentScore = 0;
+  let recencyScore = 0.7; // Default to medium recency
+  let behaviorScore = 1.0; // Default to clean
+  
+  const reasons: string[] = [];
+  
+  // Calculate identity match factor
+  const identityEvidence = evidence.filter(e => e.type === 'identity');
+  if (identityEvidence.length >= 3) {
+    identityScore = 1.0;
+    reasons.push('Identity matched on multiple independent sources.');
+  } else if (identityEvidence.length >= 2) {
+    identityScore = 0.7;
+    reasons.push('Identity partially matched on available identifiers.');
+  } else if (identityEvidence.length >= 1) {
+    identityScore = 0.4;
+    reasons.push('Limited identity verification available.');
+  } else {
+    reasons.push('No identity verification performed.');
+  }
+  
+  // Check sanctions
+  const sanctionsEvidence = evidence.filter(e => e.type === 'sanctions');
+  if (sanctionsEvidence.some(e => e.confidence < 0.5)) {
+    sanctionsScore = 0;
+    reasons.push('⚠️ Potential sanctions/PEP match detected.');
+  } else if (sanctionsEvidence.length > 0) {
+    reasons.push('No sanctions/PEP hits in major watchlists.');
+  }
+  
+  // Check documents
+  const documentEvidence = evidence.filter(e => e.type === 'document');
+  if (documentEvidence.some(e => e.confidence >= 0.9)) {
+    documentScore = 1.0;
+    reasons.push('Government ID verified with high confidence.');
+  } else if (documentEvidence.length > 0) {
+    documentScore = 0.5;
+    reasons.push('Partial document verification available.');
+  }
+  
+  // Check recency
+  const recencyEvidence = evidence.filter(e => e.type === 'recency');
+  if (recencyEvidence.some(e => e.confidence >= 0.9)) {
+    recencyScore = 1.0;
+    reasons.push('KYC data refreshed within last 12 months.');
+  } else if (recencyEvidence.some(e => e.confidence >= 0.5)) {
+    recencyScore = 0.7;
+    reasons.push('KYC data is 1-3 years old.');
+  } else {
+    recencyScore = 0.3;
+    reasons.push('KYC data may be outdated.');
+  }
+  
+  // Check behavior
+  const behaviorEvidence = evidence.filter(e => e.type === 'behavior');
+  if (behaviorEvidence.some(e => e.confidence < 0.3)) {
+    behaviorScore = 0;
+    reasons.push('⚠️ Fraud flags detected in history.');
+  } else if (behaviorEvidence.length > 0) {
+    reasons.push('No historical fraud or chargeback issues.');
+  }
+  
+  // Apply formula
+  const score = Math.round(
+    30 * identityScore +
+    25 * sanctionsScore +
+    15 * documentScore +
+    15 * recencyScore +
+    15 * behaviorScore
+  );
+  
+  // Determine risk band
+  let band: RiskBand;
+  if (score >= 80) {
+    band = 'LOW';
+  } else if (score >= 60) {
+    band = 'MEDIUM';
+  } else if (score >= 40) {
+    band = 'HIGH';
+  } else {
+    band = 'CRITICAL';
+  }
+  
+  return {
+    score: Math.min(100, Math.max(0, score)),
+    band,
+    reasons: reasons.slice(0, 5),
+  };
+}
+
+/**
+ * Create initial KYC conversation state
+ */
+export function createInitialKycState(params: {
+  verifierAgentId: string;
+  jurisdiction: string;
+  purpose: 'kyc_verification' | 'kyc_plus_migration';
+  requestedFields: string[];
+  subject: KycSubject;
+}): KycConversationState {
+  return {
+    subject: params.subject,
+    request: {
+      purpose: params.purpose,
+      requested_fields: params.requestedFields,
+      verifier_agent_id: params.verifierAgentId,
+      jurisdiction: params.jurisdiction,
+    },
+    policy: {
+      consent_scopes: ['kyc'],
+      allowed_fields: ['name', 'phone', 'email', 'address_city', 'kyc_status', 'risk_band'],
+      migration_allowed: params.purpose === 'kyc_plus_migration',
+    },
+    evidence: [],
+    trust: {
+      score: 0,
+      band: 'CRITICAL',
+      reasons: [],
+    },
+    status: 'INIT',
+    progress_pct: 0,
+    unlocked_fields: [],
+    verified_fields: [],
+    protected_fields: ['ssn', 'ssn_full', 'document_number', 'biometric'],
+    messages: [],
+  };
 }

--- a/supabase/functions/kyc-agent-agentic/index.ts
+++ b/supabase/functions/kyc-agent-agentic/index.ts
@@ -12,10 +12,17 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.39.0';
 import { 
+  HUSHH_KYC_AGENT_SYSTEM_PROMPT,
   HUSHH_IDENTITY_ORACLE_SYSTEM_PROMPT, 
   buildOracleContext, 
   parseOracleResponse,
-  type OracleResponse
+  parseKycAgentResponse,
+  calculateTrustScore,
+  createInitialKycState,
+  type OracleResponse,
+  type KycAgentResponse,
+  type KycConversationState,
+  type EvidenceItem,
 } from '../kyc-agent-a2a-protocol/prompts.ts';
 
 // CORS Headers


### PR DESCRIPTION
… Trust Scoring

Phase 2 Implementation:
- Renamed 'Hushh Identity Oracle' → 'Hushh KYC Agent' across all components
- Added comprehensive KycConversationState type (the 'brain' shared across turns)
- Implemented 6-phase state machine (INIT → HANDSHAKE → SUBJECT_IDENTIFICATION → RUNNING_CHECKS → READY_TO_DECIDE → READY_TO_MIGRATE → DONE)
- Added deterministic trust scoring formula: 30*identity + 25*sanctions + 15*document + 15*recency + 15*behavior
- Added A2AMessage schema for protocol communication
- Updated system prompt with new JSON output contract
- Data minimization policies (never output full SSN, prefer masked values)

Files Updated:
- supabase/functions/kyc-agent-a2a-protocol/prompts.ts (complete rewrite)
- supabase/functions/kyc-agent-agentic/index.ts (import updates)
- src/components/a2aPlayground/MissionControlLayout.tsx (naming)
- src/components/a2aPlayground/AgentThoughtLog.tsx (naming)
- src/components/a2aPlayground/A2AConversationScreen.tsx (naming)

Build: ✅ Successful