### PR TITLE
feat(profile): add Go to Home button in profile page footer

### DIFF
--- a/src/pages/hushh-user-profile/index.tsx
+++ b/src/pages/hushh-user-profile/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useToast, useClipboard } from "@chakra-ui/react";
 import { useFooterVisibility } from "../../utils/useFooterVisibility";
-import { ArrowLeft, User, TrendingUp, Shield, ChevronDown, Calendar, Brain, Target, Clock, Gauge, Droplets, Briefcase, Layers, Zap, Activity, ChevronUp, Edit2, Share2, Link, Copy, Check, ExternalLink } from "lucide-react";
+import { ArrowLeft, User, TrendingUp, Shield, ChevronDown, Calendar, Brain, Target, Clock, Gauge, Droplets, Briefcase, Layers, Zap, Activity, ChevronUp, Edit2, Share2, Link, Copy, Check, ExternalLink, Home } from "lucide-react";
 import { FaApple, FaWhatsapp, FaLinkedin } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
 import { SiGooglepay } from "react-icons/si";
@@ -1198,7 +1198,7 @@ const HushhUserProfilePage: React.FC = () => {
                     : "Generate Investor Profile"
               }
             </button>
-            <p className="text-xs text-[#6B7280] text-center mt-4 leading-normal px-2">
+            <p className="text-xs text-[#6B7280] text-center mt-3 leading-normal px-2">
               {investorProfile 
                 ? "Update your AI-generated investor profile."
                 : hasOnboardingData
@@ -1206,6 +1206,15 @@ const HushhUserProfilePage: React.FC = () => {
                   : "These details personalise your investor profile."
               }
             </p>
+            
+            {/* Go to Home Button */}
+            <button
+              onClick={() => navigate('/')}
+              className="flex items-center justify-center gap-2 w-full mt-3 py-2.5 text-[#2B8CEE] hover:bg-blue-50 rounded-xl transition-colors font-medium text-sm"
+            >
+              <Home className="w-4 h-4" />
+              Go to Home
+            </button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
Added a 'Go to Home' button in the fixed footer of the Investor Profile page for improved navigation UX.

## Changes
- Added Home icon import from lucide-react
- Added 'Go to Home' button below helper text in fixed footer
- Button navigates user to home page with nice hover effect
- Matches the UX pattern used in onboarding flow

## Testing
- Navigate to /hushh-user-profile
- The 'Go to Home' button should be visible in the fixed footer
- Clicking it should navigate to the home page

## Related
- Follows up on PR #235 which fixed MobileBottomNav overlap issue