### PR TITLE
refactor: Update all bills to Black & White A4 official format

### DIFF
--- a/src/components/receipt/AICourseBillCard.tsx
+++ b/src/components/receipt/AICourseBillCard.tsx
@@ -7,40 +7,32 @@ import {
   Text,
   VStack,
   HStack,
-  Divider,
   Table,
-  Thead,
   Tbody,
   Tr,
-  Th,
   Td,
-  Badge,
+  Th,
+  Thead,
 } from '@chakra-ui/react';
-
-export interface CourseItem {
-  description: string;
-  quantity: number;
-  unitPrice: number;
-  amount: number;
-}
 
 export interface AICourseBillData {
   customerName: string;
   invoiceDate: Date;
   invoiceNumber: string;
   courseName: string;
-  courseProvider: string;
+  courseDescription: string;
   courseDuration: string;
-  items: CourseItem[];
-  subtotal: number;
+  courseFee: number;
   cgst: number;
   sgst: number;
   totalAmount: number;
+  companyName: string;
+  companyAddress: string;
+  gstin: string;
   customerAddress: string;
-  corporateAddress: string;
-  customerPhone: string;
-  paymentStatus: 'PAID' | 'PENDING' | 'PARTIAL';
-  paymentMode?: string;
+  customerEmail: string;
+  customerContact: string;
+  enrollmentId: string;
 }
 
 interface AICourseBillCardProps {
@@ -48,204 +40,256 @@ interface AICourseBillCardProps {
 }
 
 /**
- * AI Course Bill Card - Online Learning Platform Style
+ * AI Course Bill Card - Official Black & White A4 Format
+ * Training/Course Invoice Style
  */
 const AICourseBillCard = forwardRef<HTMLDivElement, AICourseBillCardProps>(
   ({ data }, ref) => {
     const formatDate = (date: Date): string => {
       const day = date.getDate().toString().padStart(2, '0');
-      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      const month = months[date.getMonth()];
+      const month = (date.getMonth() + 1).toString().padStart(2, '0');
       const year = date.getFullYear();
-      return `${day} ${month} ${year}`;
+      return `${day}/${month}/${year}`;
     };
 
     const formatCurrency = (amount: number): string => {
-      return new Intl.NumberFormat('en-IN', {
-        style: 'currency',
-        currency: 'INR',
-        minimumFractionDigits: 2,
-      }).format(amount);
-    };
-
-    const getPaymentBadgeColor = () => {
-      switch (data.paymentStatus) {
-        case 'PAID': return 'green';
-        case 'PENDING': return 'red';
-        case 'PARTIAL': return 'orange';
-        default: return 'gray';
-      }
+      return `₹${amount.toFixed(2)}`;
     };
 
     return (
       <Box
         ref={ref}
         bg="white"
-        borderRadius="8px"
-        overflow="hidden"
-        maxW="550px"
-        w="100%"
-        fontFamily="'Inter', -apple-system, BlinkMacSystemFont, sans-serif"
-        border="1px solid"
-        borderColor="gray.200"
-        p={0}
+        w="210mm"
+        minH="297mm"
+        fontFamily="'Times New Roman', Times, serif"
+        border="1px solid black"
+        p="15mm"
+        color="black"
+        sx={{
+          '@media print': {
+            width: '210mm',
+            minHeight: '297mm',
+          },
+        }}
       >
-        {/* Header - Modern Tech Style */}
-        <Box 
-          bgGradient="linear(to-r, #7C3AED, #A855F7)" 
-          px={6} 
-          py={5}
-        >
-          <HStack justify="space-between" align="flex-start">
+        {/* Header */}
+        <Box borderBottom="2px solid black" pb={4} mb={4}>
+          <Flex justify="space-between" align="flex-start">
             <VStack align="flex-start" spacing={1}>
-              <Text fontSize="22px" fontWeight="700" color="white" letterSpacing="0.5px">
-                🤖 AI Academy
+              <Text fontSize="26px" fontWeight="bold" letterSpacing="1px">
+                {data.companyName}
               </Text>
-              <Text fontSize="10px" color="whiteAlpha.800">
-                Agent-to-Agent (A2A) Protocol Training
-              </Text>
+              <Text fontSize="12px">AI & Technology Training Institute</Text>
+              <Text fontSize="11px">{data.companyAddress}</Text>
+              <Text fontSize="11px">GSTIN: {data.gstin}</Text>
             </VStack>
             <VStack align="flex-end" spacing={1}>
-              <Text fontSize="18px" fontWeight="600" color="white">
-                TAX INVOICE
-              </Text>
-              <Badge colorScheme={getPaymentBadgeColor()} fontSize="10px" px={2}>
-                {data.paymentStatus}
-              </Badge>
+              <Box border="2px solid black" px={4} py={2}>
+                <Text fontSize="16px" fontWeight="bold">TAX INVOICE</Text>
+              </Box>
+              <Text fontSize="11px" mt={2}>Invoice No: {data.invoiceNumber}</Text>
+              <Text fontSize="11px">Date: {formatDate(data.invoiceDate)}</Text>
             </VStack>
-          </HStack>
+          </Flex>
         </Box>
 
-        {/* Invoice Details */}
-        <Box px={6} py={4} bg="purple.50" borderBottom="1px solid" borderColor="gray.200">
-          <HStack justify="space-between" align="flex-start">
-            <VStack align="flex-start" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">INVOICE NUMBER</Text>
-              <Text fontSize="14px" color="gray.800" fontWeight="600">{data.invoiceNumber}</Text>
-            </VStack>
-            <VStack align="flex-end" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">INVOICE DATE</Text>
-              <Text fontSize="14px" color="gray.800" fontWeight="600">{formatDate(data.invoiceDate)}</Text>
-            </VStack>
-          </HStack>
-        </Box>
+        {/* Student / Billing Details */}
+        <HStack justify="space-between" mb={6} spacing={8}>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">BILL TO (STUDENT DETAILS)</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="35%">Name:</Td>
+                  <Td p={1} fontSize="11px">{data.customerName}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Enrollment ID:</Td>
+                  <Td p={1} fontSize="11px">{data.enrollmentId}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" verticalAlign="top">Address:</Td>
+                  <Td p={1} fontSize="11px">{data.customerAddress}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Email:</Td>
+                  <Td p={1} fontSize="11px">{data.customerEmail}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Contact:</Td>
+                  <Td p={1} fontSize="11px">{data.customerContact}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">COURSE DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="35%">Course:</Td>
+                  <Td p={1} fontSize="11px">{data.courseName}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" verticalAlign="top">Description:</Td>
+                  <Td p={1} fontSize="11px">{data.courseDescription}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Duration:</Td>
+                  <Td p={1} fontSize="11px">{data.courseDuration}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Mode:</Td>
+                  <Td p={1} fontSize="11px">Online + Live Sessions</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+        </HStack>
 
-        {/* Bill To Section */}
-        <Box px={6} py={4} borderBottom="1px solid" borderColor="gray.200">
-          <VStack align="flex-start" spacing={2}>
-            <Text fontSize="11px" color="purple.600" fontWeight="600" textTransform="uppercase">
-              BILLED TO
-            </Text>
-            <Box>
-              <Text fontSize="14px" color="gray.800" fontWeight="600">{data.customerName}</Text>
-              <Text fontSize="11px" color="gray.600" mt={1} lineHeight="1.6">
-                {data.customerAddress}
-              </Text>
-              <Text fontSize="11px" color="gray.600" mt={2} lineHeight="1.6">
-                <Text as="span" fontWeight="500">Corporate:</Text> {data.corporateAddress}
-              </Text>
-              <Text fontSize="11px" color="gray.600" mt={1}>
-                Contact: {data.customerPhone}
-              </Text>
-            </Box>
-          </VStack>
-        </Box>
-
-        {/* Course Details */}
-        <Box px={6} py={4} bg="purple.50" borderBottom="1px solid" borderColor="gray.200">
-          <Text fontSize="11px" color="purple.600" fontWeight="600" textTransform="uppercase" mb={2}>
-            COURSE DETAILS
-          </Text>
-          <VStack align="flex-start" spacing={1}>
-            <HStack>
-              <Text fontSize="12px" color="gray.600" w="100px">Course:</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{data.courseName}</Text>
-            </HStack>
-            <HStack>
-              <Text fontSize="12px" color="gray.600" w="100px">Provider:</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{data.courseProvider}</Text>
-            </HStack>
-            <HStack>
-              <Text fontSize="12px" color="gray.600" w="100px">Duration:</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{data.courseDuration}</Text>
-            </HStack>
-          </VStack>
-        </Box>
-
-        {/* Items Table */}
-        <Box px={4} py={4}>
-          <Table variant="simple" size="sm">
+        {/* Service Details */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">SERVICE DETAILS</Text>
+          <Table variant="simple" size="sm" border="1px solid black">
             <Thead>
               <Tr bg="gray.100">
-                <Th fontSize="10px" color="gray.600" py={3} borderColor="gray.200">DESCRIPTION</Th>
-                <Th fontSize="10px" color="gray.600" py={3} textAlign="center" borderColor="gray.200">QTY</Th>
-                <Th fontSize="10px" color="gray.600" py={3} textAlign="right" borderColor="gray.200">UNIT PRICE</Th>
-                <Th fontSize="10px" color="gray.600" py={3} textAlign="right" borderColor="gray.200">AMOUNT</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>S.No.</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>Description</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>HSN/SAC</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="center">Qty</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Rate (₹)</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Amount (₹)</Th>
               </Tr>
             </Thead>
             <Tbody>
-              {data.items.map((item, index) => (
-                <Tr key={index}>
-                  <Td fontSize="12px" color="gray.800" py={3} borderColor="gray.100">{item.description}</Td>
-                  <Td fontSize="12px" color="gray.800" py={3} textAlign="center" borderColor="gray.100">{item.quantity}</Td>
-                  <Td fontSize="12px" color="gray.800" py={3} textAlign="right" borderColor="gray.100">{formatCurrency(item.unitPrice)}</Td>
-                  <Td fontSize="12px" color="gray.800" py={3} textAlign="right" fontWeight="500" borderColor="gray.100">{formatCurrency(item.amount)}</Td>
-                </Tr>
-              ))}
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>1</Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>
+                  {data.courseName}<br/>
+                  <Text fontSize="10px" color="gray.600">{data.courseDescription}</Text>
+                  <Text fontSize="10px" color="gray.600">Duration: {data.courseDuration}</Text>
+                  <Text fontSize="10px" color="gray.600">Includes: Video Lectures, Assignments, Certificate</Text>
+                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>999293</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="center">1</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.courseFee.toFixed(2)}</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.courseFee.toFixed(2)}</Td>
+              </Tr>
             </Tbody>
           </Table>
         </Box>
 
-        {/* Totals Section */}
-        <Box px={6} py={4} borderTop="1px solid" borderColor="gray.200">
-          <VStack align="stretch" spacing={2}>
-            <HStack justify="space-between">
-              <Text fontSize="12px" color="gray.600">Subtotal</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{formatCurrency(data.subtotal)}</Text>
-            </HStack>
-            <HStack justify="space-between">
-              <Text fontSize="11px" color="gray.500">CGST @ 9%</Text>
-              <Text fontSize="11px" color="gray.600">{formatCurrency(data.cgst)}</Text>
-            </HStack>
-            <HStack justify="space-between">
-              <Text fontSize="11px" color="gray.500">SGST @ 9%</Text>
-              <Text fontSize="11px" color="gray.600">{formatCurrency(data.sgst)}</Text>
-            </HStack>
-            
-            <Divider my={1} />
-            
-            <HStack justify="space-between">
-              <Text fontSize="16px" color="gray.800" fontWeight="700">TOTAL AMOUNT</Text>
-              <Text fontSize="18px" color="purple.700" fontWeight="700">{formatCurrency(data.totalAmount)}</Text>
-            </HStack>
+        {/* Tax & Total */}
+        <Flex justify="flex-end" mb={6}>
+          <Table variant="simple" size="sm" border="1px solid black" maxW="400px">
+            <Tbody>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>Course Fee (Taxable)</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.courseFee.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>CGST @ 9%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.cgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>SGST @ 9%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.sgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr bg="gray.100">
+                <Td border="1px solid black" fontSize="12px" p={2} fontWeight="bold">TOTAL AMOUNT</Td>
+                <Td border="1px solid black" fontSize="12px" p={2} textAlign="right" fontWeight="bold">{formatCurrency(data.totalAmount)}</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Flex>
 
-            {data.paymentMode && (
-              <HStack justify="space-between" mt={1}>
-                <Text fontSize="11px" color="gray.500">Payment Mode</Text>
-                <Text fontSize="11px" color="gray.700" fontWeight="500">{data.paymentMode}</Text>
-              </HStack>
-            )}
-          </VStack>
+        {/* Amount in Words */}
+        <Box mb={6} p={3} border="1px solid black">
+          <Text fontSize="11px">
+            <Text as="span" fontWeight="bold">Amount in Words: </Text>
+            Rupees {numberToWords(Math.floor(data.totalAmount))} Only
+          </Text>
+        </Box>
+
+        {/* Bank Details */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">BANK DETAILS FOR PAYMENT</Text>
+          <Table variant="unstyled" size="sm" maxW="400px">
+            <Tbody>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold" w="35%">Bank Name:</Td>
+                <Td p={1} fontSize="11px">HDFC Bank</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">Account Name:</Td>
+                <Td p={1} fontSize="11px">{data.companyName}</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">Account No:</Td>
+                <Td p={1} fontSize="11px">50100XXXXXXXX</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">IFSC Code:</Td>
+                <Td p={1} fontSize="11px">HDFC0001234</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Box>
+
+        {/* Course Access Info */}
+        <Box mb={6} p={3} border="1px solid black" bg="gray.50">
+          <Text fontSize="11px" fontWeight="bold" mb={2}>COURSE ACCESS INFORMATION</Text>
+          <Text fontSize="10px">• Login credentials will be sent to registered email within 24 hours</Text>
+          <Text fontSize="10px">• Access to course portal: https://academy.hushh.ai</Text>
+          <Text fontSize="10px">• Course materials are accessible for 12 months from enrollment date</Text>
+          <Text fontSize="10px">• Certificate will be issued upon successful completion</Text>
+        </Box>
+
+        {/* Terms */}
+        <Box mb={6}>
+          <Text fontSize="10px" fontWeight="bold" mb={1}>Terms & Conditions:</Text>
+          <Text fontSize="9px">• Course fee is non-refundable once access is granted</Text>
+          <Text fontSize="9px">• Course materials are for personal use only and cannot be shared</Text>
+          <Text fontSize="9px">• Subject to Pune Jurisdiction</Text>
         </Box>
 
         {/* Footer */}
-        <Box px={6} py={4} bg="gray.50" borderTop="1px solid" borderColor="gray.200">
-          <VStack spacing={2}>
-            <Text fontSize="10px" color="gray.500" textAlign="center">
-              GSTIN: 27AABCA1234F1ZP | PAN: AABCA1234F
-            </Text>
-            <Text fontSize="10px" color="gray.500" textAlign="center">
-              AI Academy | Hushh.ai, 1021 5th St W, Kirkland, WA 98033
-            </Text>
-            <Text fontSize="9px" color="gray.400" textAlign="center" mt={1}>
-              This is a computer generated invoice and does not require physical signature
-            </Text>
-          </VStack>
+        <Box borderTop="1px solid black" pt={4} mt="auto">
+          <Flex justify="space-between" align="flex-end">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="10px">Support: support@hushhacademy.ai</Text>
+              <Text fontSize="10px">Contact: +91 8004482372</Text>
+              <Text fontSize="10px">Website: www.hushhacademy.ai</Text>
+            </VStack>
+            <VStack align="flex-end" spacing={1}>
+              <Text fontSize="10px" mb={8}>For {data.companyName}</Text>
+              <Text fontSize="10px" fontStyle="italic">Authorized Signatory</Text>
+            </VStack>
+          </Flex>
+          <Text fontSize="9px" textAlign="center" mt={4} color="gray.600">
+            This is a computer generated invoice and does not require physical signature.
+          </Text>
         </Box>
       </Box>
     );
   }
 );
+
+// Helper function to convert number to words
+function numberToWords(num: number): string {
+  const ones = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten',
+    'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+  const tens = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+  if (num === 0) return 'Zero';
+  if (num < 20) return ones[num];
+  if (num < 100) return tens[Math.floor(num / 10)] + (num % 10 ? ' ' + ones[num % 10] : '');
+  if (num < 1000) return ones[Math.floor(num / 100)] + ' Hundred' + (num % 100 ? ' ' + numberToWords(num % 100) : '');
+  if (num < 100000) return numberToWords(Math.floor(num / 1000)) + ' Thousand' + (num % 1000 ? ' ' + numberToWords(num % 1000) : '');
+  if (num < 10000000) return numberToWords(Math.floor(num / 100000)) + ' Lakh' + (num % 100000 ? ' ' + numberToWords(num % 100000) : '');
+  return numberToWords(Math.floor(num / 10000000)) + ' Crore' + (num % 10000000 ? ' ' + numberToWords(num % 10000000) : '');
+}
 
 AICourseBillCard.displayName = 'AICourseBillCard';
 

--- a/src/components/receipt/ElectricityBillCard.tsx
+++ b/src/components/receipt/ElectricityBillCard.tsx
@@ -7,11 +7,12 @@ import {
   Text,
   VStack,
   HStack,
-  Divider,
   Table,
   Tbody,
   Tr,
   Td,
+  Th,
+  Thead,
 } from '@chakra-ui/react';
 
 export interface ElectricityBillData {
@@ -20,16 +21,17 @@ export interface ElectricityBillData {
   billNumber: string;
   consumerNumber: string;
   meterNumber: string;
+  connectionType: string;
+  billingPeriod: string;
   unitsConsumed: number;
   ratePerUnit: number;
-  energyCharge: number;
-  fixedCharge: number;
-  fuelAdjustment: number;
+  energyCharges: number;
+  fixedCharges: number;
   electricityDuty: number;
   totalAmount: number;
   dueDate: Date;
-  connectionAddress: string;
-  billingPeriod: string;
+  customerAddress: string;
+  sanctionedLoad: string;
 }
 
 interface ElectricityBillCardProps {
@@ -37,7 +39,8 @@ interface ElectricityBillCardProps {
 }
 
 /**
- * Electricity Bill Card - MSEDCL Style
+ * Electricity Bill Card - Official Black & White A4 Format
+ * MSEDCL Style
  */
 const ElectricityBillCard = forwardRef<HTMLDivElement, ElectricityBillCardProps>(
   ({ data }, ref) => {
@@ -56,177 +59,201 @@ const ElectricityBillCard = forwardRef<HTMLDivElement, ElectricityBillCardProps>
       <Box
         ref={ref}
         bg="white"
-        borderRadius="8px"
-        overflow="hidden"
-        maxW="450px"
-        w="100%"
-        fontFamily="'Inter', -apple-system, BlinkMacSystemFont, sans-serif"
-        border="1px solid"
-        borderColor="gray.200"
-        p={0}
+        w="210mm"
+        minH="297mm"
+        fontFamily="'Times New Roman', Times, serif"
+        border="1px solid black"
+        p="15mm"
+        color="black"
+        sx={{
+          '@media print': {
+            width: '210mm',
+            minHeight: '297mm',
+          },
+        }}
       >
-        {/* Header - MSEDCL Style */}
-        <Box bg="#1565C0" px={5} py={4}>
-          <HStack justify="space-between" align="center">
-            <VStack align="flex-start" spacing={0}>
-              <Text fontSize="20px" fontWeight="700" color="white" letterSpacing="1px">
+        {/* Header */}
+        <Box borderBottom="2px solid black" pb={4} mb={4}>
+          <Flex justify="space-between" align="flex-start">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="24px" fontWeight="bold" letterSpacing="1px">
                 MSEDCL
               </Text>
-              <Text fontSize="9px" color="white" opacity={0.9}>
+              <Text fontSize="14px" fontWeight="bold">
                 Maharashtra State Electricity Distribution Co. Ltd.
               </Text>
-            </VStack>
-            <VStack align="flex-end" spacing={0}>
-              <Text fontSize="11px" color="white" fontWeight="500">
-                ELECTRICITY BILL
-              </Text>
-              <Text fontSize="9px" color="white" opacity={0.8}>
-                LT Consumer
-              </Text>
-            </VStack>
-          </HStack>
-        </Box>
-
-        {/* Bill Info Section */}
-        <Box px={5} py={4} bg="blue.50">
-          <HStack justify="space-between" align="flex-start">
-            <VStack align="flex-start" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">
-                BILL NUMBER
-              </Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="600">
-                {data.billNumber}
-              </Text>
-            </VStack>
-            <VStack align="center" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">
-                CONSUMER NO
-              </Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="600">
-                {data.consumerNumber}
-              </Text>
+              <Text fontSize="11px">Prakashganga, Plot No. G-9, Anant Kanekar Marg</Text>
+              <Text fontSize="11px">Bandra (East), Mumbai - 400051</Text>
+              <Text fontSize="11px">CIN: U40109MH2005SGC153645</Text>
             </VStack>
             <VStack align="flex-end" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">
-                BILL DATE
-              </Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="600">
-                {formatDate(data.billDate)}
-              </Text>
+              <Box border="2px solid black" px={4} py={2}>
+                <Text fontSize="16px" fontWeight="bold">ELECTRICITY BILL</Text>
+              </Box>
+              <Text fontSize="11px" mt={2}>Bill No: {data.billNumber}</Text>
+              <Text fontSize="11px">Bill Date: {formatDate(data.billDate)}</Text>
             </VStack>
-          </HStack>
+          </Flex>
         </Box>
 
-        <Divider />
+        {/* Consumer Details */}
+        <HStack justify="space-between" mb={6} spacing={8}>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">CONSUMER DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="45%">Consumer No:</Td>
+                  <Td p={1} fontSize="11px">{data.consumerNumber}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Name:</Td>
+                  <Td p={1} fontSize="11px">{data.customerName}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" verticalAlign="top">Address:</Td>
+                  <Td p={1} fontSize="11px">{data.customerAddress}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">CONNECTION DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="45%">Meter No:</Td>
+                  <Td p={1} fontSize="11px">{data.meterNumber}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Connection Type:</Td>
+                  <Td p={1} fontSize="11px">{data.connectionType}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Sanctioned Load:</Td>
+                  <Td p={1} fontSize="11px">{data.sanctionedLoad}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Billing Period:</Td>
+                  <Td p={1} fontSize="11px">{data.billingPeriod}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+        </HStack>
 
-        {/* Customer Details */}
-        <Box px={5} py={4}>
-          <Text fontSize="10px" color="gray.500" fontWeight="500" mb={2}>
-            CONSUMER DETAILS
-          </Text>
-          <VStack align="flex-start" spacing={1}>
-            <Text fontSize="13px" color="gray.800" fontWeight="600">
-              {data.customerName}
-            </Text>
-            <Text fontSize="11px" color="gray.600" lineHeight="1.4">
-              {data.connectionAddress}
-            </Text>
-            <HStack mt={1}>
-              <Text fontSize="10px" color="gray.500">Meter No:</Text>
-              <Text fontSize="10px" color="gray.700" fontWeight="500">{data.meterNumber}</Text>
-            </HStack>
-          </VStack>
-        </Box>
-
-        <Divider />
-
-        {/* Consumption Details */}
-        <Box px={5} py={4} bg="gray.50">
-          <HStack justify="space-between">
-            <VStack align="flex-start" spacing={0}>
-              <Text fontSize="10px" color="gray.500">BILLING PERIOD</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="600">{data.billingPeriod}</Text>
-            </VStack>
-            <VStack align="flex-end" spacing={0}>
-              <Text fontSize="10px" color="gray.500">UNITS CONSUMED</Text>
-              <Text fontSize="16px" color="blue.700" fontWeight="700">{data.unitsConsumed} kWh</Text>
-            </VStack>
-          </HStack>
-        </Box>
-
-        <Divider />
-
-        {/* Charges Breakdown */}
-        <Box px={5} py={4}>
-          <Text fontSize="10px" color="gray.500" fontWeight="500" mb={3}>
-            CHARGES BREAKDOWN
-          </Text>
-          <Table variant="unstyled" size="sm">
+        {/* Meter Reading */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">CONSUMPTION DETAILS</Text>
+          <Table variant="simple" size="sm" border="1px solid black" maxW="500px">
+            <Thead>
+              <Tr bg="gray.100">
+                <Th border="1px solid black" fontSize="10px" p={2}>Description</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Units/Rate</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Amount (₹)</Th>
+              </Tr>
+            </Thead>
             <Tbody>
               <Tr>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.700">
-                  Energy Charge ({data.unitsConsumed} units × ₹{data.ratePerUnit})
-                </Td>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.energyCharge)}
-                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>Units Consumed</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.unitsConsumed} kWh</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">-</Td>
               </Tr>
               <Tr>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.700">
-                  Fixed Charge
-                </Td>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.fixedCharge)}
-                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>Energy Charges @ ₹{data.ratePerUnit}/unit</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.unitsConsumed} x {data.ratePerUnit}</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.energyCharges.toFixed(2)}</Td>
               </Tr>
               <Tr>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.700">
