### PR TITLE
chore: update SalesNotification logo URL comment

### DIFF
--- a/cloud-run/email-template-api/emails/SalesNotification.js
+++ b/cloud-run/email-template-api/emails/SalesNotification.js
@@ -22,7 +22,7 @@ export function SalesNotification(input = {}) {
   const subject = escapeHtml(d.subject ?? "Hushh Technologies — Investment Opportunity");
   const recipientName = escapeHtml(d.recipientName ?? "");
   
-  // Supabase-hosted Hushh logo
+  // Supabase-hosted Hushh logo (new design with "shush" gesture)
   const logoUrl = escapeHtml(
     d.logoUrl ?? "https://ibsisfnjxeowvdtvgzff.supabase.co/storage/v1/object/public/assets/hushh-logo.png"
   );


### PR DESCRIPTION
Updates the SalesNotification.js email template with improved comment for the Hushh logo URL.

## Changes
- Updated logo URL comment to clarify it's the new design with 'shush' gesture
- Logo URL: https://ibsisfnjxeowvdtvgzff.supabase.co/storage/v1/object/public/assets/hushh-logo.png