### PR TITLE
Fix: Refresh session token before delete account request

### DIFF
--- a/src/components/DeleteAccountModal.tsx
+++ b/src/components/DeleteAccountModal.tsx
@@ -43,7 +43,16 @@ const DeleteAccountModal = ({
     setIsDeleting(true);
 
     try {
-      // Get the current session token
+      // First, validate and refresh the session if needed
+      // getUser() validates the token and triggers an automatic refresh if expired
+      const { data: { user }, error: userError } = await config.supabaseClient.auth.getUser();
+      
+      if (userError || !user) {
+        console.error("Session validation failed:", userError);
+        throw new Error("Session expired. Please log in again.");
+      }
+
+      // Now get the refreshed session token
       const {
         data: { session },
       } = await config.supabaseClient.auth.getSession();


### PR DESCRIPTION
## Bug Fix

Fixes the 'Invalid or expired token' error when deleting account.

### Root Cause
The `getSession()` method returns cached session from local storage **without validating** if the JWT token has expired. When the token is expired (~1 hour old), the edge function's `getUser()` call fails with 'Invalid or expired token'.

### Solution
Added a `getUser()` call before `getSession()` to:
1. Validate the current JWT token
2. Automatically trigger a session refresh if the token is expired
3. Ensure the subsequent `getSession()` returns a fresh, valid token

### Changes
- `src/components/DeleteAccountModal.tsx`: Added session validation before delete request

### Testing
- Build passes ✅
- Token refresh logic ensures valid tokens are sent to edge function
- Clearer error message shown if session truly expired