-                  Fuel Adjustment Charge
-                </Td>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.fuelAdjustment)}
-                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>Fixed Charges</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">-</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.fixedCharges.toFixed(2)}</Td>
               </Tr>
               <Tr>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.700">
-                  Electricity Duty
-                </Td>
-                <Td px={0} py={1.5} fontSize="12px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.electricityDuty)}
-                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>Electricity Duty</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">-</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.electricityDuty.toFixed(2)}</Td>
+              </Tr>
+              <Tr bg="gray.100">
+                <Td border="1px solid black" fontSize="12px" p={2} fontWeight="bold" colSpan={2}>TOTAL AMOUNT PAYABLE</Td>
+                <Td border="1px solid black" fontSize="12px" p={2} textAlign="right" fontWeight="bold">{formatCurrency(data.totalAmount)}</Td>
               </Tr>
             </Tbody>
           </Table>
         </Box>
 
-        {/* Total Amount */}
-        <Box px={5} py={4} bg="#1565C0">
-          <Flex justify="space-between" align="center">
-            <Text fontSize="14px" color="white" fontWeight="600">
-              Total Amount Payable
-            </Text>
-            <Text fontSize="20px" color="white" fontWeight="700">
-              {formatCurrency(data.totalAmount)}
-            </Text>
-          </Flex>
-          <Text fontSize="10px" color="white" opacity={0.85} mt={1}>
-            Due Date: {formatDate(data.dueDate)}
+        {/* Amount in Words */}
+        <Box mb={6} p={3} border="1px solid black">
+          <Text fontSize="11px">
+            <Text as="span" fontWeight="bold">Amount in Words: </Text>
+            Rupees {numberToWords(Math.floor(data.totalAmount))} Only
           </Text>
         </Box>
 
