### PR TITLE
UI improvements for investor profile page

### DIFF
--- a/src/components/DeveloperSettings.tsx
+++ b/src/components/DeveloperSettings.tsx
@@ -1,20 +1,7 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Button,
-  Heading,
-  Text,
-  VStack,
-  HStack,
-  Icon,
-  IconButton,
-  useClipboard,
-  Collapse,
-  Code,
-  Divider,
-} from "@chakra-ui/react";
-import { ChevronDown, ChevronUp, Copy, Check, Terminal, Code as CodeIcon } from "lucide-react";
-import resources from "../resources/resources";
+import { useClipboard } from "@chakra-ui/react";
+import { Copy, Check, Terminal, Code as CodeIcon, ChevronDown, ChevronUp, Zap, ExternalLink } from "lucide-react";
+import hushhLogo from './images/Hushhogo.png';
 
 interface EndpointCardProps {
   title: string;
@@ -27,77 +14,61 @@ const EndpointCard: React.FC<EndpointCardProps> = ({ title, description, endpoin
   const { hasCopied, onCopy } = useClipboard(endpoint);
 
   return (
-    <Box
-      bg="#F8FAFC"
-      border="1px solid #E2E8F0"
-      borderRadius="12px"
-      p={4}
-      transition="all 0.2s ease"
-      _hover={{
-        borderColor: "#CBD5E1",
-        boxShadow: "0 2px 8px rgba(0,0,0,0.04)",
-      }}
-    >
-      <VStack align="stretch" spacing={3}>
-        <HStack justify="space-between" align="flex-start">
-          <VStack align="flex-start" spacing={1} flex={1}>
-            <HStack spacing={2}>
-              <Box
-                px={2}
-                py={0.5}
-                bg={method === "POST" ? "#FEF3C7" : "#DBEAFE"}
-                color={method === "POST" ? "#92400E" : "#1E40AF"}
-                borderRadius="6px"
-                fontSize="11px"
-                fontWeight="500"
-                letterSpacing="0.05em"
-              >
-                {method}
-              </Box>
-              <Text fontSize="15px" fontWeight="500" color="#0B1120">
-                {title}
-              </Text>
-            </HStack>
-            <Text fontSize="13px" color="#64748B" lineHeight="1.5">
-              {description}
-            </Text>
-          </VStack>
-        </HStack>
-
-        <Box
-          bg="white"
-          border="1px solid #E2E8F0"
-          borderRadius="8px"
-          p={3}
-          fontFamily="'Monaco', 'Menlo', monospace"
-        >
-          <HStack spacing={2} justify="space-between">
-            <Code
-              fontSize="12px"
-              color="#0F172A"
-              bg="transparent"
-              p={0}
-              flex={1}
-              wordBreak="break-all"
-              whiteSpace="pre-wrap"
+    <div className="bg-[#F9FAFB] rounded-xl p-4 border border-[#E5E7EB] hover:border-[#CBD5E1] hover:shadow-sm transition-all">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-1">
+            <span 
+              className={`px-2 py-0.5 text-[11px] font-semibold rounded-md ${
+                method === "POST" 
+                  ? "bg-amber-100 text-amber-800" 
+                  : "bg-blue-100 text-blue-800"
+              }`}
             >
-              {endpoint}
-            </Code>
-            <IconButton
-              aria-label="Copy endpoint"
-              icon={<Icon as={hasCopied ? Check : Copy} boxSize={4} />}
-              onClick={onCopy}
-              size="sm"
-              variant="ghost"
-              colorScheme={hasCopied ? "green" : "gray"}
-              minW="32px"
-              h="32px"
-              _hover={{ bg: "#F1F5F9" }}
-            />
-          </HStack>
-        </Box>
-      </VStack>
-    </Box>
+              {method}
+            </span>
+            <span className="text-[15px] font-medium text-[#111827]">{title}</span>
+          </div>
+          <p className="text-[13px] text-[#6B7280] leading-relaxed">{description}</p>
+        </div>
+      </div>
+      
+      <div className="bg-white rounded-lg border border-[#E5E7EB] p-3">
+        <div className="flex items-center gap-2">
+          <code className="flex-1 text-[12px] text-[#0F172A] font-mono break-all whitespace-pre-wrap">
+            {endpoint}
+          </code>
+          <button
+            onClick={onCopy}
+            className={`shrink-0 p-2 rounded-lg transition-colors ${
+              hasCopied 
+                ? "bg-green-50 text-green-600" 
+                : "hover:bg-slate-100 text-slate-400"
+            }`}
+            aria-label="Copy endpoint"
+          >
+            {hasCopied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Developer Avatar Component - matching chat design
+const DeveloperAvatar = ({ size = 'lg' }: { size?: 'sm' | 'md' | 'lg' }) => {
+  const sizeClasses = {
+    sm: 'w-8 h-8',
+    md: 'w-12 h-12',
+    lg: 'w-24 h-24'
+  };
+
+  return (
+    <div className="relative">
+      <div className={`${sizeClasses[size]} rounded-full overflow-hidden bg-gradient-to-br from-indigo-500 to-purple-600 shadow-lg border-2 border-indigo-500/20 flex items-center justify-center`}>
+        <Terminal className={`${size === 'lg' ? 'w-10 h-10' : 'w-5 h-5'} text-white`} />
+      </div>
+    </div>
   );
 };
 
@@ -106,8 +77,6 @@ interface DeveloperSettingsProps {
 }
 
 const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ investorSlug }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-
   // Get Supabase URL - use the actual deployed URL
   const supabaseUrl = "https://ibsisfnjxeowvdtvgzff.supabase.co";
   
@@ -139,96 +108,106 @@ const DeveloperSettings: React.FC<DeveloperSettingsProps> = ({ investorSlug }) =
   ];
 
   return (
-    <Box
-      bg="white"
-      border="1px solid #E2E8F0"
-      borderRadius="16px"
-      overflow="hidden"
-      boxShadow="0 1px 3px rgba(0,0,0,0.04)"
+    <div 
+      className="flex flex-col w-full h-full bg-white overflow-hidden" 
+      style={{ 
+        fontFamily: "'Inter', 'Manrope', sans-serif",
+        minHeight: 'calc(100vh - 180px)',
+      }}
     >
-      <Button
-        w="full"
-        onClick={() => setIsExpanded(!isExpanded)}
-        variant="ghost"
-        justifyContent="space-between"
-        p={5}
-        h="auto"
-        borderRadius={0}
-        _hover={{ bg: "#F8FAFC" }}
-        _active={{ bg: "#F1F5F9" }}
-      >
-        <HStack spacing={3}>
-          <Box
-            bg="linear-gradient(135deg, #6366F1 0%, #8B5CF6 100%)"
-            p={2}
-            borderRadius="10px"
+      {/* Header Section */}
+      <header className="flex flex-col bg-white pt-2 pb-2 sticky top-0 z-20 border-b border-slate-100">
+        {/* Top Bar */}
+        <div className="flex items-center justify-between px-4 h-14">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-bold text-slate-900 leading-tight">Developer Tools</h1>
+          </div>
+          <button 
+            onClick={() => window.open('https://docs.hushh.ai', '_blank')}
+            className="flex items-center justify-center px-3 py-2 rounded-lg text-[#2B8CEE] hover:bg-blue-50 transition-colors text-sm font-medium gap-1"
           >
-            <Icon as={Terminal} color="white" boxSize={5} />
-          </Box>
-          <VStack align="flex-start" spacing={0.5}>
-            <Text fontSize="16px" fontWeight="500" color="#0B1120">
-              Developer Settings
-            </Text>
-            <Text fontSize="13px" color="#64748B" fontWeight="500">
-              API endpoints for MCP integration
-            </Text>
-          </VStack>
-        </HStack>
-        <Icon
-          as={isExpanded ? ChevronUp : ChevronDown}
-          boxSize={5}
-          color="#64748B"
-          transition="transform 0.2s ease"
-        />
-      </Button>
+            <span>Docs</span>
+            <ExternalLink className="w-4 h-4" />
+          </button>
+        </div>
+        
+        {/* Status Badge */}
+        <div className="px-4 pb-2">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border border-purple-500/30 bg-purple-500/5 text-purple-600 text-sm font-semibold">
+            <Zap className="w-4 h-4" />
+            <span>MCP & A2A Ready</span>
+          </div>
+        </div>
+      </header>
 
-      <Collapse in={isExpanded} animateOpacity>
-        <Box p={5} pt={0}>
-          <Divider mb={4} />
+      {/* Main Content Area */}
+      <main className="flex-1 overflow-y-auto px-4 py-6 scroll-smooth">
+        
+        {/* Intro Section - matching chat empty state */}
+        <div className="flex flex-col items-center justify-center mb-8 mt-2">
+          {/* Avatar with glow effect */}
+          <div className="relative mb-6 group cursor-pointer">
+            <div className="absolute inset-0 bg-purple-500/20 rounded-full blur-xl opacity-50 group-hover:opacity-75 transition-opacity" />
+            <div className="relative">
+              <DeveloperAvatar size="lg" />
+            </div>
+          </div>
           
-          <VStack align="stretch" spacing={4}>
-            <Box
-              bg="#F0F9FF"
-              border="1px solid #BAE6FD"
-              borderRadius="10px"
-              p={4}
-            >
-              <HStack spacing={2} mb={2}>
-                <Icon as={CodeIcon} color="#0369A1" boxSize={4} />
-                <Text fontSize="14px" fontWeight="500" color="#0369A1">
-                  About MCP (Model Context Protocol)
-                </Text>
-              </HStack>
-              <Text fontSize="13px" color="#075985" lineHeight="1.6">
-                These endpoints enable AI agents to discover and interact with investor profiles.
-                The MCP standard allows agents to access structured data and tools for agent-to-agent
-                communication.
-              </Text>
-            </Box>
+          {/* Title - 22px, center, bold */}
+          <h2 
+            className="font-bold text-center text-slate-900 mb-2 max-w-[280px]"
+            style={{ fontSize: '22px', lineHeight: '1.3' }}
+          >
+            Integrate with Hushh
+          </h2>
+          
+          {/* Subtitle - 14px, center, gray */}
+          <p 
+            className="text-center text-slate-500 max-w-[300px] leading-relaxed"
+            style={{ fontSize: '14px' }}
+          >
+            Use these endpoints to enable AI agents to discover and interact with investor profiles.
+          </p>
+        </div>
 
-            {endpoints.map((endpoint, index) => (
-              <EndpointCard key={index} {...endpoint} />
-            ))}
+        {/* About MCP Section */}
+        <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 mb-6">
+          <div className="flex items-center gap-2 mb-2">
+            <CodeIcon className="w-4 h-4 text-blue-700" />
+            <span className="text-[14px] font-semibold text-blue-700">About MCP (Model Context Protocol)</span>
+          </div>
+          <p className="text-[13px] text-blue-800 leading-relaxed">
+            These endpoints enable AI agents to discover and interact with investor profiles.
+            The MCP standard allows agents to access structured data and tools for agent-to-agent
+            communication.
+          </p>
+        </div>
 
-            <Box
-              bg="#FEF3C7"
-              border="1px solid #FDE68A"
-              borderRadius="10px"
-              p={4}
-              mt={2}
-            >
-              <Text fontSize="12px" fontWeight="500" color="#92400E" mb={2}>
-                📝 Note:
-              </Text>
-              <Text fontSize="12px" color="#92400E" lineHeight="1.6">
-                All endpoints are public and don't require authentication. The chat endpoint accepts
-                POST requests with a JSON body containing: <Code fontSize="11px">{"{ message: string }"}</Code>
-              </Text>
-            </Box>
-          </VStack>
-        </Box>
-      </Collapse>
-    </Box>
+        {/* Endpoints Section */}
+        <div className="space-y-4 mb-6">
+          <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wider">API Endpoints</h3>
+          {endpoints.map((endpoint, index) => (
+            <EndpointCard key={index} {...endpoint} />
+          ))}
+        </div>
+
+        {/* Note Section */}
+        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+          <p className="text-[12px] font-semibold text-amber-800 mb-2">📝 Note:</p>
+          <p className="text-[12px] text-amber-800 leading-relaxed">
+            All endpoints are public and don't require authentication. The chat endpoint accepts
+            POST requests with a JSON body containing: <code className="bg-amber-100 px-1.5 py-0.5 rounded text-[11px]">{"{ message: string }"}</code>
+          </p>
+        </div>
+      </main>
+
+      {/* Footer Section */}
+      <footer className="bg-white px-4 py-4 border-t border-slate-200 relative z-20">
+        <p className="text-center text-[11px] text-slate-400 font-medium">
+          Powered by Hushh MCP Protocol
+        </p>
+      </footer>
+    </div>
   );
 };
 

--- a/src/components/FloatingContactBubble.tsx
+++ b/src/components/FloatingContactBubble.tsx
@@ -2,6 +2,7 @@ import { Box, Icon, Tooltip } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { Mail } from 'lucide-react';
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 
 /**
  * FloatingContactBubble component
@@ -14,9 +15,19 @@ import React from 'react';
 const MotionBox = motion(Box);
 
 export default function FloatingContactBubble() {
+  const location = useLocation();
+  
+  // Hide on investor profile pages (chat and developer sections have their own layout)
+  const isInvestorProfilePage = location.pathname.startsWith('/investor/');
+  
   const handleClick = () => {
     window.location.href = 'mailto:invest@hushh.ai';
   };
+
+  // Don't render on investor profile pages
+  if (isInvestorProfilePage) {
+    return null;
+  }
 
   return (
     <Tooltip 

--- a/src/pages/investor/PublicInvestorProfile.tsx
+++ b/src/pages/investor/PublicInvestorProfile.tsx
@@ -29,6 +29,14 @@ const PublicInvestorProfilePage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<TabType>('home');
   const [expandedFields, setExpandedFields] = useState<Set<string>>(new Set());
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  // Handle tab change with scroll to top
+  const handleTabChange = (tab: TabType) => {
+    setActiveTab(tab);
+    // Scroll to top of viewport
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
   
   const profileUrl = `https://hushhtech.com/investor/${slug}`;
   const { hasCopied, onCopy } = useClipboard(profileUrl);
@@ -486,7 +494,7 @@ const PublicInvestorProfilePage: React.FC = () => {
           <nav className="fixed bottom-0 left-0 right-0 bg-black border-t border-gray-800 z-20">
             <div className="max-w-md mx-auto flex items-center justify-around py-2 px-4 safe-bottom">
               <button
-                onClick={() => setActiveTab('home')}
+                onClick={() => handleTabChange('home')}
                 className={`flex flex-col items-center gap-1 py-2 px-4 rounded-lg transition-colors ${
                   activeTab === 'home' 
                     ? 'text-[#2B8CEE]' 
@@ -497,7 +505,7 @@ const PublicInvestorProfilePage: React.FC = () => {
                 <span className="text-xs font-medium">Home</span>
               </button>
               <button
-                onClick={() => setActiveTab('chat')}
+                onClick={() => handleTabChange('chat')}
                 className={`flex flex-col items-center gap-1 py-2 px-4 rounded-lg transition-colors ${
                   activeTab === 'chat' 
                     ? 'text-[#2B8CEE]' 
@@ -508,7 +516,7 @@ const PublicInvestorProfilePage: React.FC = () => {
                 <span className="text-xs font-medium">Chat</span>
               </button>
               <button
-                onClick={() => setActiveTab('developer')}
+                onClick={() => handleTabChange('developer')}
                 className={`flex flex-col items-center gap-1 py-2 px-4 rounded-lg transition-colors ${
                   activeTab === 'developer' 
                     ? 'text-[#2B8CEE]' 


### PR DESCRIPTION
- Add scroll to top when switching tabs (Home/Chat/Developer)
- Hide floating email button on investor profile pages
- Revamp Developer Settings UI to match chat design pattern
  - Full viewport layout with header/main/footer structure
  - Title: 22px, center aligned, bold with avatar
  - Clean endpoint cards with copy functionality
  - MCP & A2A Ready status badge
- Chat widget uses local Hushh logo and full viewport