### PR TITLE
ux: remove radio-button circles, clearer idle text

### DIFF
--- a/src/components/kyc/screens/KycFinancialLinkScreen.tsx
+++ b/src/components/kyc/screens/KycFinancialLinkScreen.tsx
@@ -158,16 +158,8 @@ const StatusIndicator: React.FC<{ status: ProductFetchStatus }> = ({ status }) =
     );
   }
 
-  // idle — empty circle
-  return (
-    <Box
-      w="18px"
-      h="18px"
-      borderRadius="full"
-      border="1.5px solid"
-      borderColor={COLORS.border}
-    />
-  );
+  // idle — no icon shown (avoids radio-button confusion)
+  return null;
 };
 
 // =====================================================
@@ -192,7 +184,7 @@ const ProductCard: React.FC<{
       case 'pending': return 'Generating report...';
       case 'unavailable': return unavailableMessage || 'Not available';
       case 'error': return errorMessage || 'Failed to fetch';
-      default: return 'Waiting to connect...';
+      default: return 'Auto-fetched on connect';
     }
   }, [status, mainValue, unavailableMessage, errorMessage]);
 


### PR DESCRIPTION
Removed empty circles from idle state cards (looked like unselected radio buttons, confusing users). Cards now show no icon until bank connects. Changed text from 'Waiting to connect...' to 'Auto-fetched on connect' to clarify cards are status indicators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed empty circle icon from idle status indicators to prevent confusion with radio buttons
  * Updated default status message to "Auto-fetched on connect" for clearer communication about product connection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->