+        {/* Due Date */}
+        <Box mb={6} p={3} border="2px solid black" maxW="300px">
+          <HStack justify="space-between">
+            <Text fontSize="12px" fontWeight="bold">Due Date:</Text>
+            <Text fontSize="12px" fontWeight="bold">{formatDate(data.dueDate)}</Text>
+          </HStack>
+          <Text fontSize="10px" mt={1} color="gray.600">Late payment surcharge applicable after due date</Text>
+        </Box>
+
+        {/* Payment Options */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">PAYMENT OPTIONS</Text>
+          <Text fontSize="11px" mb={1}>• Online: www.mahadiscom.in</Text>
+          <Text fontSize="11px" mb={1}>• MSEDCL Mobile App</Text>
+          <Text fontSize="11px" mb={1}>• MSEDCL Cash Collection Centers</Text>
+          <Text fontSize="11px" mb={1}>• Authorized Banks and Payment Gateways</Text>
+          <Text fontSize="11px">• UPI / Net Banking / Credit-Debit Card</Text>
+        </Box>
+
+        {/* Important Notes */}
+        <Box mb={6}>
+          <Text fontSize="10px" fontWeight="bold" mb={1}>Important Notes:</Text>
+          <Text fontSize="9px">• Please pay before due date to avoid disconnection</Text>
+          <Text fontSize="9px">• Keep this bill for reference</Text>
+          <Text fontSize="9px">• For complaints: 1912 (Toll Free)</Text>
+          <Text fontSize="9px">• Subject to Maharashtra Electricity Regulatory Commission guidelines</Text>
+        </Box>
+
         {/* Footer */}
-        <Box px={5} py={3} bg="gray.50">
-          <Text fontSize="9px" color="gray.500" textAlign="center">
-            Pay online at www.mahadiscom.in | Toll Free: 1800-233-3435
-          </Text>
-          <Text fontSize="8px" color="gray.400" textAlign="center" mt={1}>
-            This is a computer generated bill and does not require signature
+        <Box borderTop="1px solid black" pt={4} mt="auto">
+          <Flex justify="space-between" align="flex-end">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="10px">24x7 Helpline: 1912 (Toll Free)</Text>
+              <Text fontSize="10px">Email: customercare@mahadiscom.in</Text>
+              <Text fontSize="10px">Website: www.mahadiscom.in</Text>
+            </VStack>
+            <VStack align="flex-end" spacing={1}>
+              <Text fontSize="10px" mb={8}>For MSEDCL</Text>
+              <Text fontSize="10px" fontStyle="italic">Authorized Signatory</Text>
+            </VStack>
+          </Flex>
+          <Text fontSize="9px" textAlign="center" mt={4} color="gray.600">
+            This is a computer generated bill and does not require physical signature.
           </Text>
         </Box>
       </Box>
     );
   }
 );
+
+// Helper function to convert number to words
+function numberToWords(num: number): string {
+  const ones = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten',
+    'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+  const tens = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+  if (num === 0) return 'Zero';
+  if (num < 20) return ones[num];
+  if (num < 100) return tens[Math.floor(num / 10)] + (num % 10 ? ' ' + ones[num % 10] : '');
+  if (num < 1000) return ones[Math.floor(num / 100)] + ' Hundred' + (num % 100 ? ' ' + numberToWords(num % 100) : '');
+  if (num < 100000) return numberToWords(Math.floor(num / 1000)) + ' Thousand' + (num % 1000 ? ' ' + numberToWords(num % 1000) : '');
+  if (num < 10000000) return numberToWords(Math.floor(num / 100000)) + ' Lakh' + (num % 100000 ? ' ' + numberToWords(num % 100000) : '');
+  return numberToWords(Math.floor(num / 10000000)) + ' Crore' + (num % 10000000 ? ' ' + numberToWords(num % 10000000) : '');
+}
 
 ElectricityBillCard.displayName = 'ElectricityBillCard';
 

