### PR TITLE
test: Verify email notification after edge function deployment

### DIFF
--- a/TEST_WEBHOOK_NOTIFICATION.md
+++ b/TEST_WEBHOOK_NOTIFICATION.md
@@ -1,5 +1,11 @@
-# Email Notification Test
+# Edge Function Deployment Verification
 
-This PR tests the updated email notification system.
+Edge function `github-devops-notify` redeployed at Fri Dec 26 21:30:15 IST 2025
 
-Recipients: manish@, neelesh1@, ankit@, i-akshat@, suresh@
+## Fix Applied
+- Deployed updated template.ts with professional email design
+- Fixed: Emails not sending after PR #196, #197
+
+## Test
+This PR verifies the email notification system is working.
+


### PR DESCRIPTION
## Fix Applied

Edge function github-devops-notify was redeployed with the updated template.

### Problem
- PR #196, #197 ke baad emails nahi aa rahe the
- Template GitHub pe update ho gaya tha lekin Edge Function redeploy nahi hua tha

### Solution  
- Redeployed the Edge Function with new professional email template
- New template has table-based HTML for Gmail compatibility

### Expected
This PR merge should trigger email to all 5 team members.