### PR TITLE
fix: button shows loading during Plaid initialization

### DIFF
--- a/src/components/kyc/screens/KycFinancialLinkScreen.tsx
+++ b/src/components/kyc/screens/KycFinancialLinkScreen.tsx
@@ -338,6 +338,7 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
   }, [plaid.step, plaid.institution]);
 
   const isProcessing = ['creating_token', 'exchanging', 'fetching'].includes(plaid.step);
+  const isInitializing = plaid.step === 'idle' || plaid.step === 'creating_token';
 
   // Info message after results
   const infoMessage = useMemo(() => {
@@ -351,6 +352,7 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
 
   // Button text
   const buttonText = useMemo(() => {
+    if (plaid.step === 'idle') return 'Preparing...';
     if (plaid.step === 'creating_token') return 'Preparing...';
     if (plaid.step === 'linking') return 'Connecting...';
     if (plaid.step === 'exchanging') return 'Securing connection...';
@@ -572,8 +574,8 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
           h="52px"
           fontSize="16px"
           fontWeight="600"
-          isDisabled={isProcessing || plaid.step === 'creating_token'}
-          isLoading={isProcessing}
+          isDisabled={isInitializing || isProcessing}
+          isLoading={isInitializing || isProcessing}
           loadingText={buttonText}
           _hover={{
             bg: buttonHoverBg,


### PR DESCRIPTION
Button now shows 'Preparing...' spinner while Plaid link token is being created. Cards auto-fill after bank connection — they are status indicators, not selectable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced KYC financial link initialization flow with improved visual feedback
  * Added "Preparing..." button state during initialization
  * Refined button interactivity to prevent user actions during initialization process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->