### PR TITLE
feat: State persistence + Gemini 2.0 Flash fix for hushh-agent

### DIFF
--- a/src/hushh-agent/App.tsx
+++ b/src/hushh-agent/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import { Coach } from './types';
 import { COACHES } from './constants';
 import CoachCard from './components/CoachCard';
@@ -9,10 +9,50 @@ import { useEmailAuth } from './hooks/useEmailAuth';
 
 type FilterType = 'all' | 'biological' | 'automation' | 'dating' | 'career' | 'chatnode';
 
+// Storage keys for persistence
+const STORAGE_KEYS = {
+  ACTIVE_FILTER: 'hushh_agent_active_filter',
+  SELECTED_COACH: 'hushh_agent_selected_coach',
+};
+
 const App: React.FC = () => {
-  const [selectedCoach, setSelectedCoach] = useState<Coach | null>(null);
-  const [activeFilter, setActiveFilter] = useState<FilterType>('all');
+  // Load initial state from localStorage
+  const [selectedCoach, setSelectedCoach] = useState<Coach | null>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.SELECTED_COACH);
+      if (stored) {
+        const coachId = JSON.parse(stored);
+        return COACHES.find(c => c.id === coachId) || null;
+      }
+    } catch { /* ignore */ }
+    return null;
+  });
+  
+  const [activeFilter, setActiveFilter] = useState<FilterType>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEYS.ACTIVE_FILTER);
+      if (stored) {
+        return JSON.parse(stored) as FilterType;
+      }
+    } catch { /* ignore */ }
+    return 'all';
+  });
+  
   const [showLoginModal, setShowLoginModal] = useState(false);
+
+  // Persist activeFilter to localStorage
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEYS.ACTIVE_FILTER, JSON.stringify(activeFilter));
+  }, [activeFilter]);
+
+  // Persist selectedCoach to localStorage
+  useEffect(() => {
+    if (selectedCoach) {
+      localStorage.setItem(STORAGE_KEYS.SELECTED_COACH, JSON.stringify(selectedCoach.id));
+    } else {
+      localStorage.removeItem(STORAGE_KEYS.SELECTED_COACH);
+    }
+  }, [selectedCoach]);
   
   // Email Auth Hook
   const { isAuthenticated, isLoading, user, signOut } = useEmailAuth();

--- a/src/hushh-agent/components/ChatNode.tsx
+++ b/src/hushh-agent/components/ChatNode.tsx
@@ -48,6 +48,9 @@ import {
 const MotionBox = motion(Box);
 const MotionFlex = motion(Flex);
 
+// Storage key for chat persistence
+const CHAT_STORAGE_KEY = 'hushh_chatnode_messages';
+
 // Welcome message from Hushh Intelligence
 const WELCOME_MESSAGE: ChatMessage = {
   id: 'welcome',
@@ -67,6 +70,35 @@ Feel free to upload images or files - I can analyze them for you!
   timestamp: new Date(),
 };
 
+// Helper to load messages from localStorage
+const loadMessagesFromStorage = (): ChatMessage[] => {
+  try {
+    const stored = localStorage.getItem(CHAT_STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      // Convert timestamp strings back to Date objects
+      return parsed.map((msg: any) => ({
+        ...msg,
+        timestamp: new Date(msg.timestamp),
+      }));
+    }
+  } catch (e) {
+    console.warn('Failed to load chat history:', e);
+  }
+  return [WELCOME_MESSAGE];
+};
+
+// Helper to save messages to localStorage
+const saveMessagesToStorage = (messages: ChatMessage[]) => {
+  try {
+    // Only save last 100 messages to avoid storage limits
+    const toSave = messages.slice(-100);
+    localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(toSave));
+  } catch (e) {
+    console.warn('Failed to save chat history:', e);
+  }
+};
+
 interface ChatNodeProps {
   isOpen?: boolean;
   onClose?: () => void;
@@ -79,8 +111,13 @@ export const ChatNode: React.FC<ChatNodeProps> = ({ isOpen = true, onClose }) =>
   const imageInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // State
-  const [messages, setMessages] = useState<ChatMessage[]>([WELCOME_MESSAGE]);
+  // State - Load from localStorage on init
+  const [messages, setMessages] = useState<ChatMessage[]>(() => loadMessagesFromStorage());
+
+  // Save messages to localStorage whenever they change
+  useEffect(() => {
+    saveMessagesToStorage(messages);
+  }, [messages]);
   const [inputValue, setInputValue] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [attachedFile, setAttachedFile] = useState<File | null>(null);

--- a/supabase/functions/chatnode-ai/index.ts
+++ b/supabase/functions/chatnode-ai/index.ts
@@ -17,7 +17,7 @@ const corsHeaders = {
 
 // Gemini API Configuration
 const GEMINI_API_KEY = Deno.env.get("GEMINI_API_KEY") || "";
-const GEMINI_MODEL = "gemini-2.5-flash-preview-05-20"; // Best available model
+const GEMINI_MODEL = "gemini-2.0-flash"; // Latest fast model
 const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:generateContent`;
 
 // Hushh Intelligence System Prompt


### PR DESCRIPTION
## Summary
This PR adds:

### 1. Gemini Model Fix (Critical)
- Changed from `gemini-2.5-flash-preview-05-20` to `gemini-2.0-flash`
- The old model was returning 404 errors
- ChatNode now works correctly with Hushh Intelligence branding

### 2. State Persistence for hushh-agent
- **activeFilter** - Persists which view is active (ChatNode, Resume Node, etc.)
- **selectedCoach** - Persists which coach/agent is selected
- **Chat messages** - Persists last 100 messages in ChatNode

### How it works:
1. User opens ChatNode → state saved to localStorage
2. User switches tabs → app reloads
3. On reload → state restored from localStorage
4. User is back on ChatNode with chat history intact! 🎉

### Files Changed:
- `supabase/functions/chatnode-ai/index.ts` - Gemini model fix
- `src/hushh-agent/App.tsx` - State persistence
- `src/hushh-agent/components/ChatNode.tsx` - Chat history persistence

### Testing:
1. Open /hushh-agent
2. Click on Chat Node
3. Send a message
4. Switch to another tab and come back
5. ✅ Should stay on Chat Node with messages preserved