--- a/src/components/receipt/FoodBillCard.tsx
+++ b/src/components/receipt/FoodBillCard.tsx
@@ -7,13 +7,12 @@ import {
   Text,
   VStack,
   HStack,
-  Divider,
   Table,
-  Thead,
   Tbody,
   Tr,
-  Th,
   Td,
+  Th,
+  Thead,
 } from '@chakra-ui/react';
 
 export interface FoodItem {
@@ -28,15 +27,14 @@ export interface FoodBillData {
   billDate: Date;
   billNumber: string;
   items: FoodItem[];
-  subtotal: number;
+  subTotal: number;
   cgst: number;
   sgst: number;
   totalAmount: number;
-  paymentMode: string;
-  tableNo?: string;
-  serverName?: string;
-  customerAddress: string;
-  customerPhone: string;
+  restaurantName: string;
+  restaurantAddress: string;
+  gstin: string;
+  tableNumber?: string;
 }
 
 interface FoodBillCardProps {
@@ -44,7 +42,8 @@ interface FoodBillCardProps {
 }
 
 /**
- * Food Bill Card - Apoorva Delicacies Restaurant Style
+ * Food Bill Card - Official Black & White A4 Format
+ * Restaurant Bill Style
  */
 const FoodBillCard = forwardRef<HTMLDivElement, FoodBillCardProps>(
   ({ data }, ref) => {
@@ -52,11 +51,13 @@ const FoodBillCard = forwardRef<HTMLDivElement, FoodBillCardProps>(
       const day = date.getDate().toString().padStart(2, '0');
       const month = (date.getMonth() + 1).toString().padStart(2, '0');
       const year = date.getFullYear();
-      const hours = date.getHours();
+      return `${day}/${month}/${year}`;
+    };
+
+    const formatTime = (date: Date): string => {
+      const hours = date.getHours().toString().padStart(2, '0');
       const minutes = date.getMinutes().toString().padStart(2, '0');
-      const ampm = hours >= 12 ? 'PM' : 'AM';
-      const hour12 = hours % 12 || 12;
-      return `${day}/${month}/${year} ${hour12}:${minutes} ${ampm}`;
+      return `${hours}:${minutes}`;
     };
 
     const formatCurrency = (amount: number): string => {
@@ -67,133 +68,199 @@ const FoodBillCard = forwardRef<HTMLDivElement, FoodBillCardProps>(
       <Box
         ref={ref}
         bg="white"
-        borderRadius="8px"
-        overflow="hidden"
-        maxW="400px"
-        w="100%"
-        fontFamily="'Courier New', Courier, monospace"
-        border="1px solid"
-        borderColor="gray.300"
-        p={0}
+        w="210mm"
+        minH="297mm"
+        fontFamily="'Times New Roman', Times, serif"
+        border="1px solid black"
+        p="15mm"
+        color="black"
+        sx={{
+          '@media print': {
+            width: '210mm',
+            minHeight: '297mm',
+          },
+        }}
       >
-        {/* Header - Restaurant Style */}
-        <Box px={5} py={4} textAlign="center" borderBottom="2px dashed" borderColor="gray.300">
-          <Text fontSize="24px" fontWeight="700" color="orange.600" letterSpacing="2px">
-            APOORVA
+        {/* Header */}
+        <Box borderBottom="2px solid black" pb={4} mb={4} textAlign="center">
+          <Text fontSize="28px" fontWeight="bold" letterSpacing="2px">
+            {data.restaurantName}
           </Text>
-          <Text fontSize="12px" color="orange.500" fontWeight="600" mt={-1}>
-            DELICACIES
+          <Text fontSize="12px" mt={1}>
+            {data.restaurantAddress}
           </Text>
-          <Text fontSize="10px" color="gray.600" mt={2}>
-            Pure Vegetarian Restaurant
+          <Text fontSize="11px" mt={1}>
+            GSTIN: {data.gstin}
           </Text>
-          <Text fontSize="9px" color="gray.500" mt={1}>
-            Shop No. 12, Phoenix Mall, Dhanori, Pune - 411015
-          </Text>
-          <Text fontSize="9px" color="gray.500">
-            Tel: 020-27654321 | FSSAI: 11521034000789
-          </Text>
+          <Box border="2px solid black" display="inline-block" px={4} py={2} mt={3}>
+            <Text fontSize="16px" fontWeight="bold">TAX INVOICE</Text>
+          </Box>
         </Box>
 
         {/* Bill Info */}
-        <Box px={4} py={3} bg="orange.50" borderBottom="1px dashed" borderColor="gray.300">
-          <HStack justify="space-between">
-            <VStack align="flex-start" spacing={0}>
-              <Text fontSize="10px" color="gray.500">BILL NO</Text>
-              <Text fontSize="11px" color="gray.800" fontWeight="600">{data.billNumber}</Text>
-            </VStack>
-            <VStack align="flex-end" spacing={0}>
-              <Text fontSize="10px" color="gray.500">DATE & TIME</Text>
-              <Text fontSize="11px" color="gray.800" fontWeight="600">{formatDate(data.billDate)}</Text>
-            </VStack>
-          </HStack>
-          {data.tableNo && (
-            <HStack justify="space-between" mt={2}>
-              <Text fontSize="10px" color="gray.600">Table: {data.tableNo}</Text>
-              {data.serverName && <Text fontSize="10px" color="gray.600">Server: {data.serverName}</Text>}
-            </HStack>
-          )}
-        </Box>
-
-        {/* Customer Info */}
-        <Box px={4} py={3} borderBottom="1px dashed" borderColor="gray.300">
-          <Text fontSize="10px" color="gray.500" mb={1}>CUSTOMER</Text>
-          <Text fontSize="12px" color="gray.800" fontWeight="600">{data.customerName}</Text>
-          <Text fontSize="9px" color="gray.600" mt={1}>{data.customerAddress}</Text>
-          <Text fontSize="9px" color="gray.600">Ph: {data.customerPhone}</Text>
-        </Box>
+        <HStack justify="space-between" mb={6} spacing={8}>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">BILL DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="40%">Bill No:</Td>
+                  <Td p={1} fontSize="11px">{data.billNumber}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Date:</Td>
+                  <Td p={1} fontSize="11px">{formatDate(data.billDate)}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Time:</Td>
+                  <Td p={1} fontSize="11px">{formatTime(data.billDate)}</Td>
+                </Tr>
+                {data.tableNumber && (
+                  <Tr>
+                    <Td p={1} fontSize="11px" fontWeight="bold">Table No:</Td>
+                    <Td p={1} fontSize="11px">{data.tableNumber}</Td>
+                  </Tr>
+                )}
+              </Tbody>
+            </Table>
+          </Box>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">CUSTOMER DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="30%">Name:</Td>
+                  <Td p={1} fontSize="11px">{data.customerName}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Mode:</Td>
+                  <Td p={1} fontSize="11px">Dine-In</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+        </HStack>
 
         {/* Items Table */}
-        <Box px={3} py={3}>
-          <Table variant="unstyled" size="sm">
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">ORDER DETAILS</Text>
+          <Table variant="simple" size="sm" border="1px solid black">
             <Thead>
-              <Tr borderBottom="1px solid" borderColor="gray.200">
-                <Th px={1} py={2} fontSize="9px" color="gray.600" fontWeight="600" textTransform="uppercase">Item</Th>
-                <Th px={1} py={2} fontSize="9px" color="gray.600" fontWeight="600" textAlign="center">Qty</Th>
-                <Th px={1} py={2} fontSize="9px" color="gray.600" fontWeight="600" textAlign="right">Rate</Th>
-                <Th px={1} py={2} fontSize="9px" color="gray.600" fontWeight="600" textAlign="right">Amt</Th>
+              <Tr bg="gray.100">
+                <Th border="1px solid black" fontSize="10px" p={2}>S.No.</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>Item Description</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>HSN/SAC</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="center">Qty</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Rate (₹)</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Amount (₹)</Th>
               </Tr>
             </Thead>
             <Tbody>
               {data.items.map((item, index) => (
                 <Tr key={index}>
-                  <Td px={1} py={1.5} fontSize="11px" color="gray.800">{item.name}</Td>
-                  <Td px={1} py={1.5} fontSize="11px" color="gray.800" textAlign="center">{item.quantity}</Td>
-                  <Td px={1} py={1.5} fontSize="11px" color="gray.800" textAlign="right">{item.rate.toFixed(2)}</Td>
-                  <Td px={1} py={1.5} fontSize="11px" color="gray.800" textAlign="right" fontWeight="500">{item.amount.toFixed(2)}</Td>
+                  <Td border="1px solid black" fontSize="11px" p={2}>{index + 1}</Td>
+                  <Td border="1px solid black" fontSize="11px" p={2}>{item.name}</Td>
+                  <Td border="1px solid black" fontSize="11px" p={2}>996331</Td>
+                  <Td border="1px solid black" fontSize="11px" p={2} textAlign="center">{item.quantity}</Td>
+                  <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{item.rate.toFixed(2)}</Td>
+                  <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{item.amount.toFixed(2)}</Td>
                 </Tr>
               ))}
             </Tbody>
           </Table>
         </Box>
 
-        {/* Divider */}
-        <Divider borderStyle="dashed" borderColor="gray.300" />
+        {/* Tax & Total */}
+        <Flex justify="flex-end" mb={6}>
+          <Table variant="simple" size="sm" border="1px solid black" maxW="350px">
+            <Tbody>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>Sub Total</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.subTotal.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>CGST @ 2.5%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.cgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>SGST @ 2.5%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.sgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr bg="gray.100">
+                <Td border="1px solid black" fontSize="12px" p={2} fontWeight="bold">GRAND TOTAL</Td>
+                <Td border="1px solid black" fontSize="12px" p={2} textAlign="right" fontWeight="bold">{formatCurrency(data.totalAmount)}</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Flex>
 
-        {/* Totals */}
-        <Box px={4} py={3}>
-          <HStack justify="space-between" mb={1}>
-            <Text fontSize="11px" color="gray.600">Sub Total</Text>
-            <Text fontSize="11px" color="gray.800" fontWeight="500">{formatCurrency(data.subtotal)}</Text>
-          </HStack>
-          <HStack justify="space-between" mb={1}>
-            <Text fontSize="10px" color="gray.500">CGST @ 2.5%</Text>
-            <Text fontSize="10px" color="gray.600">{formatCurrency(data.cgst)}</Text>
-          </HStack>
-          <HStack justify="space-between" mb={2}>
-            <Text fontSize="10px" color="gray.500">SGST @ 2.5%</Text>
-            <Text fontSize="10px" color="gray.600">{formatCurrency(data.sgst)}</Text>
-          </HStack>
-          
-          <Divider my={2} />
-          
-          <HStack justify="space-between">
-            <Text fontSize="14px" color="gray.800" fontWeight="700">GRAND TOTAL</Text>
-            <Text fontSize="16px" color="orange.600" fontWeight="700">{formatCurrency(data.totalAmount)}</Text>
-          </HStack>
-          
-          <HStack justify="space-between" mt={2}>
-            <Text fontSize="10px" color="gray.500">Payment Mode</Text>
-            <Text fontSize="10px" color="gray.700" fontWeight="500">{data.paymentMode}</Text>
-          </HStack>
+        {/* Amount in Words */}
+        <Box mb={6} p={3} border="1px solid black">
+          <Text fontSize="11px">
+            <Text as="span" fontWeight="bold">Amount in Words: </Text>
+            Rupees {numberToWords(Math.floor(data.totalAmount))} Only
+          </Text>
+        </Box>
+
+        {/* Payment Info */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">PAYMENT DETAILS</Text>
+          <Table variant="unstyled" size="sm" maxW="300px">
+            <Tbody>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">Payment Mode:</Td>
+                <Td p={1} fontSize="11px">Cash / UPI / Card</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">Payment Status:</Td>
+                <Td p={1} fontSize="11px">PAID</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Box>
+
+        {/* Terms */}
+        <Box mb={6}>
+          <Text fontSize="10px" fontWeight="bold" mb={1}>Terms & Conditions:</Text>
+          <Text fontSize="9px">• Goods once sold will not be taken back or exchanged</Text>
+          <Text fontSize="9px">• Subject to Pune Jurisdiction</Text>
         </Box>
 
         {/* Footer */}
-        <Box px={4} py={3} bg="orange.50" borderTop="2px dashed" borderColor="gray.300" textAlign="center">
-          <Text fontSize="11px" color="orange.600" fontWeight="600">
-            Thank You! Visit Again!
-          </Text>
-          <Text fontSize="8px" color="gray.500" mt={1}>
-            GSTIN: 27AADCA1234F1Z5
-          </Text>
-          <Text fontSize="8px" color="gray.400" mt={1}>
-            This is a computer generated bill
+        <Box borderTop="1px solid black" pt={4} mt="auto">
+          <Flex justify="space-between" align="flex-end">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="10px">Thank you for dining with us!</Text>
+              <Text fontSize="10px">Visit Again!</Text>
+            </VStack>
+            <VStack align="flex-end" spacing={1}>
+              <Text fontSize="10px" mb={8}>For {data.restaurantName}</Text>
+              <Text fontSize="10px" fontStyle="italic">Authorized Signatory</Text>
+            </VStack>
+          </Flex>
+          <Text fontSize="9px" textAlign="center" mt={4} color="gray.600">
+            This is a computer generated invoice and does not require physical signature.
           </Text>
         </Box>
       </Box>
     );
   }
 );
+
+// Helper function to convert number to words
+function numberToWords(num: number): string {
+  const ones = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten',
+    'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+  const tens = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+  if (num === 0) return 'Zero';
+  if (num < 20) return ones[num];
+  if (num < 100) return tens[Math.floor(num / 10)] + (num % 10 ? ' ' + ones[num % 10] : '');
+  if (num < 1000) return ones[Math.floor(num / 100)] + ' Hundred' + (num % 100 ? ' ' + numberToWords(num % 100) : '');
+  if (num < 100000) return numberToWords(Math.floor(num / 1000)) + ' Thousand' + (num % 1000 ? ' ' + numberToWords(num % 1000) : '');
+  if (num < 10000000) return numberToWords(Math.floor(num / 100000)) + ' Lakh' + (num % 100000 ? ' ' + numberToWords(num % 100000) : '');
+  return numberToWords(Math.floor(num / 10000000)) + ' Crore' + (num % 10000000 ? ' ' + numberToWords(num % 10000000) : '');
+}
 
 FoodBillCard.displayName = 'FoodBillCard';
 

--- a/src/components/receipt/SeminarBillCard.tsx
+++ b/src/components/receipt/SeminarBillCard.tsx
@@ -7,22 +7,13 @@ import {
   Text,
   VStack,
   HStack,
-  Divider,
   Table,
-  Thead,
   Tbody,
   Tr,
-  Th,
   Td,
-  Badge,
+  Th,
+  Thead,
 } from '@chakra-ui/react';
-
-export interface SeminarItem {
-  description: string;
-  quantity: number;
-  unitPrice: number;
-  amount: number;
-}
 
 export interface SeminarBillData {
   customerName: string;
@@ -31,16 +22,15 @@ export interface SeminarBillData {
   eventName: string;
   eventDate: string;
   eventVenue: string;
-  items: SeminarItem[];
-  subtotal: number;
+  registrationFee: number;
   cgst: number;
   sgst: number;
   totalAmount: number;
+  companyName: string;
+  companyAddress: string;
+  gstin: string;
   customerAddress: string;
-  corporateAddress: string;
-  customerPhone: string;
-  paymentStatus: 'PAID' | 'PENDING' | 'PARTIAL';
-  paymentMode?: string;
+  customerContact: string;
 }
 
 interface SeminarBillCardProps {
@@ -48,206 +38,221 @@ interface SeminarBillCardProps {
 }
 
 /**
- * Seminar/Conference Bill Card - TravelPlus Style Invoice
+ * Seminar Bill Card - Official Black & White A4 Format
+ * Conference/Seminar Invoice Style
  */
 const SeminarBillCard = forwardRef<HTMLDivElement, SeminarBillCardProps>(
   ({ data }, ref) => {
     const formatDate = (date: Date): string => {
       const day = date.getDate().toString().padStart(2, '0');
-      const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-      const month = months[date.getMonth()];
+      const month = (date.getMonth() + 1).toString().padStart(2, '0');
       const year = date.getFullYear();
-      return `${day} ${month} ${year}`;
+      return `${day}/${month}/${year}`;
     };
 
     const formatCurrency = (amount: number): string => {
-      return new Intl.NumberFormat('en-IN', {
-        style: 'currency',
-        currency: 'INR',
-        minimumFractionDigits: 2,
-      }).format(amount);
-    };
-
-    const getPaymentBadgeColor = () => {
-      switch (data.paymentStatus) {
-        case 'PAID': return 'green';
-        case 'PENDING': return 'red';
-        case 'PARTIAL': return 'orange';
-        default: return 'gray';
-      }
+      return `₹${amount.toFixed(2)}`;
     };
 
     return (
       <Box
         ref={ref}
         bg="white"
-        borderRadius="8px"
-        overflow="hidden"
-        maxW="550px"
-        w="100%"
-        fontFamily="'Inter', -apple-system, BlinkMacSystemFont, sans-serif"
-        border="1px solid"
-        borderColor="gray.200"
-        p={0}
+        w="210mm"
+        minH="297mm"
+        fontFamily="'Times New Roman', Times, serif"
+        border="1px solid black"
+        p="15mm"
+        color="black"
+        sx={{
+          '@media print': {
+            width: '210mm',
+            minHeight: '297mm',
+          },
+        }}
       >
-        {/* Header - Professional Style */}
-        <Box 
-          bgGradient="linear(to-r, #1a365d, #2c5282)" 
-          px={6} 
-          py={5}
-        >
-          <HStack justify="space-between" align="flex-start">
+        {/* Header */}
+        <Box borderBottom="2px solid black" pb={4} mb={4}>
+          <Flex justify="space-between" align="flex-start">
             <VStack align="flex-start" spacing={1}>
-              <Text fontSize="24px" fontWeight="700" color="white" letterSpacing="1px">
-                TravelPlus
+              <Text fontSize="28px" fontWeight="bold" letterSpacing="2px">
+                {data.companyName}
               </Text>
-              <Text fontSize="10px" color="whiteAlpha.800">
-                Corporate Events & Conferences
-              </Text>
+              <Text fontSize="12px">Event Management & Travel Services</Text>
+              <Text fontSize="11px">{data.companyAddress}</Text>
+              <Text fontSize="11px">GSTIN: {data.gstin}</Text>
             </VStack>
             <VStack align="flex-end" spacing={1}>
-              <Text fontSize="20px" fontWeight="600" color="white">
-                TAX INVOICE
-              </Text>
-              <Badge colorScheme={getPaymentBadgeColor()} fontSize="10px" px={2}>
-                {data.paymentStatus}
-              </Badge>
-            </VStack>
-          </HStack>
-        </Box>
-
-        {/* Invoice Details */}
-        <Box px={6} py={4} bg="gray.50" borderBottom="1px solid" borderColor="gray.200">
-          <HStack justify="space-between" align="flex-start">
-            <VStack align="flex-start" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">INVOICE NUMBER</Text>
-              <Text fontSize="14px" color="gray.800" fontWeight="600">{data.invoiceNumber}</Text>
-            </VStack>
-            <VStack align="flex-end" spacing={1}>
-              <Text fontSize="10px" color="gray.500" fontWeight="500">INVOICE DATE</Text>
-              <Text fontSize="14px" color="gray.800" fontWeight="600">{formatDate(data.invoiceDate)}</Text>
-            </VStack>
-          </HStack>
-        </Box>
-
-        {/* Bill To Section */}
-        <Box px={6} py={4} borderBottom="1px solid" borderColor="gray.200">
-          <HStack align="flex-start" spacing={8}>
-            <VStack align="flex-start" spacing={2} flex={1}>
-              <Text fontSize="11px" color="blue.600" fontWeight="600" textTransform="uppercase">
-                BILLED TO
-              </Text>
-              <Box>
-                <Text fontSize="14px" color="gray.800" fontWeight="600">{data.customerName}</Text>
-                <Text fontSize="11px" color="gray.600" mt={1} lineHeight="1.6">
-                  {data.customerAddress}
-                </Text>
-                <Text fontSize="11px" color="gray.600" mt={2} lineHeight="1.6">
-                  <Text as="span" fontWeight="500">Corporate:</Text> {data.corporateAddress}
-                </Text>
-                <Text fontSize="11px" color="gray.600" mt={1}>
-                  Contact: {data.customerPhone}
-                </Text>
+              <Box border="2px solid black" px={4} py={2}>
+                <Text fontSize="16px" fontWeight="bold">TAX INVOICE</Text>
               </Box>
+              <Text fontSize="11px" mt={2}>Invoice No: {data.invoiceNumber}</Text>
+              <Text fontSize="11px">Date: {formatDate(data.invoiceDate)}</Text>
             </VStack>
-          </HStack>
+          </Flex>
         </Box>
 
-        {/* Event Details */}
-        <Box px={6} py={4} bg="blue.50" borderBottom="1px solid" borderColor="gray.200">
-          <Text fontSize="11px" color="blue.600" fontWeight="600" textTransform="uppercase" mb={2}>
-            EVENT DETAILS
-          </Text>
-          <VStack align="flex-start" spacing={1}>
-            <HStack>
-              <Text fontSize="12px" color="gray.600" w="80px">Event:</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{data.eventName}</Text>
-            </HStack>
-            <HStack>
-              <Text fontSize="12px" color="gray.600" w="80px">Date:</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{data.eventDate}</Text>
-            </HStack>
-            <HStack>
-              <Text fontSize="12px" color="gray.600" w="80px">Venue:</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{data.eventVenue}</Text>
-            </HStack>
-          </VStack>
-        </Box>
+        {/* Bill To / Ship To */}
+        <HStack justify="space-between" mb={6} spacing={8}>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">BILL TO</Text>
+            <Text fontSize="12px" fontWeight="bold">{data.customerName}</Text>
+            <Text fontSize="11px" mt={1}>{data.customerAddress}</Text>
+            <Text fontSize="11px" mt={1}>Contact: {data.customerContact}</Text>
+          </Box>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">EVENT DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="35%">Event:</Td>
+                  <Td p={1} fontSize="11px">{data.eventName}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Date:</Td>
+                  <Td p={1} fontSize="11px">{data.eventDate}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Venue:</Td>
+                  <Td p={1} fontSize="11px">{data.eventVenue}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+        </HStack>
 
-        {/* Items Table */}
-        <Box px={4} py={4}>
-          <Table variant="simple" size="sm">
+        {/* Service Details */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">SERVICE DETAILS</Text>
+          <Table variant="simple" size="sm" border="1px solid black">
             <Thead>
               <Tr bg="gray.100">
-                <Th fontSize="10px" color="gray.600" py={3} borderColor="gray.200">DESCRIPTION</Th>
-                <Th fontSize="10px" color="gray.600" py={3} textAlign="center" borderColor="gray.200">QTY</Th>
-                <Th fontSize="10px" color="gray.600" py={3} textAlign="right" borderColor="gray.200">UNIT PRICE</Th>
-                <Th fontSize="10px" color="gray.600" py={3} textAlign="right" borderColor="gray.200">AMOUNT</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>S.No.</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>Description</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>HSN/SAC</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="center">Qty</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Rate (₹)</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Amount (₹)</Th>
               </Tr>
             </Thead>
             <Tbody>
-              {data.items.map((item, index) => (
-                <Tr key={index}>
-                  <Td fontSize="12px" color="gray.800" py={3} borderColor="gray.100">{item.description}</Td>
-                  <Td fontSize="12px" color="gray.800" py={3} textAlign="center" borderColor="gray.100">{item.quantity}</Td>
-                  <Td fontSize="12px" color="gray.800" py={3} textAlign="right" borderColor="gray.100">{formatCurrency(item.unitPrice)}</Td>
-                  <Td fontSize="12px" color="gray.800" py={3} textAlign="right" fontWeight="500" borderColor="gray.100">{formatCurrency(item.amount)}</Td>
-                </Tr>
-              ))}
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>1</Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>
+                  Conference Registration Fee<br/>
+                  <Text fontSize="10px" color="gray.600">{data.eventName}</Text>
+                  <Text fontSize="10px" color="gray.600">Includes: Entry, Materials, Lunch & Networking</Text>
+                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>998596</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="center">1</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.registrationFee.toFixed(2)}</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.registrationFee.toFixed(2)}</Td>
+              </Tr>
             </Tbody>
           </Table>
         </Box>
 
-        {/* Totals Section */}
-        <Box px={6} py={4} borderTop="1px solid" borderColor="gray.200">
-          <VStack align="stretch" spacing={2}>
-            <HStack justify="space-between">
-              <Text fontSize="12px" color="gray.600">Subtotal</Text>
-              <Text fontSize="12px" color="gray.800" fontWeight="500">{formatCurrency(data.subtotal)}</Text>
-            </HStack>
-            <HStack justify="space-between">
-              <Text fontSize="11px" color="gray.500">CGST @ 9%</Text>
-              <Text fontSize="11px" color="gray.600">{formatCurrency(data.cgst)}</Text>
-            </HStack>
-            <HStack justify="space-between">
-              <Text fontSize="11px" color="gray.500">SGST @ 9%</Text>
-              <Text fontSize="11px" color="gray.600">{formatCurrency(data.sgst)}</Text>
-            </HStack>
-            
-            <Divider my={1} />
-            
-            <HStack justify="space-between">
-              <Text fontSize="16px" color="gray.800" fontWeight="700">TOTAL AMOUNT</Text>
-              <Text fontSize="18px" color="blue.700" fontWeight="700">{formatCurrency(data.totalAmount)}</Text>
-            </HStack>
+        {/* Tax & Total */}
+        <Flex justify="flex-end" mb={6}>
+          <Table variant="simple" size="sm" border="1px solid black" maxW="400px">
+            <Tbody>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>Taxable Amount</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.registrationFee.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>CGST @ 9%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.cgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>SGST @ 9%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.sgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr bg="gray.100">
+                <Td border="1px solid black" fontSize="12px" p={2} fontWeight="bold">TOTAL AMOUNT</Td>
+                <Td border="1px solid black" fontSize="12px" p={2} textAlign="right" fontWeight="bold">{formatCurrency(data.totalAmount)}</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Flex>
 
-            {data.paymentMode && (
-              <HStack justify="space-between" mt={1}>
-                <Text fontSize="11px" color="gray.500">Payment Mode</Text>
-                <Text fontSize="11px" color="gray.700" fontWeight="500">{data.paymentMode}</Text>
-              </HStack>
-            )}
-          </VStack>
+        {/* Amount in Words */}
+        <Box mb={6} p={3} border="1px solid black">
+          <Text fontSize="11px">
+            <Text as="span" fontWeight="bold">Amount in Words: </Text>
+            Rupees {numberToWords(Math.floor(data.totalAmount))} Only
+          </Text>
+        </Box>
+
+        {/* Bank Details */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">BANK DETAILS FOR PAYMENT</Text>
+          <Table variant="unstyled" size="sm" maxW="400px">
+            <Tbody>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold" w="35%">Bank Name:</Td>
+                <Td p={1} fontSize="11px">HDFC Bank</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">Account No:</Td>
+                <Td p={1} fontSize="11px">50100XXXXXXXX</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">IFSC Code:</Td>
+                <Td p={1} fontSize="11px">HDFC0001234</Td>
+              </Tr>
+              <Tr>
+                <Td p={1} fontSize="11px" fontWeight="bold">Branch:</Td>
+                <Td p={1} fontSize="11px">Kirkland, WA</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Box>
+
+        {/* Terms */}
+        <Box mb={6}>
+          <Text fontSize="10px" fontWeight="bold" mb={1}>Terms & Conditions:</Text>
+          <Text fontSize="9px">• Registration is non-refundable and non-transferable</Text>
+          <Text fontSize="9px">• Entry is subject to valid ID proof</Text>
+          <Text fontSize="9px">• Organizers reserve the right to modify the program</Text>
+          <Text fontSize="9px">• Subject to Pune Jurisdiction</Text>
         </Box>
 
         {/* Footer */}
-        <Box px={6} py={4} bg="gray.50" borderTop="1px solid" borderColor="gray.200">
-          <VStack spacing={2}>
-            <Text fontSize="10px" color="gray.500" textAlign="center">
-              GSTIN: 27AABCT1234F1ZP | PAN: AABCT1234F
-            </Text>
-            <Text fontSize="10px" color="gray.500" textAlign="center">
-              TravelPlus Events Pvt. Ltd. | 45 MG Road, Bangalore - 560001
-            </Text>
-            <Text fontSize="9px" color="gray.400" textAlign="center" mt={1}>
-              This is a computer generated invoice and does not require physical signature
-            </Text>
-          </VStack>
+        <Box borderTop="1px solid black" pt={4} mt="auto">
+          <Flex justify="space-between" align="flex-end">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="10px">For queries: +91 8004482372</Text>
+              <Text fontSize="10px">Email: events@travelplus.com</Text>
+            </VStack>
+            <VStack align="flex-end" spacing={1}>
+              <Text fontSize="10px" mb={8}>For {data.companyName}</Text>
+              <Text fontSize="10px" fontStyle="italic">Authorized Signatory</Text>
+            </VStack>
+          </Flex>
+          <Text fontSize="9px" textAlign="center" mt={4} color="gray.600">
+            This is a computer generated invoice and does not require physical signature.
+          </Text>
         </Box>
       </Box>
     );
   }
 );
+
+// Helper function to convert number to words
+function numberToWords(num: number): string {
+  const ones = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten',
+    'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+  const tens = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+  if (num === 0) return 'Zero';
+  if (num < 20) return ones[num];
+  if (num < 100) return tens[Math.floor(num / 10)] + (num % 10 ? ' ' + ones[num % 10] : '');
+  if (num < 1000) return ones[Math.floor(num / 100)] + ' Hundred' + (num % 100 ? ' ' + numberToWords(num % 100) : '');
+  if (num < 100000) return numberToWords(Math.floor(num / 1000)) + ' Thousand' + (num % 1000 ? ' ' + numberToWords(num % 1000) : '');
+  if (num < 10000000) return numberToWords(Math.floor(num / 100000)) + ' Lakh' + (num % 100000 ? ' ' + numberToWords(num % 100000) : '');
+  return numberToWords(Math.floor(num / 10000000)) + ' Crore' + (num % 10000000 ? ' ' + numberToWords(num % 10000000) : '');
+}
 
 SeminarBillCard.displayName = 'SeminarBillCard';
 

--- a/src/components/receipt/WiFiBillCard.tsx
+++ b/src/components/receipt/WiFiBillCard.tsx
@@ -12,6 +12,8 @@ import {
   Tbody,
   Tr,
   Td,
+  Th,
+  Thead,
 } from '@chakra-ui/react';
 
 export interface WiFiBillData {
@@ -35,7 +37,8 @@ interface WiFiBillCardProps {
 }
 
 /**
- * WiFi Bill Card - Hathway Internet Bill Style
+ * WiFi Bill Card - Official Black & White A4 Format
+ * Hathway Internet Bill Style
  */
 const WiFiBillCard = forwardRef<HTMLDivElement, WiFiBillCardProps>(
   ({ data }, ref) => {
@@ -54,168 +57,191 @@ const WiFiBillCard = forwardRef<HTMLDivElement, WiFiBillCardProps>(
       <Box
         ref={ref}
         bg="white"
-        borderRadius="8px"
-        overflow="hidden"
-        maxW="450px"
-        w="100%"
-        fontFamily="'Inter', -apple-system, BlinkMacSystemFont, sans-serif"
-        border="1px solid"
-        borderColor="gray.200"
-        p={0}
+        w="210mm"
+        minH="297mm"
+        fontFamily="'Times New Roman', Times, serif"
+        border="1px solid black"
+        p="15mm"
+        color="black"
+        sx={{
+          '@media print': {
+            width: '210mm',
+            minHeight: '297mm',
+          },
+        }}
       >
-        {/* Header - Hathway Style */}
-        <Box bg="#E53935" px={5} py={4}>
-          <HStack justify="space-between" align="center">
-            <VStack align="flex-start" spacing={0}>
-              <Text fontSize="22px" fontWeight="700" color="white" letterSpacing="1px">
+        {/* Header */}
+        <Box borderBottom="2px solid black" pb={4} mb={4}>
+          <Flex justify="space-between" align="flex-start">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="28px" fontWeight="bold" letterSpacing="2px">
                 HATHWAY
               </Text>
-              <Text fontSize="10px" color="white" opacity={0.9}>
-                Digital Cable Network
-              </Text>
-            </VStack>
-            <VStack align="flex-end" spacing={0}>
-              <Text fontSize="11px" color="white" fontWeight="500">
-                TAX INVOICE
-              </Text>
-              <Text fontSize="10px" color="white" opacity={0.8}>
-                GSTIN: 27AAACH7756R1ZW
-              </Text>
-            </VStack>
-          </HStack>
-        </Box>
-
-        {/* Bill Info Section */}
-        <Box px={5} py={4} bg="gray.50">
-          <HStack justify="space-between" align="flex-start">
-            <VStack align="flex-start" spacing={1}>
-              <Text fontSize="11px" color="gray.500" fontWeight="500">
-                BILL NUMBER
-              </Text>
-              <Text fontSize="13px" color="gray.800" fontWeight="600">
-                {data.billNumber}
-              </Text>
+              <Text fontSize="12px">Digital Cable Network Pvt. Ltd.</Text>
+              <Text fontSize="11px">CIN: U64200MH2001PTC132576</Text>
             </VStack>
             <VStack align="flex-end" spacing={1}>
-              <Text fontSize="11px" color="gray.500" fontWeight="500">
-                BILL DATE
-              </Text>
-              <Text fontSize="13px" color="gray.800" fontWeight="600">
-                {formatDate(data.billDate)}
-              </Text>
+              <Box border="2px solid black" px={4} py={2}>
+                <Text fontSize="16px" fontWeight="bold">TAX INVOICE</Text>
+              </Box>
+              <Text fontSize="11px">GSTIN: 27AAACH7756R1ZW</Text>
+              <Text fontSize="11px">PAN: AAACH7756R</Text>
             </VStack>
-          </HStack>
-        </Box>
-
-        <Divider />
-
-        {/* Customer Details */}
-        <Box px={5} py={4}>
-          <Text fontSize="11px" color="gray.500" fontWeight="500" mb={2}>
-            CUSTOMER DETAILS
+          </Flex>
+          <Text fontSize="11px" mt={2}>
+            Regd. Office: Unit 1, Techniplex-1, Techniplex Complex, Off Veer Savarkar Flyover, Goregaon (West), Mumbai - 400062
           </Text>
-          <VStack align="flex-start" spacing={2}>
-            <Box>
-              <Text fontSize="14px" color="gray.800" fontWeight="600">
-                {data.customerName}
-              </Text>
-              <Text fontSize="12px" color="gray.600" mt={1}>
-                Customer ID: {data.customerId}
-              </Text>
-            </Box>
-            <Text fontSize="12px" color="gray.600" lineHeight="1.5">
-              {data.connectionAddress}
-            </Text>
-          </VStack>
         </Box>
 
-        <Divider />
+        {/* Bill Details */}
+        <HStack justify="space-between" mb={6} spacing={8}>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">BILL DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="40%">Bill Number:</Td>
+                  <Td p={1} fontSize="11px">{data.billNumber}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Bill Date:</Td>
+                  <Td p={1} fontSize="11px">{formatDate(data.billDate)}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Due Date:</Td>
+                  <Td p={1} fontSize="11px">{formatDate(data.dueDate)}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Billing Period:</Td>
+                  <Td p={1} fontSize="11px">{data.billingPeriod}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+          <Box flex={1} border="1px solid black" p={3}>
+            <Text fontSize="10px" fontWeight="bold" mb={2} textDecoration="underline">CUSTOMER DETAILS</Text>
+            <Table variant="unstyled" size="sm">
+              <Tbody>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" w="40%">Customer ID:</Td>
+                  <Td p={1} fontSize="11px">{data.customerId}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold">Name:</Td>
+                  <Td p={1} fontSize="11px">{data.customerName}</Td>
+                </Tr>
+                <Tr>
+                  <Td p={1} fontSize="11px" fontWeight="bold" verticalAlign="top">Address:</Td>
+                  <Td p={1} fontSize="11px">{data.connectionAddress}</Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </Box>
+        </HStack>
 
         {/* Plan Details */}
-        <Box px={5} py={4}>
-          <Text fontSize="11px" color="gray.500" fontWeight="500" mb={3}>
-            PLAN DETAILS
-          </Text>
-          <HStack justify="space-between" bg="red.50" p={3} borderRadius="6px">
-            <VStack align="flex-start" spacing={0}>
-              <Text fontSize="13px" color="gray.800" fontWeight="600">
-                {data.planName}
-              </Text>
-              <Text fontSize="11px" color="gray.600">
-                {data.planSpeed}
-              </Text>
-            </VStack>
-            <Text fontSize="12px" color="gray.600">
-              Billing Period: {data.billingPeriod}
-            </Text>
-          </HStack>
-        </Box>
-
-        <Divider />
-
-        {/* Charges Breakdown */}
-        <Box px={5} py={4}>
-          <Text fontSize="11px" color="gray.500" fontWeight="500" mb={3}>
-            CHARGES BREAKDOWN
-          </Text>
-          <Table variant="unstyled" size="sm">
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">SUBSCRIPTION DETAILS</Text>
+          <Table variant="simple" size="sm" border="1px solid black">
+            <Thead>
+              <Tr bg="gray.100">
+                <Th border="1px solid black" fontSize="10px" p={2}>S.No.</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>Description</Th>
+                <Th border="1px solid black" fontSize="10px" p={2}>HSN/SAC</Th>
+                <Th border="1px solid black" fontSize="10px" p={2} textAlign="right">Amount (₹)</Th>
+              </Tr>
+            </Thead>
             <Tbody>
               <Tr>
-                <Td px={0} py={2} fontSize="13px" color="gray.700">
-                  Monthly Subscription Charge
+                <Td border="1px solid black" fontSize="11px" p={2}>1</Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>
+                  {data.planName} - {data.planSpeed}<br/>
+                  <Text fontSize="10px" color="gray.600">Monthly Internet Subscription Charges</Text>
                 </Td>
-                <Td px={0} py={2} fontSize="13px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.monthlyCharge)}
-                </Td>
-              </Tr>
-              <Tr>
-                <Td px={0} py={2} fontSize="13px" color="gray.700">
-                  CGST @ 9%
-                </Td>
-                <Td px={0} py={2} fontSize="13px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.cgst)}
-                </Td>
-              </Tr>
-              <Tr>
-                <Td px={0} py={2} fontSize="13px" color="gray.700">
-                  SGST @ 9%
-                </Td>
-                <Td px={0} py={2} fontSize="13px" color="gray.800" textAlign="right" fontWeight="500">
-                  {formatCurrency(data.sgst)}
-                </Td>
+                <Td border="1px solid black" fontSize="11px" p={2}>998422</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.monthlyCharge.toFixed(2)}</Td>
               </Tr>
             </Tbody>
           </Table>
         </Box>
 
-        {/* Total Amount */}
-        <Box px={5} py={4} bg="#E53935">
-          <Flex justify="space-between" align="center">
-            <Text fontSize="14px" color="white" fontWeight="600">
-              Total Amount Due
-            </Text>
-            <Text fontSize="20px" color="white" fontWeight="700">
-              {formatCurrency(data.totalAmount)}
-            </Text>
-          </Flex>
-          <Text fontSize="11px" color="white" opacity={0.85} mt={1}>
-            Due Date: {formatDate(data.dueDate)}
+        {/* Tax Breakdown */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">TAX DETAILS</Text>
+          <Table variant="simple" size="sm" border="1px solid black" maxW="400px">
+            <Tbody>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>Taxable Amount</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.monthlyCharge.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>CGST @ 9%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.cgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr>
+                <Td border="1px solid black" fontSize="11px" p={2}>SGST @ 9%</Td>
+                <Td border="1px solid black" fontSize="11px" p={2} textAlign="right">{data.sgst.toFixed(2)}</Td>
+              </Tr>
+              <Tr bg="gray.100">
+                <Td border="1px solid black" fontSize="12px" p={2} fontWeight="bold">TOTAL AMOUNT</Td>
+                <Td border="1px solid black" fontSize="12px" p={2} textAlign="right" fontWeight="bold">{formatCurrency(data.totalAmount)}</Td>
+              </Tr>
+            </Tbody>
+          </Table>
+        </Box>
+
+        {/* Amount in Words */}
+        <Box mb={6} p={3} border="1px solid black">
+          <Text fontSize="11px">
+            <Text as="span" fontWeight="bold">Amount in Words: </Text>
+            Rupees {numberToWords(Math.floor(data.totalAmount))} Only
           </Text>
         </Box>
 
+        {/* Payment Info */}
+        <Box mb={6}>
+          <Text fontSize="12px" fontWeight="bold" mb={2} textDecoration="underline">PAYMENT INFORMATION</Text>
+          <Text fontSize="11px" mb={1}>• Payment can be made via UPI, Net Banking, Credit/Debit Card, or Cash</Text>
+          <Text fontSize="11px" mb={1}>• Late payment may attract penalty charges</Text>
+          <Text fontSize="11px">• For online payment: Visit www.hathway.com or use Hathway App</Text>
+        </Box>
+
         {/* Footer */}
-        <Box px={5} py={3} bg="gray.50">
-          <Text fontSize="10px" color="gray.500" textAlign="center">
-            For queries: 1800-419-6666 | support@hathway.com
-          </Text>
-          <Text fontSize="9px" color="gray.400" textAlign="center" mt={1}>
-            This is a computer generated invoice and does not require signature
+        <Box borderTop="1px solid black" pt={4} mt="auto">
+          <Flex justify="space-between" align="flex-end">
+            <VStack align="flex-start" spacing={1}>
+              <Text fontSize="10px">Customer Care: 1800-419-6666 (Toll Free)</Text>
+              <Text fontSize="10px">Email: support@hathway.com</Text>
+              <Text fontSize="10px">Website: www.hathway.com</Text>
+            </VStack>
+            <VStack align="flex-end" spacing={1}>
+              <Text fontSize="10px" mb={8}>For Hathway Digital Cable Network Pvt. Ltd.</Text>
+              <Text fontSize="10px" fontStyle="italic">Authorized Signatory</Text>
+            </VStack>
+          </Flex>
+          <Text fontSize="9px" textAlign="center" mt={4} color="gray.600">
+            This is a computer generated invoice and does not require physical signature.
           </Text>
         </Box>
       </Box>
     );
   }
 );
+
+// Helper function to convert number to words
+function numberToWords(num: number): string {
+  const ones = ['', 'One', 'Two', 'Three', 'Four', 'Five', 'Six', 'Seven', 'Eight', 'Nine', 'Ten',
+    'Eleven', 'Twelve', 'Thirteen', 'Fourteen', 'Fifteen', 'Sixteen', 'Seventeen', 'Eighteen', 'Nineteen'];
+  const tens = ['', '', 'Twenty', 'Thirty', 'Forty', 'Fifty', 'Sixty', 'Seventy', 'Eighty', 'Ninety'];
+
+  if (num === 0) return 'Zero';
+  if (num < 20) return ones[num];
+  if (num < 100) return tens[Math.floor(num / 10)] + (num % 10 ? ' ' + ones[num % 10] : '');
+  if (num < 1000) return ones[Math.floor(num / 100)] + ' Hundred' + (num % 100 ? ' ' + numberToWords(num % 100) : '');
+  if (num < 100000) return numberToWords(Math.floor(num / 1000)) + ' Thousand' + (num % 1000 ? ' ' + numberToWords(num % 1000) : '');
+  if (num < 10000000) return numberToWords(Math.floor(num / 100000)) + ' Lakh' + (num % 100000 ? ' ' + numberToWords(num % 100000) : '');
+  return numberToWords(Math.floor(num / 10000000)) + ' Crore' + (num % 10000000 ? ' ' + numberToWords(num % 10000000) : '');
+}
 
 WiFiBillCard.displayName = 'WiFiBillCard';
 

--- a/src/utils/receiptUtils.ts
+++ b/src/utils/receiptUtils.ts
@@ -153,14 +153,18 @@ export const generateReceiptData = (
 };
 
 // ============================================
-// WIFI BILL UTILITIES
+// IMPORT TYPES FROM BILL CARDS
 // ============================================
 
 import { WiFiBillData } from '../components/receipt/WiFiBillCard';
 import { FoodBillData, FoodItem } from '../components/receipt/FoodBillCard';
-import { SeminarBillData, SeminarItem } from '../components/receipt/SeminarBillCard';
+import { SeminarBillData } from '../components/receipt/SeminarBillCard';
 import { ElectricityBillData } from '../components/receipt/ElectricityBillCard';
-import { AICourseBillData, CourseItem } from '../components/receipt/AICourseBillCard';
+import { AICourseBillData } from '../components/receipt/AICourseBillCard';
+
+// ============================================
+// WIFI BILL UTILITIES
+// ============================================
 
 /**
  * Generate WiFi Bill Number
@@ -250,7 +254,7 @@ export const generateFoodBillData = (
     { name: 'Sweet Lassi', quantity: 4, rate: 85, amount: 340 },
   ];
 
-  const subtotal = 2510; // Fixed subtotal
+  const subTotal = 2510; // Fixed subtotal
   const cgst = 62.75; // 2.5%
   const sgst = 62.25; // 2.5%
   const totalAmount = 2635; // Fixed total
@@ -260,15 +264,14 @@ export const generateFoodBillData = (
     billDate,
     billNumber: generateFoodBillNumber(),
     items,
-    subtotal: Math.round(subtotal * 100) / 100,
+    subTotal: Math.round(subTotal * 100) / 100,
     cgst: Math.round(cgst * 100) / 100,
     sgst: Math.round(sgst * 100) / 100,
     totalAmount: Math.round(totalAmount * 100) / 100,
-    paymentMode: 'UPI',
-    tableNo: 'T-07',
-    serverName: 'Rahul',
-    customerAddress: 'Row house 7, matra montana, dhanori, pune, maharastra',
-    customerPhone: '+91 8004482372',
+    restaurantName: 'Apoorva Delicacies',
+    restaurantAddress: 'Shop No. 5, Dhanori Road, Near Chandan Nagar, Pune - 411015',
+    gstin: '27AAECA1234B1ZK',
+    tableNumber: 'T-07',
   };
 };
 
@@ -297,14 +300,7 @@ export const generateSeminarBillData = (
   eventDate: string = '20-21 Nov 2024',
   eventVenue: string = 'Marriott Convention Center, Pune'
 ): SeminarBillData => {
-  // Items that sum up to ₹4,468 (before 18% GST = ₹5,273) - HALF of original
-  const items: SeminarItem[] = [
-    { description: 'Conference Pass - Standard (1 Day)', quantity: 1, unitPrice: 2750, amount: 2750 },
-    { description: 'Workshop: AI Implementation Basics', quantity: 1, unitPrice: 1100, amount: 1100 },
-    { description: 'Networking Lunch', quantity: 1, unitPrice: 618, amount: 618 },
-  ];
-
-  const subtotal = 4468; // Fixed subtotal (half)
+  const registrationFee = 4468; // Fixed base amount (half)
   const cgst = 402.12; // 9%
   const sgst = 402.88; // 9%
   const totalAmount = 5273; // Fixed total (half)
@@ -316,16 +312,15 @@ export const generateSeminarBillData = (
     eventName,
     eventDate,
     eventVenue,
-    items,
-    subtotal: Math.round(subtotal * 100) / 100,
+    registrationFee: Math.round(registrationFee * 100) / 100,
     cgst: Math.round(cgst * 100) / 100,
     sgst: Math.round(sgst * 100) / 100,
     totalAmount: Math.round(totalAmount * 100) / 100,
+    companyName: 'TravelPlus Events Pvt. Ltd.',
+    companyAddress: '301, Business Park, Baner Road, Pune - 411045',
+    gstin: '27AABCT5678E1Z5',
     customerAddress: 'Row house 7, matra montana, dhanori, pune, maharastra',
-    corporateAddress: 'Hushh.ai, 1021 5th St W, Kirkland, WA 98033',
-    customerPhone: '+91 8004482372',
-    paymentStatus: 'PAID',
-    paymentMode: 'Bank Transfer',
+    customerContact: '+91 8004482372',
   };
 };
 
@@ -371,10 +366,9 @@ export const generateElectricityBillData = (
 ): ElectricityBillData => {
   const unitsConsumed = 285;
   const ratePerUnit = 7.50;
-  const energyCharge = unitsConsumed * ratePerUnit; // 2137.50
-  const fixedCharge = 150;
-  const fuelAdjustment = 85.50;
-  const electricityDuty = 99;
+  const energyCharges = unitsConsumed * ratePerUnit; // 2137.50
+  const fixedCharges = 150;
+  const electricityDuty = 184.50;
   const totalAmount = 2472; // Fixed total
 
   // Get billing period (current month)
@@ -392,16 +386,17 @@ export const generateElectricityBillData = (
     billNumber: generateElectricityBillNumber(),
     consumerNumber: generateConsumerNumber(),
     meterNumber: generateMeterNumber(),
+    connectionType: 'LT Residential',
+    billingPeriod: `${month} ${year}`,
     unitsConsumed,
     ratePerUnit,
-    energyCharge: Math.round(energyCharge * 100) / 100,
-    fixedCharge,
-    fuelAdjustment,
+    energyCharges: Math.round(energyCharges * 100) / 100,
+    fixedCharges,
     electricityDuty,
     totalAmount,
     dueDate,
-    connectionAddress: 'Row house 7, matra montana, dhanori, pune, maharastra',
-    billingPeriod: `${month} ${year}`,
+    customerAddress: 'Row house 7, matra montana, dhanori, pune, maharastra',
+    sanctionedLoad: '5 kW',
   };
 };
 
@@ -420,6 +415,16 @@ export const generateAICourseInvoiceNumber = (): string => {
 };
 
 /**
+ * Generate Enrollment ID
+ * Example: "ENR-2024-12345"
+ */
+export const generateEnrollmentId = (): string => {
+  const year = new Date().getFullYear();
+  const randomNum = Math.floor(10000 + Math.random() * 90000);
+  return `ENR-${year}-${randomNum}`;
+};
+
+/**
  * Generate AI Course Bill Data
  * Total: ₹2,800 (Base: ₹2,373 + GST 18%)
  */
@@ -427,14 +432,7 @@ export const generateAICourseBillData = (
   customerName: string,
   invoiceDate: Date
 ): AICourseBillData => {
-  // Items that sum up to ₹2,373 (before 18% GST = ₹2,800)
-  const items: CourseItem[] = [
-    { description: 'A2A Protocol Fundamentals Course', quantity: 1, unitPrice: 1500, amount: 1500 },
-    { description: 'Agent Communication Workshop', quantity: 1, unitPrice: 600, amount: 600 },
-    { description: 'Certification & Course Materials', quantity: 1, unitPrice: 273, amount: 273 },
-  ];
-
-  const subtotal = 2373; // Fixed subtotal
+  const courseFee = 2373; // Fixed base amount
   const cgst = 213.57; // 9%
   const sgst = 213.43; // 9%
   const totalAmount = 2800; // Fixed total
@@ -444,18 +442,19 @@ export const generateAICourseBillData = (
     invoiceDate,
     invoiceNumber: generateAICourseInvoiceNumber(),
     courseName: 'A2A Protocol & Agentic AI Masterclass',
-    courseProvider: 'AI Academy by Hushh.ai',
+    courseDescription: 'Complete course on Agent-to-Agent communication and Agentic AI development',
     courseDuration: '4 Weeks (16 Hours)',
-    items,
-    subtotal: Math.round(subtotal * 100) / 100,
+    courseFee: Math.round(courseFee * 100) / 100,
     cgst: Math.round(cgst * 100) / 100,
     sgst: Math.round(sgst * 100) / 100,
     totalAmount: Math.round(totalAmount * 100) / 100,
+    companyName: 'Hushh AI Academy',
+    companyAddress: '1021 5th St W, Kirkland, WA 98033',
+    gstin: '27AABCH9012F1ZQ',
     customerAddress: 'Row house 7, matra montana, dhanori, pune, maharastra',
-    corporateAddress: 'Hushh.ai, 1021 5th St W, Kirkland, WA 98033',
-    customerPhone: '+91 8004482372',
-    paymentStatus: 'PAID',
-    paymentMode: 'UPI',
+    customerEmail: 'ankitkumarsingh@gmail.com',
+    customerContact: '+91 8004482372',
+    enrollmentId: generateEnrollmentId(),
   };
 };
 


### PR DESCRIPTION
- WiFiBillCard: Black & White, A4 size, Times New Roman font
- FoodBillCard: Black & White, A4 size, official restaurant style
- SeminarBillCard: Black & White, A4 size, TravelPlus invoice format
- ElectricityBillCard: Black & White, A4 size, MSEDCL official style
- AICourseBillCard: Black & White, A4 size, AI Academy invoice
- receiptUtils.ts: Fixed interfaces to match simplified bill data types

All bills now look like official government/corporate receipts:
- A4 paper: 210mm x 297mm with 15mm padding
- Black text on white background only
- Times New Roman font for professional look
- TAX INVOICE headers, tables, Amount in Words, signatures