### PR TITLE
fix: Step10 use country-state-city npm package directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "antd": "^5.22.1",
         "axios": "^1.10.0",
         "contentlayer": "^0.3.4",
+        "country-state-city": "^3.2.1",
         "date-fns": "^4.1.0",
         "eruda": "^3.4.3",
         "firebase": "^11.10.0",
@@ -7990,6 +7991,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/country-state-city": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/country-state-city/-/country-state-city-3.2.1.tgz",
+      "integrity": "sha512-kxbanqMc6izjhc/EHkGPCTabSPZ2G6eG4/97akAYHJUN4stzzFEvQPZoF8oXDQ+10gM/O/yUmISCR1ZVxyb6EA==",
+      "license": "GPL-3.0"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "antd": "^5.22.1",
     "axios": "^1.10.0",
     "contentlayer": "^0.3.4",
+    "country-state-city": "^3.2.1",
     "date-fns": "^4.1.0",
     "eruda": "^3.4.3",
     "firebase": "^11.10.0",

--- a/src/pages/onboarding/Step10.tsx
+++ b/src/pages/onboarding/Step10.tsx
@@ -2,11 +2,12 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import config from '../../resources/config/config';
 import { useFooterVisibility } from '../../utils/useFooterVisibility';
+import { Country as CSCCountry, State as CSCState, City as CSCCity } from 'country-state-city';
 
 // Edge Function URL for GPS geocoding (real-time location detection)
 const LOCATION_GEOCODE_API = `${config.SUPABASE_URL}/functions/v1/hushh-location-geocode`;
 
-// Types for location data from our Edge Function
+// Types for location data
 interface Country {
   isoCode: string;
   name: string;
@@ -20,9 +21,6 @@ interface State {
 interface City {
   name: string;
 }
-
-// Supabase Edge Function URL
-const LOCATIONS_API = 'https://ibsisfnjxeowvdtvgzff.supabase.co/functions/v1/get-locations';
 
 // Back arrow icon
 const BackIcon = () => (
@@ -98,78 +96,65 @@ function OnboardingStep10() {
     window.scrollTo(0, 0);
   }, []);
 
-  // Fetch countries on mount
+  // Load countries on mount (using npm package directly - no API call needed)
   useEffect(() => {
-    const fetchCountries = async () => {
-      try {
-        setLoadingCountries(true);
-        const response = await fetch(`${LOCATIONS_API}?type=countries`);
-        const result = await response.json();
-        if (result.data) {
-          setCountries(result.data);
-          setCountriesLoaded(true);
-          console.log('[Step10] Countries loaded:', result.data.length);
-        }
-      } catch (err) {
-        console.error('Error fetching countries:', err);
-      } finally {
-        setLoadingCountries(false);
-      }
-    };
-
-    fetchCountries();
+    try {
+      setLoadingCountries(true);
+      const allCountries = CSCCountry.getAllCountries().map(c => ({
+        isoCode: c.isoCode,
+        name: c.name,
+      }));
+      setCountries(allCountries);
+      setCountriesLoaded(true);
+      console.log('[Step10] Countries loaded:', allCountries.length);
+    } catch (err) {
+      console.error('Error loading countries:', err);
+    } finally {
+      setLoadingCountries(false);
+    }
   }, []);
 
-  // Fetch states when country changes
+  // Load states when country changes (using npm package directly)
   useEffect(() => {
     if (!country) {
       setStates([]);
       return;
     }
 
-    const fetchStates = async () => {
-      try {
-        setLoadingStates(true);
-        const response = await fetch(`${LOCATIONS_API}?type=states&country=${country}`);
-        const result = await response.json();
-        if (result.data) {
-          setStates(result.data);
-          console.log('[Step10] States loaded for', country, ':', result.data.length);
-        }
-      } catch (err) {
-        console.error('Error fetching states:', err);
-      } finally {
-        setLoadingStates(false);
-      }
-    };
-
-    fetchStates();
+    try {
+      setLoadingStates(true);
+      const countryStates = CSCState.getStatesOfCountry(country).map(s => ({
+        isoCode: s.isoCode,
+        name: s.name,
+      }));
+      setStates(countryStates);
+      console.log('[Step10] States loaded for', country, ':', countryStates.length);
+    } catch (err) {
+      console.error('Error loading states:', err);
+    } finally {
+      setLoadingStates(false);
+    }
   }, [country]);
 
-  // Fetch cities when state changes
+  // Load cities when state changes (using npm package directly)
   useEffect(() => {
     if (!country || !state) {
       setCities([]);
       return;
     }
 
-    const fetchCities = async () => {
-      try {
-        setLoadingCities(true);
-        const response = await fetch(`${LOCATIONS_API}?type=cities&country=${country}&state=${state}`);
-        const result = await response.json();
-        if (result.data) {
-          setCities(result.data);
-          console.log('[Step10] Cities loaded for', state, ':', result.data.length);
-        }
-      } catch (err) {
-        console.error('Error fetching cities:', err);
-      } finally {
-        setLoadingCities(false);
-      }
-    };
-
-    fetchCities();
+    try {
+      setLoadingCities(true);
+      const stateCities = CSCCity.getCitiesOfState(country, state).map(c => ({
+        name: c.name,
+      }));
+      setCities(stateCities);
+      console.log('[Step10] Cities loaded for', state, ':', stateCities.length);
+    } catch (err) {
+      console.error('Error loading cities:', err);
+    } finally {
+      setLoadingCities(false);
+    }
   }, [country, state]);
 
   // ============================================


### PR DESCRIPTION
## Problem
The `get-locations` Edge Function was returning 404 error (not deployed), causing the Country/State/City dropdowns to be empty and non-functional.

## Solution
Use the `country-state-city` npm package directly in the frontend instead of making API calls:
- Added `country-state-city` package to dependencies
- Import `Country`, `State`, `City` from the package
- Load data synchronously (no API calls = instant loading)

## Benefits
- ✅ No dependency on Edge Function
- ✅ Instant data loading (no network latency)
- ✅ Works offline
- ✅ All 250+ countries, 4500+ states, 25000+ cities available

## Test Results
- 127 passed, 1 skipped ✅