### PR TITLE
feat(nda): Global NDA Gate with Strict Enforcement & Apple-Style UI

### DIFF
--- a/src/components/GlobalNDAGate.tsx
+++ b/src/components/GlobalNDAGate.tsx
@@ -1,11 +1,15 @@
 /**
  * GlobalNDAGate Component
  * 
- * Wrapper component that enforces NDA signing for authenticated users.
- * - Checks if user is authenticated
- * - If authenticated, verifies NDA status
- * - Redirects to /sign-nda if NDA not signed
- * - Renders children if NDA is signed or user is not authenticated
+ * GLOBAL NDA ENFORCEMENT - Acts as a universal key for the entire website.
+ * 
+ * How it works:
+ * - If user is NOT authenticated → Allow access (they'll see public marketing pages)
+ * - If user IS authenticated → Check NDA status
+ *   - If NDA signed → Allow access to all routes
+ *   - If NDA NOT signed → Redirect to /sign-nda (only allow minimal auth routes)
+ * 
+ * This ensures NO authenticated user can access ANY content without signing the NDA first.
  */
 
 import React, { useEffect, useState, ReactNode } from 'react';
@@ -19,12 +23,19 @@ interface GlobalNDAGateProps {
   session: Session | null;
 }
 
-// Routes that don't require NDA check (public routes)
-const PUBLIC_ROUTES = [
-  '/',
+// MINIMAL routes that bypass NDA check for authenticated users
+// These are ONLY the routes needed for authentication and NDA signing itself
+const AUTH_ROUTES = [
   '/Login',
   '/Signup',
   '/auth/callback',
+  '/sign-nda',
+];
+
+// Public routes accessible WITHOUT authentication
+// These are marketing/info pages visible to non-logged-in users
+const UNAUTHENTICATED_PUBLIC_ROUTES = [
+  '/',
   '/privacy-policy',
   '/faq',
   '/carrer-privacy-policy',
@@ -32,24 +43,28 @@ const PUBLIC_ROUTES = [
   '/eu-uk-jobs-privacy-policy',
   '/delete-account',
   '/investor-guide',
-  '/hushhid',
-  '/investor',
-  '/sign-nda',
-  '/hushh-ai',
-  '/hushh-agent',
-  '/kai',
-  '/kai-india',
-  '/studio',
+  '/about',
+  '/services',
+  '/career',
+  '/community',
+  '/Contact',
+  '/benefits',
 ];
 
-// Check if a path matches any public route pattern
-const isPublicRoute = (pathname: string): boolean => {
-  return PUBLIC_ROUTES.some(route => {
-    // Exact match for home route
-    if (route === '/') {
-      return pathname === '/';
-    }
-    // For other routes, check exact match or sub-routes
+// Check if path is an auth-related route
+const isAuthRoute = (pathname: string): boolean => {
+  return AUTH_ROUTES.some(route => 
+    pathname === route || pathname.startsWith(`${route}/`)
+  );
+};
+
+// Check if path is a public route (for unauthenticated users)
+const isUnauthenticatedPublicRoute = (pathname: string): boolean => {
+  // Home page exact match
+  if (pathname === '/') return true;
+  
+  return UNAUTHENTICATED_PUBLIC_ROUTES.some(route => {
+    if (route === '/') return false; // Already handled above
     return pathname === route || pathname.startsWith(`${route}/`);
   });
 };
@@ -62,34 +77,39 @@ const GlobalNDAGate: React.FC<GlobalNDAGateProps> = ({ children, session }) => {
 
   useEffect(() => {
     const checkNDA = async () => {
-      // Skip check for public routes
-      if (isPublicRoute(location.pathname)) {
-        setIsChecking(false);
-        setHasSignedNDA(true); // Allow access to public routes
-        return;
-      }
-
-      // If no session, allow access (they'll hit login page if needed)
-      if (!session?.user?.id) {
+      const pathname = location.pathname;
+      
+      // Always allow auth-related routes (login, signup, sign-nda, callback)
+      if (isAuthRoute(pathname)) {
         setIsChecking(false);
         setHasSignedNDA(true);
         return;
       }
 
+      // If no session (not logged in), allow access to public pages
+      if (!session?.user?.id) {
+        // Allow public marketing pages for non-authenticated users
+        setIsChecking(false);
+        setHasSignedNDA(true);
+        return;
+      }
+
+      // USER IS AUTHENTICATED - Check NDA status
       try {
         const status = await checkNDAStatus(session.user.id);
         setHasSignedNDA(status.hasSignedNda);
         
-        // Redirect to NDA page if not signed
+        // If NDA not signed, redirect to NDA page
         if (!status.hasSignedNda) {
-          // Store the intended destination
-          sessionStorage.setItem('nda_redirect_after', location.pathname);
+          // Store the intended destination for redirect after signing
+          sessionStorage.setItem('nda_redirect_after', pathname);
           navigate('/sign-nda', { replace: true });
         }
       } catch (error) {
         console.error('Error checking NDA status:', error);
-        // On error, allow access but log the issue
-        setHasSignedNDA(true);
+        // On error, redirect to NDA page to be safe
+        sessionStorage.setItem('nda_redirect_after', pathname);
+        navigate('/sign-nda', { replace: true });
       } finally {
         setIsChecking(false);
       }
@@ -98,14 +118,15 @@ const GlobalNDAGate: React.FC<GlobalNDAGateProps> = ({ children, session }) => {
     checkNDA();
   }, [session, location.pathname, navigate]);
 
-  // Re-check when session changes
+  // Re-check when session changes (user logs in/out)
   useEffect(() => {
     if (session?.user?.id) {
       setIsChecking(true);
+      setHasSignedNDA(null);
     }
   }, [session?.user?.id]);
 
-  // Show loading state while checking
+  // Show loading state while checking - Apple-style black/white design
   if (isChecking) {
     return (
       <Box
@@ -113,17 +134,17 @@ const GlobalNDAGate: React.FC<GlobalNDAGateProps> = ({ children, session }) => {
         display="flex"
         alignItems="center"
         justifyContent="center"
-        bg="linear-gradient(180deg, #0a0a0f 0%, #1a1a2e 100%)"
+        bg="white"
       >
         <VStack spacing={4}>
           <Spinner
-            thickness="4px"
+            thickness="3px"
             speed="0.65s"
-            emptyColor="gray.700"
-            color="cyan.400"
+            emptyColor="gray.200"
+            color="black"
             size="xl"
           />
-          <Text color="gray.400" fontSize="sm">
+          <Text color="gray.600" fontSize="sm">
             Verifying access...
           </Text>
         </VStack>
@@ -131,7 +152,7 @@ const GlobalNDAGate: React.FC<GlobalNDAGateProps> = ({ children, session }) => {
     );
   }
 
-  // Render children if NDA is signed or access is allowed
+  // Render children if access is allowed
   return <>{children}</>;
 };
 

--- a/src/pages/sign-nda/index.tsx
+++ b/src/pages/sign-nda/index.tsx
@@ -1,8 +1,8 @@
 /**
  * Sign NDA Page
  * 
- * This page is shown to authenticated users who haven't signed the NDA yet.
- * They must sign the NDA before accessing any protected routes.
+ * Apple-style clean black and white design.
+ * White background with black header - simple and minimal.
  */
 
 import React, { useState, useEffect } from 'react';
@@ -19,18 +19,15 @@ import {
   FormLabel,
   FormErrorMessage,
   Container,
-  Spinner,
   useToast,
   Divider,
   HStack,
   Icon,
-  Alert,
-  AlertIcon,
 } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { FaFileSignature, FaShieldAlt, FaCheckCircle, FaLock } from 'react-icons/fa';
 import config from '../../resources/config/config';
-import { signNDA, generateNDAPdf, uploadSignedNDA } from '../../services/nda/ndaService';
+import { signNDA, sendNDANotification } from '../../services/nda/ndaService';
 
 const MotionBox = motion(Box);
 
@@ -43,7 +40,6 @@ const SignNDAPage: React.FC = () => {
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
-  const [isGeneratingPdf, setIsGeneratingPdf] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   
@@ -121,6 +117,22 @@ const SignNDAPage: React.FC = () => {
       const result = await signNDA(signerName.trim(), 'v1.0', pdfUrl || undefined);
       
       if (result.success) {
+        // Send notification email to manish@hushh.ai and ankit@hushh.ai
+        try {
+          await sendNDANotification(
+            signerName.trim(),
+            userEmail || 'unknown@email.com',
+            result.signedAt || new Date().toISOString(),
+            result.ndaVersion || 'v1.0',
+            pdfUrl || undefined,
+            undefined,
+            userId
+          );
+        } catch (notificationError) {
+          console.error('Failed to send NDA notification:', notificationError);
+          // Don't block the user flow if notification fails
+        }
+        
         toast({
           title: 'NDA Signed Successfully',
           description: 'Thank you for signing the Non-Disclosure Agreement.',
@@ -159,55 +171,60 @@ const SignNDAPage: React.FC = () => {
   };
 
   return (
-    <Box
-      minH="100vh"
-      bg="linear-gradient(180deg, #0a0a0f 0%, #1a1a2e 100%)"
-      py={{ base: 8, md: 16 }}
-      px={4}
-    >
-      <Container maxW="container.md">
-        <MotionBox
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5 }}
-        >
-          {/* Header */}
-          <VStack spacing={4} mb={8} textAlign="center">
-            <Icon as={FaFileSignature} boxSize={12} color="cyan.400" />
+    <Box minH="100vh" bg="white">
+      {/* Black Header */}
+      <Box
+        bg="black"
+        py={{ base: 6, md: 10 }}
+        px={4}
+      >
+        <Container maxW="container.md">
+          <VStack spacing={3} textAlign="center">
+            <Icon as={FaFileSignature} boxSize={10} color="white" />
             <Heading
               as="h1"
               size="xl"
-              bgGradient="linear(to-r, cyan.400, blue.500)"
-              bgClip="text"
+              color="white"
+              fontWeight="600"
+              letterSpacing="-0.02em"
             >
               Non-Disclosure Agreement
             </Heading>
-            <Text color="gray.400" maxW="md">
+            <Text color="gray.400" fontSize="md" maxW="lg">
               Before accessing the platform, please review and sign our NDA to protect 
               confidential information.
             </Text>
           </VStack>
+        </Container>
+      </Box>
 
+      {/* White Content Area */}
+      <Container maxW="container.md" py={{ base: 6, md: 12 }} px={4}>
+        <MotionBox
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+        >
           {/* NDA Document */}
           <Box
-            bg="whiteAlpha.50"
+            bg="white"
             borderRadius="xl"
             border="1px solid"
-            borderColor="whiteAlpha.100"
-            p={{ base: 4, md: 8 }}
+            borderColor="gray.200"
+            p={{ base: 5, md: 8 }}
             mb={8}
           >
             <VStack align="stretch" spacing={6}>
               {/* Security Notice */}
               <HStack
-                bg="rgba(49, 130, 206, 0.15)"
+                bg="gray.50"
                 p={4}
                 borderRadius="lg"
                 border="1px solid"
-                borderColor="blue.500"
+                borderColor="gray.200"
               >
-                <Icon as={FaShieldAlt} color="blue.400" boxSize={5} />
-                <Text color="blue.300" fontSize="sm">
+                <Icon as={FaShieldAlt} color="black" boxSize={5} />
+                <Text color="gray.600" fontSize="sm">
                   This agreement protects both you and Hushh. Your signature will be 
                   securely recorded with timestamp and IP address for verification.
                 </Text>
@@ -217,32 +234,32 @@ const SignNDAPage: React.FC = () => {
               <Box
                 maxH="300px"
                 overflowY="auto"
-                bg="blackAlpha.400"
+                bg="gray.50"
                 p={6}
                 borderRadius="lg"
                 border="1px solid"
-                borderColor="whiteAlpha.100"
+                borderColor="gray.200"
                 css={{
                   '&::-webkit-scrollbar': { width: '6px' },
-                  '&::-webkit-scrollbar-track': { background: 'transparent' },
+                  '&::-webkit-scrollbar-track': { background: '#f5f5f5' },
                   '&::-webkit-scrollbar-thumb': { 
-                    background: 'rgba(255,255,255,0.2)', 
+                    background: '#d1d1d1', 
                     borderRadius: '3px' 
                   },
                 }}
               >
                 <VStack align="stretch" spacing={4}>
-                  <Heading size="sm" color="white">
+                  <Heading size="sm" color="black">
                     MUTUAL NON-DISCLOSURE AGREEMENT
                   </Heading>
                   
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     This Non-Disclosure Agreement ("Agreement") is entered into between 
                     Hushh Technologies LLC ("Hushh") and the undersigned party ("Recipient").
                   </Text>
                   
-                  <Heading size="xs" color="white">1. Definition of Confidential Information</Heading>
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Heading size="xs" color="black">1. Definition of Confidential Information</Heading>
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     "Confidential Information" means any non-public information disclosed by Hushh 
                     to the Recipient, including but not limited to: business strategies, financial 
                     information, investment strategies, fund performance data, technical specifications, 
@@ -250,8 +267,8 @@ const SignNDAPage: React.FC = () => {
                     as confidential or that reasonably should be understood to be confidential.
                   </Text>
                   
-                  <Heading size="xs" color="white">2. Obligations of the Recipient</Heading>
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Heading size="xs" color="black">2. Obligations of the Recipient</Heading>
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     The Recipient agrees to: (a) hold Confidential Information in strict confidence; 
                     (b) not disclose Confidential Information to any third party without prior written 
                     consent; (c) use Confidential Information solely for evaluating a potential 
@@ -259,29 +276,29 @@ const SignNDAPage: React.FC = () => {
                     of such information.
                   </Text>
                   
-                  <Heading size="xs" color="white">3. Exceptions</Heading>
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Heading size="xs" color="black">3. Exceptions</Heading>
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     This Agreement does not apply to information that: (a) is or becomes publicly 
                     available through no fault of the Recipient; (b) was known to the Recipient 
                     prior to disclosure; (c) is independently developed by the Recipient; (d) is 
                     disclosed pursuant to a court order or legal requirement.
                   </Text>
                   
-                  <Heading size="xs" color="white">4. Term and Termination</Heading>
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Heading size="xs" color="black">4. Term and Termination</Heading>
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     This Agreement shall remain in effect for a period of three (3) years from 
                     the date of execution. The obligations of confidentiality shall survive the 
                     termination of this Agreement.
                   </Text>
                   
-                  <Heading size="xs" color="white">5. Governing Law</Heading>
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Heading size="xs" color="black">5. Governing Law</Heading>
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     This Agreement shall be governed by the laws of the State of Delaware, 
                     United States of America, without regard to its conflict of laws principles.
                   </Text>
                   
-                  <Heading size="xs" color="white">6. Acknowledgment</Heading>
-                  <Text color="gray.300" fontSize="sm" lineHeight="tall">
+                  <Heading size="xs" color="black">6. Acknowledgment</Heading>
+                  <Text color="gray.700" fontSize="sm" lineHeight="tall">
                     By signing below, the Recipient acknowledges that they have read, understood, 
                     and agree to be bound by the terms of this Non-Disclosure Agreement. The Recipient 
                     further acknowledges that any breach of this Agreement may result in irreparable 
@@ -291,16 +308,16 @@ const SignNDAPage: React.FC = () => {
                 </VStack>
               </Box>
 
-              <Divider borderColor="whiteAlpha.200" />
+              <Divider borderColor="gray.200" />
 
               {/* Signature Section */}
               <VStack align="stretch" spacing={4}>
-                <Heading size="sm" color="white">
+                <Heading size="sm" color="black">
                   Digital Signature
                 </Heading>
                 
                 <FormControl isInvalid={!!nameError}>
-                  <FormLabel color="gray.300" fontSize="sm">
+                  <FormLabel color="gray.700" fontSize="sm" fontWeight="500">
                     Full Legal Name
                   </FormLabel>
                   <Input
@@ -310,13 +327,13 @@ const SignNDAPage: React.FC = () => {
                       if (nameError) setNameError('');
                     }}
                     placeholder="Enter your full legal name"
-                    bg="blackAlpha.400"
+                    bg="white"
                     border="1px solid"
-                    borderColor="whiteAlpha.200"
-                    color="white"
-                    _placeholder={{ color: 'gray.500' }}
-                    _hover={{ borderColor: 'whiteAlpha.400' }}
-                    _focus={{ borderColor: 'cyan.400', boxShadow: '0 0 0 1px cyan' }}
+                    borderColor="gray.300"
+                    color="black"
+                    _placeholder={{ color: 'gray.400' }}
+                    _hover={{ borderColor: 'gray.400' }}
+                    _focus={{ borderColor: 'black', boxShadow: '0 0 0 1px black' }}
                     size="lg"
                     fontFamily="'Caveat', cursive, system-ui"
                     fontSize="xl"
@@ -331,16 +348,24 @@ const SignNDAPage: React.FC = () => {
                       setAgreedToTerms(e.target.checked);
                       if (termsError) setTermsError('');
                     }}
-                    colorScheme="cyan"
+                    colorScheme="blackAlpha"
+                    iconColor="white"
+                    borderColor="gray.400"
                     size="lg"
+                    sx={{
+                      '[data-checked] > span:first-of-type': {
+                        bg: 'black',
+                        borderColor: 'black',
+                      },
+                    }}
                   >
-                    <Text color="gray.300" fontSize="sm">
+                    <Text color="gray.700" fontSize="sm">
                       I have read, understood, and agree to the terms of this Non-Disclosure 
                       Agreement. I acknowledge that this constitutes my legal electronic signature.
                     </Text>
                   </Checkbox>
                   {termsError && (
-                    <Text color="red.400" fontSize="xs" mt={2}>
+                    <Text color="red.500" fontSize="xs" mt={2}>
                       {termsError}
                     </Text>
                   )}
@@ -349,7 +374,7 @@ const SignNDAPage: React.FC = () => {
                 {/* User Info */}
                 {userEmail && (
                   <HStack spacing={2} pt={2}>
-                    <Icon as={FaLock} color="gray.500" boxSize={3} />
+                    <Icon as={FaLock} color="gray.400" boxSize={3} />
                     <Text color="gray.500" fontSize="xs">
                       Signing as: {userEmail}
                     </Text>
@@ -366,18 +391,21 @@ const SignNDAPage: React.FC = () => {
             loadingText="Signing NDA..."
             size="lg"
             width="full"
-            bgGradient="linear(to-r, cyan.500, blue.600)"
+            bg="black"
             color="white"
             _hover={{
-              bgGradient: 'linear(to-r, cyan.400, blue.500)',
-              transform: 'translateY(-2px)',
-              boxShadow: '0 10px 40px rgba(0, 200, 255, 0.3)',
+              bg: 'gray.800',
+              transform: 'translateY(-1px)',
             }}
             _active={{
+              bg: 'gray.900',
               transform: 'translateY(0)',
             }}
             leftIcon={<FaCheckCircle />}
             isDisabled={!agreedToTerms || !signerName.trim() || isSubmitting}
+            borderRadius="lg"
+            fontWeight="500"
+            h="56px"
           >
             Sign & Continue
           </Button>


### PR DESCRIPTION
# 🔐 Global NDA Gate - Strict Enforcement

## 📋 Summary
This PR implements a **Global NDA Gate** that acts as a universal key for the entire Hushh platform. Authenticated users MUST sign the NDA before accessing ANY route on the website.

---

## 🔧 Technical Implementation

### Architecture
- **GlobalNDAGate Component**: Higher-order component that wraps the entire app router
- **Session-Based Verification**: Uses Supabase auth to check NDA status in real-time
- **Strict Route Enforcement**: Only 4 routes bypass NDA check:
  - `/Login`
  - `/Signup`
  - `/auth/callback`
  - `/sign-nda`

### Key Functions
| Function | Purpose |
|----------|---------|
| `isAuthRoute()` | Path matching helper for auth-related routes |
| `checkNDAStatus()` | Async Supabase query for NDA status |
| `sendNDANotification()` | Sends email notification on NDA signing |

### Flow Diagram
```
User → Auth Check → NDA Status Check → 
  ├── Signed → Allow Access
  └── Not Signed → Redirect to /sign-nda → Sign → Redirect Back
```

---

## 👨‍💻 Developer Notes

### Key Constants
```typescript
// Minimal routes for auth flow
const AUTH_ROUTES = ['/Login', '/Signup', '/auth/callback', '/sign-nda'];

// Marketing pages for non-logged users
const UNAUTHENTICATED_PUBLIC_ROUTES = ['/', '/privacy-policy', '/faq', ...];
```

### SessionStorage Usage
- `nda_redirect_after`: Stores intended destination before NDA redirect
- Cleared after successful NDA signing

### Component Re-render Triggers
- Session changes (login/logout)
- Route changes (location.pathname)

---

## 🎨 Product Features

### User Experience
- **NDA as 'Global Key'**: Users cannot access ANY platform features until NDA signed
- **Smart Redirect**: After signing, users are redirected to their intended destination
- **Apple-Style UI**: Clean black header, white content area, minimalist design

### NDA Document
- 6 comprehensive sections covering confidentiality
- Digital signature with legal name input
- Terms acceptance checkbox with validation
- Legally binding under electronic signature laws

### Notifications
- Email sent to `manish@hushh.ai` and `ankit@hushh.ai` on every NDA signing
- Includes signer name, email, timestamp, and NDA version

---

## 📁 Files Changed
| File | Changes |
|------|---------|
| `src/components/GlobalNDAGate.tsx` | Strict enforcement logic, minimal route bypass |
| `src/pages/sign-nda/index.tsx` | Apple-style UI redesign, notification integration |

---

## ✅ Testing Checklist
- [ ] Authenticated user without NDA → Redirected to /sign-nda
- [ ] Authenticated user with NDA → Can access all routes
- [ ] Non-authenticated user → Can access public marketing pages
- [ ] After signing NDA → Redirected to intended destination
- [ ] Email notification sent to manish@hushh.ai and ankit@hushh.ai

---

## 🚀 Deployment Notes
No database migrations required. Changes are frontend-only and use existing Supabase tables.