### PR TITLE
feat: Plaid financial link as first onboarding step (before Step 1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ import PrivacyControlsPage from './pages/hushh-user-profile/privacy';
 import PublicHushhProfilePage from './pages/hushhid';
 import PublicInvestorProfilePage from './pages/investor/PublicInvestorProfile';
 import HushhIDHeroDemo from './pages/hushhid-hero-demo';
+import OnboardingFinancialLink from './pages/onboarding/FinancialLink';
 import OnboardingStep1 from './pages/onboarding/Step1';
 import OnboardingStep2 from './pages/onboarding/Step2';
 import OnboardingStep3 from './pages/onboarding/Step3';
@@ -222,6 +223,11 @@ function App() {
             <Route path="/auth/callback" element={<AuthCallback />} />
             {/* Investor Onboarding Guide - Public landing page */}
             <Route path="/investor-guide" element={<InvestorGuidePage />} />
+            <Route path="/onboarding/financial-link" element={
+              <ProtectedRoute>
+                <OnboardingFinancialLink />
+              </ProtectedRoute>
+            } />
             <Route path="/onboarding/step-1" element={
               <ProtectedRoute>
                 <OnboardingStep1 />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -182,7 +182,7 @@ export default function Hero() {
     }
     return { 
       text: "Complete Your Hushh Profile", 
-      action: () => navigate("/onboarding/step-1"),
+      action: () => navigate("/onboarding/financial-link"),
       loading: false
     };
   };

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -64,7 +64,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 
       if (!onboardingData || !onboardingData.is_completed) {
         if (!isOnOnboardingPage) {
-          navigate('/onboarding/step-1', { replace: true });
+          navigate('/onboarding/financial-link', { replace: true });
           return;
         }
       }

--- a/src/components/profile/profilePage.tsx
+++ b/src/components/profile/profilePage.tsx
@@ -270,7 +270,7 @@ const ProfilePage: React.FC = () => {
     }
     return { 
       text: "Complete Your Hushh Profile", 
-      action: () => navigate("/onboarding/step-1") 
+      action: () => navigate("/onboarding/financial-link")
     };
   };
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -139,7 +139,7 @@ const AuthCallback: React.FC = () => {
       return customRedirect;
     }
     // Otherwise, default behavior: onboarding or profile
-    return hasCompletedOnboarding ? '/hushh-user-profile' : '/onboarding/step-1';
+    return hasCompletedOnboarding ? '/hushh-user-profile' : '/onboarding/financial-link';
   };
 
   useEffect(() => {

--- a/src/pages/onboarding/FinancialLink.tsx
+++ b/src/pages/onboarding/FinancialLink.tsx
@@ -1,0 +1,113 @@
+/**
+ * FinancialLink — Pre-Onboarding Financial Verification
+ * 
+ * This is the FIRST step in the onboarding flow (before Step 1).
+ * Links user's bank via Plaid and fetches:
+ * 1. Balance
+ * 2. Assets
+ * 3. Investments
+ * 
+ * On completion → navigates to /onboarding/step-1
+ * Data is saved to Supabase `user_financial_data` table automatically.
+ */
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Box, Button, Text } from '@chakra-ui/react';
+import config from '../../resources/config/config';
+import KycFinancialLinkScreen from '../../components/kyc/screens/KycFinancialLinkScreen';
+import type { FinancialVerificationResult } from '../../types/kyc';
+
+export default function OnboardingFinancialLink() {
+  const navigate = useNavigate();
+  const [userId, setUserId] = useState<string>('');
+  const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  // Get authenticated user
+  useEffect(() => {
+    const getUser = async () => {
+      if (!config.supabaseClient) {
+        navigate('/login');
+        return;
+      }
+
+      const { data: { user } } = await config.supabaseClient.auth.getUser();
+      if (!user) {
+        navigate('/login');
+        return;
+      }
+
+      setUserId(user.id);
+      setUserEmail(user.email || undefined);
+
+      // Check if user already completed financial link
+      const { data: financialData } = await config.supabaseClient
+        .from('user_financial_data')
+        .select('status')
+        .eq('user_id', user.id)
+        .single();
+
+      // If already completed, skip to step 1
+      if (financialData?.status === 'complete' || financialData?.status === 'partial') {
+        navigate('/onboarding/step-1', { replace: true });
+        return;
+      }
+
+      setIsReady(true);
+    };
+
+    getUser();
+  }, [navigate]);
+
+  // Handle financial verification complete → go to Step 1
+  const handleContinue = (result: FinancialVerificationResult) => {
+    console.log('[FinancialLink] Verification complete:', result);
+    navigate('/onboarding/step-1');
+  };
+
+  // Skip option — let user proceed without linking bank
+  const handleSkip = () => {
+    navigate('/onboarding/step-1');
+  };
+
+  if (!isReady || !userId) {
+    return (
+      <Box minH="100vh" bg="linear-gradient(180deg, #0A0A0F 0%, #12121A 100%)" />
+    );
+  }
+
+  return (
+    <Box position="relative">
+      <KycFinancialLinkScreen
+        userId={userId}
+        userEmail={userEmail}
+        onContinue={handleContinue}
+        bankName="Hushh"
+      />
+
+      {/* Skip Button — fixed at bottom */}
+      <Box
+        position="fixed"
+        bottom="16px"
+        left="50%"
+        transform="translateX(-50%)"
+        zIndex={10}
+      >
+        <Button
+          variant="ghost"
+          color="whiteAlpha.400"
+          fontSize="sm"
+          fontWeight="400"
+          onClick={handleSkip}
+          _hover={{ color: 'whiteAlpha.700' }}
+        >
+          Skip for now →
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/pages/onboarding/InvestorGuide.tsx
+++ b/src/pages/onboarding/InvestorGuide.tsx
@@ -183,9 +183,9 @@ export default function InvestorGuide() {
 
   const handleStartJourney = () => {
     if (isLoggedIn) {
-      navigate('/onboarding/step-1');
+      navigate('/onboarding/financial-link');
     } else {
-      navigate('/login', { state: { redirectTo: '/onboarding/step-1' } });
+      navigate('/login', { state: { redirectTo: '/onboarding/financial-link' } });
     }
   };
 


### PR DESCRIPTION
Adds /onboarding/financial-link route as the FIRST step in onboarding. User links bank via Plaid to fetch Balance, Assets, Investments before proceeding to Step 1. All entry points updated. Skip option available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a financial verification step as the new entry point in the onboarding process
  * Users are presented with a verification screen upon initial login
  * Automatically advances users who have already completed verification to the next step
  * Users can skip financial verification and proceed directly to standard onboarding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->