### PR TITLE
feat: Update Agent Mailer UI with sticky footer and proper header

### DIFF
--- a/src/pages/hushh-agent-mailer/index.tsx
+++ b/src/pages/hushh-agent-mailer/index.tsx
@@ -1,33 +1,16 @@
 /**
  * Hushh Agent Mailer Dashboard
- * Professional Mobile-First Design with Clean UI
+ * Professional Mobile-First Design with Sticky Footer like Onboarding
  * 
  * Flow: Dashboard → Supabase Edge Function → Cloud Run → Gmail API
  * Route: /hushh-agent-mailer (protected - requires authentication)
  */
 
-import React, { useState } from "react";
-import {
-  Box,
-  VStack,
-  HStack,
-  Text,
-  Textarea,
-  Button,
-  useToast,
-  Icon,
-  Collapse,
-  Spinner,
-  Badge,
-  Table,
-  Thead,
-  Tbody,
-  Tr,
-  Th,
-  Td,
-} from "@chakra-ui/react";
-import { ChevronRightIcon, LockIcon, CheckCircleIcon, RepeatIcon } from "@chakra-ui/icons";
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useToast, Spinner, Badge } from "@chakra-ui/react";
 import { createClient } from "@supabase/supabase-js";
+import { useFooterVisibility } from "../../utils/useFooterVisibility";
 
 // Supabase client
 const supabase = createClient(
@@ -80,23 +63,50 @@ const SENDER_OPTIONS = [
   { email: "neelesh@hushh.ai", name: "Neelesh Meena" },
 ];
 
-// Design tokens matching Tailwind config
-const colors = {
-  primary: "#2f80ed",
-  matteBlack: "#1a1a1a",
-  charcoal: "#4a4a4a",
-  offGrey: "#f5f5f7",
-  borderGrey: "#e5e5e5",
-  gray100: "#F3F4F6",
-  gray400: "#9CA3AF",
-  gray500: "#6B7280",
-};
+// Back arrow icon
+const BackIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M19 12H5M12 19l-7-7 7-7" />
+  </svg>
+);
+
+// Help icon
+const HelpIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+    <line x1="12" y1="17" x2="12.01" y2="17" />
+  </svg>
+);
+
+// Material Symbols Component
+const MaterialIcon: React.FC<{ name: string; filled?: boolean; className?: string }> = ({ 
+  name, 
+  filled = false, 
+  className = "" 
+}) => (
+  <span 
+    className={`material-symbols-outlined ${className}`}
+    style={{ 
+      fontVariationSettings: `'FILL' ${filled ? 1 : 0}, 'wght' 500` 
+    }}
+  >
+    {name}
+  </span>
+);
 
 const HushhAgentMailerPage: React.FC = () => {
+  const navigate = useNavigate();
   const toast = useToast();
+  const isFooterVisible = useFooterVisibility();
+  
+  // Scroll to top on mount
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   
   // View state
-  const [activeView, setActiveView] = useState<"compose" | "logs">("compose");
+  const [activeView, setActiveView] = useState<"compose" | "history">("compose");
   
   // Form state
   const [fromEmail, setFromEmail] = useState(SENDER_OPTIONS[0].email);
@@ -209,597 +219,327 @@ const HushhAgentMailerPage: React.FC = () => {
   };
 
   return (
-    <Box
-      bg="white"
-      minH="100vh"
-      fontFamily="'Inter', sans-serif"
-      display="flex"
-      flexDirection="column"
-      alignItems="center"
-      justifyContent={{ base: "flex-start", sm: "center" }}
-      py={{ base: 0, sm: 8 }}
-    >
-      <Box
-        w="full"
-        maxW="md"
-        mx="auto"
-        minH={{ base: "100vh", sm: "auto" }}
-        display="flex"
-        flexDirection="column"
-        p={5}
-        bg="white"
-        borderRadius={{ base: 0, sm: "2xl" }}
-        boxShadow={{ base: "none", sm: "0 2px 8px rgba(0, 0, 0, 0.04)" }}
-        border={{ base: "none", sm: "1px solid" }}
-        borderColor={{ base: "transparent", sm: "gray.100" }}
+    <>
+      {/* Add Google Material Symbols font */}
+      <link 
+        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" 
+        rel="stylesheet" 
+      />
+      
+      <div 
+        className="bg-slate-50 min-h-screen"
+        style={{ fontFamily: "'Manrope', sans-serif" }}
       >
-        {/* Header */}
-        <Box mb={6}>
-          <VStack spacing={2} mb={3} align="flex-start">
-            <Text
-              fontSize="2xl"
-              fontWeight="bold"
-              letterSpacing="tight"
-              color={colors.matteBlack}
+        <div className="relative flex min-h-screen w-full flex-col bg-white max-w-[500px] mx-auto shadow-xl overflow-hidden border-x border-slate-100">
+          
+          {/* Sticky Header - Like Investor Profile */}
+          <header className="flex items-center justify-between px-4 pt-4 pb-3 bg-white sticky top-0 z-10 border-b border-slate-100">
+            <button 
+              onClick={() => navigate(-1)}
+              aria-label="Go back"
+              className="flex size-10 shrink-0 items-center justify-center text-slate-900 rounded-full hover:bg-slate-50 transition-colors"
             >
+              <BackIcon />
+            </button>
+            <h1 className="text-base font-semibold text-slate-900">
               Hushh Agent Mailer
-            </Text>
-            <HStack spacing={2}>
-              <Box
-                px={2.5}
-                py={1}
-                borderRadius="full"
-                fontSize="10px"
-                fontWeight="bold"
-                textTransform="uppercase"
-                letterSpacing="wider"
-                bg={colors.primary}
-                color="white"
-                boxShadow="sm"
-              >
-                AGENTIC
-              </Box>
-              <Box
-                px={2.5}
-                py={1}
-                borderRadius="full"
-                fontSize="10px"
-                fontWeight="bold"
-                textTransform="uppercase"
-                letterSpacing="wider"
-                border="1px solid"
-                borderColor={colors.primary}
-                color={colors.primary}
-                bg="white"
-                boxShadow="sm"
-              >
-                FUND A
-              </Box>
-            </HStack>
-          </VStack>
-          <Text
-            color={colors.charcoal}
-            fontSize="sm"
-            lineHeight="relaxed"
-            borderLeft="3px solid"
-            borderColor={colors.primary}
-            pl={3}
-            py={0.5}
-          >
-            Send personalized bulk emails to investors and leads using AI-powered templates.
-          </Text>
-        </Box>
-
-        {/* Compose/Logs Toggle */}
-        <HStack spacing={3} mb={6}>
-          <Button
-            flex={1}
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            gap={2}
-            px={4}
-            py={2.5}
-            borderRadius="lg"
-            bg={activeView === "compose" ? colors.primary : "white"}
-            color={activeView === "compose" ? "white" : colors.charcoal}
-            border={activeView === "compose" ? "none" : "1px solid"}
-            borderColor={colors.borderGrey}
-            fontWeight="medium"
-            fontSize="sm"
-            boxShadow={activeView === "compose" ? "0 4px 14px 0 rgba(47, 128, 237, 0.3)" : "none"}
-            _hover={{
-              bg: activeView === "compose" ? "#2563eb" : colors.offGrey,
-              color: activeView === "compose" ? "white" : colors.matteBlack,
-            }}
-            transition="all 0.2s"
-            _active={{ transform: "scale(0.95)" }}
-            onClick={() => setActiveView("compose")}
-          >
-            <Box as="span" fontSize="18px">✏️</Box>
-            Compose
-          </Button>
-          <Button
-            flex="none"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            gap={2}
-            px={4}
-            py={2.5}
-            borderRadius="lg"
-            bg={activeView === "logs" ? colors.primary : "white"}
-            color={activeView === "logs" ? "white" : colors.charcoal}
-            border={activeView === "logs" ? "none" : "1px solid"}
-            borderColor={colors.borderGrey}
-            fontWeight="medium"
-            fontSize="sm"
-            boxShadow={activeView === "logs" ? "0 4px 14px 0 rgba(47, 128, 237, 0.3)" : "none"}
-            _hover={{
-              bg: activeView === "logs" ? "#2563eb" : colors.offGrey,
-              color: activeView === "logs" ? "white" : colors.matteBlack,
-            }}
-            transition="all 0.2s"
-            onClick={() => {
-              setActiveView("logs");
-              fetchLogs();
-            }}
-          >
-            <Box as="span" fontSize="18px">🕐</Box>
-            Logs
-          </Button>
-        </HStack>
-
-        {/* Main Content */}
-        <Box flex={1}>
-          {activeView === "compose" ? (
-            <VStack spacing={5} align="stretch">
-              {/* From Email */}
-              <VStack spacing={1.5} align="stretch">
-                <Text
-                  fontSize="xs"
-                  fontWeight="bold"
-                  textTransform="uppercase"
-                  letterSpacing="wide"
-                  color={colors.charcoal}
-                >
-                  From Email
-                </Text>
-                <Box position="relative">
-                  <Box
-                    as="select"
-                    w="full"
-                    pl={3.5}
-                    pr={10}
-                    py={3}
-                    borderRadius="lg"
-                    bg={colors.offGrey}
-                    border="1px solid transparent"
-                    color={colors.matteBlack}
-                    fontWeight="medium"
-                    fontSize="sm"
-                    cursor="pointer"
-                    appearance="none"
-                    _hover={{ borderColor: colors.borderGrey }}
-                    _focus={{
-                      ring: 1,
-                      ringColor: colors.primary,
-                      borderColor: colors.primary,
-                      bg: "white",
-                    }}
-                    transition="all 0.2s"
-                    outline="none"
-                    value={fromEmail}
-                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setFromEmail(e.target.value)}
-                  >
-                    {SENDER_OPTIONS.map((sender) => (
-                      <option key={sender.email} value={sender.email}>
-                        {sender.name} ({sender.email})
-                      </option>
-                    ))}
-                  </Box>
-                  <Box
-                    position="absolute"
-                    top="50%"
-                    right={3}
-                    transform="translateY(-50%)"
-                    pointerEvents="none"
-                    color={colors.charcoal}
-                  >
-                    <Text fontSize="lg">▾</Text>
-                  </Box>
-                </Box>
-                <HStack spacing={1.5} px={1}>
-                  <Icon as={CheckCircleIcon} boxSize="14px" color={colors.primary} />
-                  <Text fontSize="10px" color={colors.gray500} fontWeight="medium">
-                    Authenticated via Gmail Domain-Wide Delegation
-                  </Text>
-                </HStack>
-              </VStack>
-
-              {/* Recipients */}
-              <VStack spacing={1.5} align="stretch">
-                <HStack justify="space-between">
-                  <Text
-                    fontSize="xs"
-                    fontWeight="bold"
-                    textTransform="uppercase"
-                    letterSpacing="wide"
-                    color={colors.charcoal}
-                  >
-                    Recipients
-                  </Text>
-                  {recipientCount > 0 && (
-                    <Box
-                      px={2}
-                      py={0.5}
-                      borderRadius="md"
-                      fontSize="10px"
-                      fontWeight="bold"
-                      bg="blue.50"
-                      color={colors.primary}
-                      border="1px solid"
-                      borderColor="rgba(47, 128, 237, 0.2)"
-                    >
-                      {recipientCount} RECIPIENT{recipientCount !== 1 ? "S" : ""}
-                    </Box>
-                  )}
-                </HStack>
-                <Box position="relative">
-                  <Textarea
-                    w="full"
-                    p={3.5}
-                    borderRadius="lg"
-                    bg={colors.offGrey}
-                    border="1px solid transparent"
-                    color={colors.matteBlack}
-                    fontFamily="mono"
-                    fontSize="sm"
-                    placeholder="Enter email addresses..."
-                    _placeholder={{ color: colors.gray400 }}
-                    _hover={{ borderColor: colors.borderGrey }}
-                    _focus={{
-                      ring: 1,
-                      ringColor: colors.primary,
-                      borderColor: colors.primary,
-                      bg: "white",
-                    }}
-                    transition="all 0.2s"
-                    outline="none"
-                    resize="none"
-                    rows={4}
-                    lineHeight="relaxed"
-                    value={toEmails}
-                    onChange={(e) => setToEmails(e.target.value)}
-                  />
-                  <Box position="absolute" bottom={3} right={3}>
-                    <HStack
-                      spacing={1}
-                      bg="white"
-                      px={2}
-                      py={1}
-                      borderRadius="md"
-                      border="1px solid"
-                      borderColor="rgba(47, 128, 237, 0.3)"
-                      boxShadow="sm"
-                      fontSize="10px"
-                      fontWeight="bold"
-                      color={colors.primary}
-                    >
-                      <Text>✨</Text>
-                      <Text>AI PARSING</Text>
-                    </HStack>
-                  </Box>
-                </Box>
-                <Text fontSize="10px" color={colors.gray400} px={1}>
-                  Comma-separated addresses.
-                </Text>
-              </VStack>
-
-              {/* Divider */}
-              <Box h="1px" w="full" bg={colors.borderGrey} />
-
-              {/* Template Customization */}
-              <Box
-                cursor="pointer"
-                borderRadius="lg"
-                border="1px solid"
-                borderColor={colors.borderGrey}
-                p={3}
-                _hover={{
-                  borderColor: colors.primary,
-                  bg: "rgba(47, 128, 237, 0.03)",
-                }}
-                transition="all 0.2s"
-                onClick={() => setShowAdvanced(!showAdvanced)}
-                role="group"
-              >
-                <HStack justify="space-between">
-                  <HStack spacing={3}>
-                    <Box
-                      p={2}
-                      bg="blue.50"
-                      borderRadius="md"
-                      color={colors.primary}
-                      _groupHover={{ bg: colors.primary, color: "white" }}
-                      transition="all 0.2s"
-                    >
-                      <Text fontSize="18px">⚙️</Text>
-                    </Box>
-                    <VStack spacing={0} align="flex-start">
-                      <Text
-                        fontSize="sm"
-                        fontWeight="semibold"
-                        color={colors.matteBlack}
-                        _groupHover={{ color: colors.primary }}
-                        transition="all 0.2s"
-                      >
-                        Template Customization
-                      </Text>
-                      <Text fontSize="10px" color={colors.gray500}>
-                        Edit variables and layout
-                      </Text>
-                    </VStack>
-                  </HStack>
-                  <Icon
-                    as={ChevronRightIcon}
-                    color={colors.gray400}
-                    _groupHover={{ color: colors.primary }}
-                    transform={showAdvanced ? "rotate(90deg)" : "rotate(0deg)"}
-                    transition="all 0.3s"
-                  />
-                </HStack>
-              </Box>
-
-              {/* Advanced Options */}
-              <Collapse in={showAdvanced} animateOpacity>
-                <VStack spacing={3} pt={2} align="stretch">
-                  <HStack spacing={3}>
-                    <VStack flex={1} spacing={1} align="stretch">
-                      <Text fontSize="10px" fontWeight="bold" color={colors.charcoal} textTransform="uppercase">
-                        Badge Text
-                      </Text>
-                      <Box
-                        as="input"
-                        type="text"
-                        value={badgeText}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBadgeText(e.target.value)}
-                        px={3}
-                        py={2}
-                        borderRadius="md"
-                        bg={colors.offGrey}
-                        border="1px solid transparent"
-                        fontSize="sm"
-                        _focus={{ borderColor: colors.primary, bg: "white" }}
-                      />
-                    </VStack>
-                    <VStack flex={1} spacing={1} align="stretch">
-                      <Text fontSize="10px" fontWeight="bold" color={colors.charcoal} textTransform="uppercase">
-                        Subtitle
-                      </Text>
-                      <Box
-                        as="input"
-                        type="text"
-                        value={subtitle}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSubtitle(e.target.value)}
-                        px={3}
-                        py={2}
-                        borderRadius="md"
-                        bg={colors.offGrey}
-                        border="1px solid transparent"
-                        fontSize="sm"
-                        _focus={{ borderColor: colors.primary, bg: "white" }}
-                      />
-                    </VStack>
-                  </HStack>
-                  <VStack spacing={1} align="stretch">
-                    <Text fontSize="10px" fontWeight="bold" color={colors.charcoal} textTransform="uppercase">
-                      Intro Highlight
-                    </Text>
-                    <Box
-                      as="input"
-                      type="text"
-                      value={introHighlight}
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setIntroHighlight(e.target.value)}
-                      px={3}
-                      py={2}
-                      borderRadius="md"
-                      bg={colors.offGrey}
-                      border="1px solid transparent"
-                      fontSize="sm"
-                      _focus={{ borderColor: colors.primary, bg: "white" }}
-                    />
-                  </VStack>
-                  <HStack spacing={3}>
-                    <VStack flex={1} spacing={1} align="stretch">
-                      <Text fontSize="10px" fontWeight="bold" color={colors.charcoal} textTransform="uppercase">
-                        CTA Text
-                      </Text>
-                      <Box
-                        as="input"
-                        type="text"
-                        value={ctaText}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCtaText(e.target.value)}
-                        px={3}
-                        py={2}
-                        borderRadius="md"
-                        bg={colors.offGrey}
-                        border="1px solid transparent"
-                        fontSize="sm"
-                        _focus={{ borderColor: colors.primary, bg: "white" }}
-                      />
-                    </VStack>
-                    <VStack flex={1} spacing={1} align="stretch">
-                      <Text fontSize="10px" fontWeight="bold" color={colors.charcoal} textTransform="uppercase">
-                        CTA URL
-                      </Text>
-                      <Box
-                        as="input"
-                        type="text"
-                        value={ctaUrl}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setCtaUrl(e.target.value)}
-                        px={3}
-                        py={2}
-                        borderRadius="md"
-                        bg={colors.offGrey}
-                        border="1px solid transparent"
-                        fontSize="sm"
-                        _focus={{ borderColor: colors.primary, bg: "white" }}
-                      />
-                    </VStack>
-                  </HStack>
-                </VStack>
-              </Collapse>
-
-              {/* Results */}
-              {results && (
-                <Box
-                  p={4}
-                  borderRadius="lg"
-                  border="1px solid"
-                  borderColor={colors.borderGrey}
-                  bg={colors.offGrey}
-                >
-                  <HStack justify="space-between" mb={3}>
-                    <Text fontWeight="semibold" color={colors.matteBlack}>
-                      Results
-                    </Text>
-                    <HStack spacing={2}>
-                      <Badge colorScheme="green" px={2} py={0.5}>
-                        ✓ Sent: {results.summary.sent}
-                      </Badge>
-                      {results.summary.failed > 0 && (
-                        <Badge colorScheme="red" px={2} py={0.5}>
-                          ✗ Failed: {results.summary.failed}
-                        </Badge>
-                      )}
-                    </HStack>
-                  </HStack>
-                  <VStack spacing={2} align="stretch" maxH="200px" overflowY="auto">
-                    {results.results.map((result, idx) => (
-                      <HStack key={idx} justify="space-between" fontSize="sm">
-                        <Text color={colors.charcoal} isTruncated maxW="60%">
-                          {result.email}
-                        </Text>
-                        <Badge colorScheme={result.success ? "green" : "red"} size="sm">
-                          {result.success ? "Sent" : "Failed"}
-                        </Badge>
-                      </HStack>
-                    ))}
-                  </VStack>
-                </Box>
-              )}
-            </VStack>
-          ) : (
-            /* Logs View */
-            <VStack spacing={4} align="stretch">
-              <HStack justify="space-between">
-                <Text fontWeight="semibold" color={colors.matteBlack}>
-                  Email Logs
-                </Text>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={fetchLogs}
-                  isLoading={isLoadingLogs}
-                  leftIcon={<RepeatIcon />}
-                >
-                  Refresh
-                </Button>
-              </HStack>
-              {isLoadingLogs ? (
-                <Box textAlign="center" py={8}>
-                  <Spinner color={colors.primary} />
-                </Box>
-              ) : emailLogs.length === 0 ? (
-                <Text color={colors.gray500} textAlign="center" py={8}>
-                  No emails sent yet. Send your first email!
-                </Text>
-              ) : (
-                <Box overflowX="auto">
-                  <Table variant="simple" size="sm">
-                    <Thead>
-                      <Tr>
-                        <Th color={colors.gray500} borderColor={colors.borderGrey}>Recipient</Th>
-                        <Th color={colors.gray500} borderColor={colors.borderGrey}>Status</Th>
-                        <Th color={colors.gray500} borderColor={colors.borderGrey}>Sent</Th>
-                      </Tr>
-                    </Thead>
-                    <Tbody>
-                      {emailLogs.map((log) => (
-                        <Tr key={log.id}>
-                          <Td color={colors.matteBlack} borderColor={colors.borderGrey} fontSize="sm">
-                            {log.recipient_name || log.recipient_email}
-                          </Td>
-                          <Td borderColor={colors.borderGrey}>
-                            <Badge colorScheme={log.status === 'SENT' ? 'green' : 'red'} size="sm">
-                              {log.status}
-                            </Badge>
-                          </Td>
-                          <Td color={colors.gray500} borderColor={colors.borderGrey} fontSize="xs">
-                            {new Date(log.created_at).toLocaleDateString()}
-                          </Td>
-                        </Tr>
-                      ))}
-                    </Tbody>
-                  </Table>
-                </Box>
-              )}
-            </VStack>
-          )}
-        </Box>
-
-        {/* Footer CTA */}
-        {activeView === "compose" && (
-          <Box
-            mt="auto"
-            pt={4}
-            position={{ base: "sticky", sm: "static" }}
-            bottom={0}
-            bg={{ base: "rgba(255,255,255,0.9)", sm: "transparent" }}
-            backdropFilter={{ base: "blur(8px)", sm: "none" }}
-            pb={{ base: 24, sm: 0 }}
-            borderTop={{ base: "1px solid", sm: "none" }}
-            borderColor={{ base: colors.borderGrey, sm: "transparent" }}
-            mx={{ base: -5, sm: 0 }}
-            px={{ base: 5, sm: 0 }}
-          >
-            <Button
-              w="full"
-              bg={colors.primary}
-              color="white"
-              fontWeight="bold"
-              py={3.5}
-              h="auto"
-              borderRadius="xl"
-              boxShadow="0 4px 14px 0 rgba(47, 128, 237, 0.3)"
-              fontSize="15px"
-              _hover={{ bg: "#2563eb", boxShadow: "lg" }}
-              transition="all 0.3s"
-              onClick={handleSend}
-              isLoading={isLoading}
-              loadingText={`Sending to ${recipientCount} recipient${recipientCount !== 1 ? "s" : ""}...`}
-              isDisabled={recipientCount === 0}
-              rightIcon={<Text fontSize="lg">➤</Text>}
-              _disabled={{ bg: colors.primary, opacity: 0.5, cursor: "not-allowed" }}
+            </h1>
+            <button 
+              className="flex size-10 shrink-0 items-center justify-center text-slate-900 rounded-full hover:bg-slate-50 transition-colors"
+              aria-label="Help"
             >
-              Send to {recipientCount} Recipient{recipientCount !== 1 ? "s" : ""}
-            </Button>
-            <VStack mt={4} spacing={1}>
-              <HStack spacing={1.5} opacity={0.6}>
-                <Icon as={LockIcon} boxSize="12px" color={colors.matteBlack} />
-                <Text fontSize="9px" textTransform="uppercase" letterSpacing="widest" color={colors.matteBlack} fontWeight="semibold">
+              <HelpIcon />
+            </button>
+          </header>
+
+          {/* Main Content - with padding for sticky footer */}
+          <main className="flex-1 flex flex-col px-6 pb-52">
+            {/* Badges & Description */}
+            <div className="flex flex-col items-center text-center mt-6 mb-6 space-y-4">
+              <div className="flex space-x-2">
+                <span className="px-4 py-1.5 rounded-full bg-[#2b8cee] text-white text-[11px] font-bold tracking-wider uppercase shadow-sm">
+                  Agentic
+                </span>
+                <span className="px-4 py-1.5 rounded-full bg-[#2b8cee] text-white text-[11px] font-bold tracking-wider uppercase shadow-sm">
+                  Fund A
+                </span>
+              </div>
+              <p className="text-slate-500 text-sm font-medium leading-relaxed max-w-[300px]">
+                Send personalized bulk emails to investors using AI-powered templates.
+              </p>
+            </div>
+
+            {/* Compose/History Toggle */}
+            <div className="flex gap-3 mb-6">
+              <button 
+                onClick={() => setActiveView("compose")}
+                className={`flex-1 rounded-xl py-3 px-4 flex items-center justify-center space-x-2 transition-all active:scale-95 shadow-sm ${
+                  activeView === "compose" 
+                    ? "bg-[#2b8cee] text-white" 
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+              >
+                <MaterialIcon name="edit_square" className="text-[20px]" />
+                <span className="text-sm font-bold">Compose</span>
+              </button>
+              <button 
+                onClick={() => {
+                  setActiveView("history");
+                  fetchLogs();
+                }}
+                className={`flex-1 rounded-xl py-3 px-4 flex items-center justify-center space-x-2 transition-all active:scale-95 shadow-sm ${
+                  activeView === "history" 
+                    ? "bg-[#2b8cee] text-white" 
+                    : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                }`}
+              >
+                <MaterialIcon name="history" className="text-[20px]" />
+                <span className="text-sm font-semibold">History</span>
+              </button>
+            </div>
+
+            {activeView === "compose" ? (
+              <div className="flex flex-col gap-5 w-full">
+                {/* Sender Account Section */}
+                <div>
+                  <div className="flex justify-between items-center mb-2 px-0.5">
+                    <label className="text-[11px] font-bold text-slate-900 uppercase tracking-widest">
+                      Sender Account
+                    </label>
+                    <div className="flex items-center space-x-1 text-slate-500">
+                      <MaterialIcon name="check_circle" filled className="text-[14px] text-green-600" />
+                      <span className="text-[10px] font-bold uppercase tracking-wide">Authenticated</span>
+                    </div>
+                  </div>
+                  <div className="relative">
+                    <div className="absolute inset-y-0 left-4 flex items-center pointer-events-none">
+                      <MaterialIcon name="account_circle" className="text-slate-400 text-[20px]" />
+                    </div>
+                    <select 
+                      className="w-full appearance-none bg-slate-100 hover:bg-slate-200 text-slate-900 rounded-2xl py-4 pl-11 pr-10 text-sm font-medium outline-none transition-all cursor-pointer border-2 border-transparent focus:border-[#2b8cee]"
+                      value={fromEmail}
+                      onChange={(e) => setFromEmail(e.target.value)}
+                    >
+                      {SENDER_OPTIONS.map((sender) => (
+                        <option key={sender.email} value={sender.email}>
+                          {sender.name} ({sender.email})
+                        </option>
+                      ))}
+                    </select>
+                    <div className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-400">
+                      <MaterialIcon name="expand_more" className="text-[20px]" />
+                    </div>
+                  </div>
+                  <p className="mt-1.5 text-[10px] text-slate-400 px-0.5">Via Gmail Domain-Wide Delegation</p>
+                </div>
+
+                {/* Recipients Section */}
+                <div>
+                  <label className="block text-[11px] font-bold text-slate-900 uppercase tracking-widest mb-2 px-0.5">
+                    Recipients
+                  </label>
+                  <div className="relative bg-slate-100 rounded-2xl hover:bg-slate-50 transition-colors border-2 border-transparent focus-within:border-[#2b8cee]">
+                    <textarea 
+                      className="w-full h-36 bg-transparent rounded-2xl p-4 text-sm font-medium text-slate-900 placeholder-slate-400 outline-none resize-none border-none"
+                      placeholder="investor1@company.com, investor2@fund.com"
+                      value={toEmails}
+                      onChange={(e) => setToEmails(e.target.value)}
+                    />
+                    <div className="absolute bottom-3 right-3 z-10">
+                      <button className="flex items-center space-x-1.5 bg-[#2b8cee] text-white px-3 py-2 rounded-xl shadow-lg transition-all active:scale-95 hover:bg-blue-600">
+                        <MaterialIcon name="auto_awesome" filled className="text-[14px]" />
+                        <span className="text-[10px] font-bold uppercase tracking-wide">AI Parse</span>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Template Customization */}
+                <button 
+                  onClick={() => setShowAdvanced(!showAdvanced)}
+                  className="w-full bg-slate-100 hover:bg-slate-200 rounded-2xl p-4 flex items-center justify-between active:scale-[0.98] transition-all group"
+                >
+                  <div className="flex items-center space-x-4">
+                    <div className="w-11 h-11 rounded-xl bg-white flex items-center justify-center text-slate-700 shadow-sm group-hover:scale-105 transition-transform">
+                      <MaterialIcon name="tune" className="text-[22px]" />
+                    </div>
+                    <div className="text-left">
+                      <h3 className="text-sm font-bold text-slate-900">Template Customization</h3>
+                      <p className="text-[11px] font-medium text-slate-500 mt-0.5">Customize email content</p>
+                    </div>
+                  </div>
+                  <MaterialIcon 
+                    name="chevron_right" 
+                    className={`text-slate-400 group-hover:text-slate-600 transition-all ${showAdvanced ? 'rotate-90' : ''}`} 
+                  />
+                </button>
+
+                {/* Advanced Options (Collapsible) */}
+                {showAdvanced && (
+                  <div className="p-4 bg-slate-50 rounded-2xl space-y-4 border border-slate-200">
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-[10px] font-bold text-slate-500 uppercase mb-1.5">Badge Text</label>
+                        <input
+                          type="text"
+                          value={badgeText}
+                          onChange={(e) => setBadgeText(e.target.value)}
+                          className="w-full bg-white rounded-xl px-3 py-2.5 text-sm border border-slate-200 outline-none focus:border-[#2b8cee]"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-[10px] font-bold text-slate-500 uppercase mb-1.5">Subtitle</label>
+                        <input
+                          type="text"
+                          value={subtitle}
+                          onChange={(e) => setSubtitle(e.target.value)}
+                          className="w-full bg-white rounded-xl px-3 py-2.5 text-sm border border-slate-200 outline-none focus:border-[#2b8cee]"
+                        />
+                      </div>
+                    </div>
+                    <div>
+                      <label className="block text-[10px] font-bold text-slate-500 uppercase mb-1.5">Intro Highlight</label>
+                      <input
+                        type="text"
+                        value={introHighlight}
+                        onChange={(e) => setIntroHighlight(e.target.value)}
+                        className="w-full bg-white rounded-xl px-3 py-2.5 text-sm border border-slate-200 outline-none focus:border-[#2b8cee]"
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div>
+                        <label className="block text-[10px] font-bold text-slate-500 uppercase mb-1.5">CTA Text</label>
+                        <input
+                          type="text"
+                          value={ctaText}
+                          onChange={(e) => setCtaText(e.target.value)}
+                          className="w-full bg-white rounded-xl px-3 py-2.5 text-sm border border-slate-200 outline-none focus:border-[#2b8cee]"
+                        />
+                      </div>
+                      <div>
+                        <label className="block text-[10px] font-bold text-slate-500 uppercase mb-1.5">CTA URL</label>
+                        <input
+                          type="text"
+                          value={ctaUrl}
+                          onChange={(e) => setCtaUrl(e.target.value)}
+                          className="w-full bg-white rounded-xl px-3 py-2.5 text-sm border border-slate-200 outline-none focus:border-[#2b8cee]"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {/* Results */}
+                {results && (
+                  <div className="p-4 bg-slate-50 rounded-2xl border border-slate-200">
+                    <div className="flex justify-between items-center mb-3">
+                      <span className="font-semibold text-slate-900">Results</span>
+                      <div className="flex gap-2">
+                        <Badge colorScheme="green" px={2} py={0.5}>✓ Sent: {results.summary.sent}</Badge>
+                        {results.summary.failed > 0 && (
+                          <Badge colorScheme="red" px={2} py={0.5}>✗ Failed: {results.summary.failed}</Badge>
+                        )}
+                      </div>
+                    </div>
+                    <div className="space-y-2 max-h-40 overflow-y-auto">
+                      {results.results.map((result, idx) => (
+                        <div key={idx} className="flex justify-between items-center text-sm">
+                          <span className="text-slate-500 truncate max-w-[60%]">{result.email}</span>
+                          <Badge colorScheme={result.success ? "green" : "red"} size="sm">
+                            {result.success ? "Sent" : "Failed"}
+                          </Badge>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              /* History View */
+              <div className="space-y-4">
+                <div className="flex justify-between items-center">
+                  <span className="font-semibold text-slate-900">Email Logs</span>
+                  <button
+                    onClick={fetchLogs}
+                    disabled={isLoadingLogs}
+                    className="text-sm text-[#2b8cee] font-medium flex items-center gap-1"
+                  >
+                    <MaterialIcon name="refresh" className="text-[16px]" />
+                    Refresh
+                  </button>
+                </div>
+                
+                {isLoadingLogs ? (
+                  <div className="flex justify-center py-8">
+                    <Spinner color="#2b8cee" />
+                  </div>
+                ) : emailLogs.length === 0 ? (
+                  <p className="text-slate-500 text-center py-8">
+                    No emails sent yet. Send your first email!
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {emailLogs.map((log) => (
+                      <div 
+                        key={log.id} 
+                        className="bg-slate-100 rounded-2xl p-4 flex justify-between items-center"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-slate-900">
+                            {log.recipient_name || log.recipient_email}
+                          </p>
+                          <p className="text-[11px] text-slate-500">
+                            {new Date(log.created_at).toLocaleDateString()}
+                          </p>
+                        </div>
+                        <Badge colorScheme={log.status === 'SENT' ? 'green' : 'red'}>
+                          {log.status}
+                        </Badge>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </main>
+
+          {/* Fixed Footer - Like Onboarding - Above MobileBottomNav - Hidden when main footer is visible */}
+          {!isFooterVisible && activeView === "compose" && (
+            <div className="fixed bottom-20 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.05)]" data-mailer-footer>
+              {/* Send Button */}
+              <button
+                onClick={handleSend}
+                disabled={isLoading || recipientCount === 0}
+                className={`
+                  w-full flex items-center justify-center h-14 rounded-full font-bold text-base tracking-wide transition-all mb-3
+                  ${recipientCount > 0 && !isLoading
+                    ? 'bg-[#2b8cee] hover:bg-blue-600 active:scale-[0.98] text-white cursor-pointer'
+                    : 'bg-slate-100 text-slate-400 cursor-not-allowed'
+                  }
+                `}
+              >
+                {isLoading ? (
+                  <Spinner size="sm" color="white" />
+                ) : (
+                  recipientCount === 0 
+                    ? "Enter Recipients to Send" 
+                    : `Send to ${recipientCount} Recipient${recipientCount !== 1 ? 's' : ''}`
+                )}
+              </button>
+              
+              {/* Footer Note */}
+              <div className="flex items-center justify-center space-x-2 text-slate-400">
+                <MaterialIcon name="lock" className="text-[14px]" />
+                <span className="text-[10px] font-bold uppercase tracking-widest">
                   Secure Agentic Workflow
-                </Text>
-              </HStack>
-              <Text fontSize="10px" color={colors.gray400}>
-                © 2024 Hushh.ai
-              </Text>
-            </VStack>
-          </Box>
-        )}
-      </Box>
-    </Box>
+                </span>
+              </div>
+              <p className="text-center text-[10px] text-slate-400 mt-1">© 2025 Hushh.ai</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Changes

- Remove fake iOS status bar mockup (9:41 with icons)
- Add proper header with back arrow, centered title, and help button
- Add sticky bottom footer like onboarding pages
- Position footer at bottom-20 to avoid MobileBottomNav overlap
- Use useFooterVisibility hook for footer visibility management
- Add Compose/History toggle tabs
- Add Template Customization expandable section

## Testing

Navigate to /hushh-agent-mailer and verify:
1. Header shows back arrow, title, and help button
2. Sticky footer appears above MobileBottomNav (no overlap)
3. Send button is functional
4. Compose/History tabs work