### PR TITLE
fix: Make PR Quality Check always pass

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -68,17 +68,19 @@ jobs:
           PR_TITLE="${{ github.event.pull_request.title }}"
           echo "PR Title: $PR_TITLE"
           
-          # Check if title follows conventional commits
+          # Check if title follows conventional commits (informational only)
           if [[ "$PR_TITLE" =~ ^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\(.+\))?:\ .+ ]]; then
             echo "✅ PR title follows conventional commits format"
           else
-            echo "⚠️ Warning: PR title doesn't follow conventional commits format"
+            echo "ℹ️ Note: PR title doesn't follow conventional commits format"
             echo "Suggested formats:"
             echo "  feat: add new feature"
             echo "  fix: resolve bug"
             echo "  docs: update documentation"
             echo "  chore: maintenance task"
           fi
+          # Always pass - AI Code Review handles the real review
+          exit 0
 
       - name: Check PR description
         run: |


### PR DESCRIPTION
### **User description**
## Summary
- Makes PR Quality Check job informational only (always passes)
- AI Code Review (PR-Agent) handles actual code review
- Conventional commit format is now a suggestion, not a requirement

This ensures all future PRs can pass CI checks.


___

### **PR Type**
Enhancement


___

### **Description**
- Turn PR title format check into informational step

- Change non-conformance warning to informational note

- Insert `exit 0` to always pass this job


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-checks.yml</strong><dd><code>Informational PR title check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-checks.yml

<ul><li>Updated comment to reflect informational-only status<br> <li> Converted warning echo to informational note<br> <li> Added <code>exit 0</code> to force job to always pass</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/280/files#diff-1da7a27709d11ac16eef3de8e46ed10672b7b1d63a790ffbcbd23a94b19efdcb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR quality check workflow to make conventional commit title validation informational rather than blocking, allowing PRs to proceed regardless of commit message format compliance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->