### PR TITLE
feat: Financial verification gate — must complete before KYC

### DIFF
--- a/src/components/kyc/screens/KycFinancialLinkScreen.tsx
+++ b/src/components/kyc/screens/KycFinancialLinkScreen.tsx
@@ -25,6 +25,7 @@ import {
 import { keyframes } from '@emotion/react';
 import { usePlaidLinkHook } from '../../../services/plaid/usePlaidLink';
 import { formatCurrency, getHeaderTitle, type ProductFetchStatus } from '../../../services/plaid/plaidService';
+import type { FinancialVerificationResult } from '../../../types/kyc';
 
 // =====================================================
 // Props
@@ -35,8 +36,8 @@ export interface KycFinancialLinkScreenProps {
   userId: string;
   /** User email (optional, improves Plaid Link UX) */
   userEmail?: string;
-  /** Called when user clicks "Continue to KYC" */
-  onContinue: () => void;
+  /** Called with financial verification result when user clicks "Continue to KYC" */
+  onContinue: (result: FinancialVerificationResult) => void;
   /** Bank name to display */
   bankName?: string;
 }
@@ -299,7 +300,18 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
   // Handle button click
   const handleButtonClick = () => {
     if (plaid.step === 'done' && plaid.canProceed) {
-      onContinue();
+      // Build the financial verification result for the gate
+      const result: FinancialVerificationResult = {
+        verified: true,
+        productsAvailable: plaid.productsAvailable,
+        institutionName: plaid.institution?.name,
+        institutionId: plaid.institution?.id,
+        balanceAvailable: plaid.balanceStatus === 'success',
+        assetsAvailable: plaid.assetsStatus === 'success',
+        investmentsAvailable: plaid.investmentsStatus === 'success',
+        timestamp: new Date().toISOString(),
+      };
+      onContinue(result);
       return;
     }
     if (plaid.step === 'error' || (plaid.step === 'done' && !plaid.canProceed)) {

--- a/src/components/kyc/screens/KycFlowContainer.tsx
+++ b/src/components/kyc/screens/KycFlowContainer.tsx
@@ -29,6 +29,7 @@ import {
   KycCheckRequest,
   KycCheckResponse,
   FlowStep,
+  FinancialVerificationResult,
   generateSyntheticSteps,
 } from '../../../types/kyc';
 
@@ -78,6 +79,8 @@ const initialState: KycFlowState = {
   request: null,
   response: null,
   showDetailModal: false,
+  financialVerified: false,
+  financialData: null,
 };
 
 // =====================================================
@@ -241,25 +244,57 @@ export const KycFlowContainer: React.FC<KycFlowContainerProps> = ({
   
   /**
    * Handle FINANCIAL_LINK → INTRO transition
-   * Called after user successfully links bank and financial data is fetched
+   * GATE: Only proceeds if financial verification result is valid (≥1 product)
    */
-  const handleFinancialLinkComplete = useCallback(() => {
-    console.log('[KYC Flow] Financial verification complete, proceeding to KYC intro');
+  const handleFinancialLinkComplete = useCallback((result: FinancialVerificationResult) => {
+    // GATE CHECK: Must have at least 1 product verified
+    if (!result.verified || result.productsAvailable < 1) {
+      console.warn('[KYC Flow] Financial verification failed — blocking KYC');
+      setState(prev => ({
+        ...prev,
+        step: 'ERROR',
+        error: 'Financial verification is required before proceeding to KYC. Please link your bank account and verify at least one financial product (Balance, Assets, or Investments).',
+      }));
+      return;
+    }
+
+    console.log('[KYC Flow] Financial verification complete ✅', {
+      productsAvailable: result.productsAvailable,
+      institution: result.institutionName,
+      balance: result.balanceAvailable,
+      assets: result.assetsAvailable,
+      investments: result.investmentsAvailable,
+    });
+
     setState(prev => ({
       ...prev,
       step: 'INTRO',
+      financialVerified: true,
+      financialData: result,
     }));
   }, []);
   
   /**
    * Handle INTRO → DETAILS_CONSENT transition
+   * GATE: Only proceeds if financial verification is done
    */
   const handleIntroComplete = useCallback(() => {
+    // Double-check financial gate
+    if (!state.financialVerified) {
+      console.warn('[KYC Flow] Attempted to skip financial verification — blocking');
+      setState(prev => ({
+        ...prev,
+        step: 'FINANCIAL_LINK',
+        error: 'Please complete financial verification first.',
+      }));
+      return;
+    }
+    
     setState(prev => ({
       ...prev,
       step: 'DETAILS_CONSENT',
     }));
-  }, []);
+  }, [state.financialVerified]);
   
   /**
    * Handle DETAILS_CONSENT → AGENTS_COLLAB transition

--- a/src/types/kyc.ts
+++ b/src/types/kyc.ts
@@ -124,6 +124,20 @@ export type FlowStep =
   | 'ERROR';
 
 /**
+ * Financial verification result stored in state
+ */
+export interface FinancialVerificationResult {
+  verified: boolean;
+  productsAvailable: number;
+  institutionName?: string;
+  institutionId?: string;
+  balanceAvailable: boolean;
+  assetsAvailable: boolean;
+  investmentsAvailable: boolean;
+  timestamp: string;
+}
+
+/**
  * Complete flow state for the KYC UI
  */
 export interface KycFlowState {
@@ -133,6 +147,10 @@ export interface KycFlowState {
   request?: KycCheckRequest | null;
   response?: KycCheckResponse | null;
   showDetailModal: boolean;
+  /** Gate: financial verification must be done before KYC */
+  financialVerified: boolean;
+  /** Financial verification result data */
+  financialData?: FinancialVerificationResult | null;
 }
 
 /**
@@ -225,7 +243,8 @@ export interface KycAgentDetailModalProps {
 export interface KycFinancialLinkScreenProps {
   userId: string;
   userEmail?: string;
-  onContinue: () => void;
+  /** Called with financial verification result when user clicks Continue */
+  onContinue: (result: FinancialVerificationResult) => void;
   bankName?: string;
 }
 


### PR DESCRIPTION
Adds a strict gate: user MUST complete financial link (Balance/Assets/Investments via Plaid) before KYC can start. financialVerified flag in state, double-checked at INTRO and DETAILS transitions. 3 files, +74 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KYC flow now requires financial account verification with at least one verified product linked before progression
  * Financial verification data including institution details and product availability is captured and stored
  * System validates verification status at critical KYC stages to ensure compliance requirements are met

<!-- end of auto-generated comment: release notes by coderabbit.ai -->