### PR TITLE
fix: Step6 always detect GPS in real-time on every visit

### DIFF
--- a/src/pages/onboarding/Step6.tsx
+++ b/src/pages/onboarding/Step6.tsx
@@ -101,7 +101,7 @@ export default function OnboardingStep6() {
         .single();
 
       if (onboardingData) {
-        // If user already has data, use it
+        // If user already has data, use it (but still detect fresh GPS)
         if (onboardingData.citizenship_country) {
           setCitizenshipCountry(onboardingData.citizenship_country);
           setUserManuallyChanged(true); // User already has data, allow continue
@@ -110,15 +110,11 @@ export default function OnboardingStep6() {
           setResidenceCountry(onboardingData.residence_country);
         }
         
-        // If GPS data already cached, mark as detected
-        if (onboardingData.gps_location_data) {
-          setLocationDetected(true);
-          setDetectionAttempted(true);
-          return;
-        }
+        // NOTE: We no longer skip GPS detection even if cached.
+        // Always detect fresh GPS location in real-time every time user visits Step 6
       }
 
-      // Start GPS detection for new users
+      // ALWAYS detect GPS location in real-time (every page visit)
       detectLocation(user.id);
     };
 

--- a/src/services/location/locationService.ts
+++ b/src/services/location/locationService.ts
@@ -65,7 +65,7 @@ export class LocationService {
         {
           enableHighAccuracy: true,
           timeout: 10000,
-          maximumAge: 300000, // 5 minutes cache
+          maximumAge: 0, // Always get fresh real-time GPS data (no caching)
           ...options,
         }
       );


### PR DESCRIPTION
## Summary
Step 6 now detects GPS location in real-time every time user visits the page.

## Changes:
- **Step6.tsx**: Removed early return when GPS data cached - now ALWAYS detects fresh GPS location
- **locationService.ts**: Changed `maximumAge` from 300000ms (5 min) to 0 (no caching - always real-time)

## What this fixes:
- Every time user visits Step 6, fresh GPS location is detected
- Location API remains isolated in service layer
- All location data collected: country, state, city, postalCode, phoneDialCode, timezone, formattedAddress, lat/lng

## Test Results
- 127 passed, 1 skipped ✅