### PR TITLE
feat: Save Balance, Assets, Investments to Supabase after Plaid fetch

### DIFF
--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -292,6 +292,106 @@ export const checkAssetReport = async (
 };
 
 // =====================================================
+// Save to Supabase
+// =====================================================
+
+/**
+ * Save financial data (Balance, Assets, Investments) to Supabase
+ * Upserts into `user_financial_data` table
+ */
+export const saveFinancialDataToSupabase = async (
+  userId: string,
+  data: FinancialDataResponse,
+  institutionName?: string,
+  institutionId?: string,
+  itemId?: string,
+): Promise<{ success: boolean; error?: string }> => {
+  try {
+    // Dynamic import to avoid circular deps
+    const config = (await import('../../resources/config/config')).default;
+    const supabase = config.supabaseClient;
+
+    if (!supabase) {
+      console.warn('[Plaid] Supabase client not available — skipping save');
+      return { success: false, error: 'Supabase client not initialized' };
+    }
+
+    const row = {
+      user_id: userId,
+      plaid_item_id: itemId || null,
+      institution_name: institutionName || null,
+      institution_id: institutionId || null,
+      balances: data.balance.available ? data.balance.data : null,
+      asset_report: data.assets.available ? data.assets.data : null,
+      asset_report_token: data.assets.data?.asset_report_token || null,
+      investments: data.investments.available ? data.investments.data : null,
+      available_products: {
+        balance: data.balance.available,
+        assets: data.assets.available,
+        investments: data.investments.available,
+      },
+      status: data.status,
+      fetch_errors: buildFetchErrors(data),
+      updated_at: new Date().toISOString(),
+    };
+
+    // Upsert — update if user already has a record, insert otherwise
+    const { error } = await supabase
+      .from('user_financial_data')
+      .upsert(row, { onConflict: 'user_id' })
+      .select()
+      .single();
+
+    if (error) {
+      // If upsert with onConflict fails (no unique constraint), try insert
+      if (error.code === '42P10' || error.message?.includes('unique')) {
+        const { error: insertError } = await supabase
+          .from('user_financial_data')
+          .insert(row);
+
+        if (insertError) {
+          console.error('[Plaid] Failed to save financial data:', insertError);
+          return { success: false, error: insertError.message };
+        }
+      } else {
+        console.error('[Plaid] Failed to save financial data:', error);
+        return { success: false, error: error.message };
+      }
+    }
+
+    console.log('[Plaid] ✅ Financial data saved to Supabase', {
+      userId,
+      institution: institutionName,
+      balance: data.balance.available,
+      assets: data.assets.available,
+      investments: data.investments.available,
+    });
+
+    return { success: true };
+  } catch (err: any) {
+    console.error('[Plaid] Error saving financial data:', err);
+    return { success: false, error: err.message };
+  }
+};
+
+/**
+ * Build fetch_errors JSONB from product results
+ */
+const buildFetchErrors = (data: FinancialDataResponse): Record<string, string> | null => {
+  const errors: Record<string, string> = {};
+
+  if (data.balance.error) errors.balance = data.balance.error;
+  if (data.assets.error) errors.assets = data.assets.error;
+  if (data.investments.error) errors.investments = data.investments.error;
+
+  if (data.balance.reason === 'not_supported') errors.balance = 'Product not supported';
+  if (data.assets.reason === 'not_supported') errors.assets = 'Product not supported';
+  if (data.investments.reason === 'not_supported') errors.investments = 'Product not supported';
+
+  return Object.keys(errors).length > 0 ? errors : null;
+};
+
+// =====================================================
 // Utility Functions
 // =====================================================
 

--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -16,6 +16,7 @@ import {
   fetchAllFinancialData,
   checkAssetReport,
   getProductStatus,
+  saveFinancialDataToSupabase,
   type FinancialDataResponse,
   type ProductFetchStatus,
 } from './plaidService';
@@ -176,6 +177,15 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
         canProceed: financialResult.summary.can_proceed,
         productsAvailable: financialResult.summary.products_available,
       }));
+
+      // Save financial data to Supabase (fire-and-forget, non-blocking)
+      saveFinancialDataToSupabase(
+        userId,
+        financialResult,
+        institutionInfo.name,
+        institutionInfo.id,
+        exchangeResult.item_id,
+      ).catch((err) => console.warn('[Plaid] Background save failed:', err));
 
       // If assets are pending, start polling
       if (assetsStatus === 'pending' && financialResult.assets.data?.asset_report_token) {

--- a/supabase/migrations/create_user_financial_data.sql
+++ b/supabase/migrations/create_user_financial_data.sql
@@ -32,6 +32,10 @@ CREATE TABLE IF NOT EXISTS public.user_financial_data (
   updated_at TIMESTAMPTZ DEFAULT now()
 );
 
+-- Unique constraint on user_id for upsert support
+ALTER TABLE public.user_financial_data
+  ADD CONSTRAINT user_financial_data_user_id_unique UNIQUE (user_id);
+
 -- Index for fast lookup by user
 CREATE INDEX IF NOT EXISTS idx_user_financial_data_user_id
   ON public.user_financial_data (user_id);


### PR DESCRIPTION
Adds saveFinancialDataToSupabase() that saves all 3 financial products to user_financial_data table. Called fire-and-forget in usePlaidLink after fetch completes. Added unique constraint on user_id for upsert. 3 files, +114 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Financial data from linked accounts is now automatically saved and securely persisted to your profile.
  * Background data synchronization runs automatically after each account connection.

* **Chores**
  * Database infrastructure updated with enhanced security policies restricting access to personal financial information.
  * Automatic timestamp tracking implemented for all financial data modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->