### PR TITLE
fix: re-enable NDA integration tests after edge function redeployment

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,10 +5,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['tests/**/*.test.ts'],
-    // Exclude integration/smoke tests that require live Supabase edge functions
     exclude: [
-      'tests/ndaNotification.test.ts',
-      'tests/ndaIntegration.test.ts',
       'node_modules/**',
     ],
     coverage: {


### PR DESCRIPTION
## Summary
Both `nda-signed-notification` and `nda-admin-fetch` Supabase edge functions were redeployed with the current runtime (they were on old v361/v324 runtimes causing 404s). Both now return HTTP 200.

This PR re-enables the previously excluded NDA integration tests in `vitest.config.ts`.

## Verification
- `nda-signed-notification` OPTIONS → 200 ✅
- `nda-admin-fetch` OPTIONS → 200 ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled notification and integration tests to run as part of the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->