### PR TITLE
fix: prevent screen refresh on navigate back + sandbox mode

### DIFF
--- a/src/pages/onboarding/FinancialLink.tsx
+++ b/src/pages/onboarding/FinancialLink.tsx
@@ -10,7 +10,7 @@
  * On completion → navigates to /onboarding/step-1
  * Data is saved to Supabase `user_financial_data` table automatically.
  */
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Box } from '@chakra-ui/react';
 import config from '../../resources/config/config';
@@ -22,14 +22,18 @@ export default function OnboardingFinancialLink() {
   const [userId, setUserId] = useState<string>('');
   const [userEmail, setUserEmail] = useState<string | undefined>(undefined);
   const [isReady, setIsReady] = useState(false);
+  const hasInitialized = useRef(false);
 
   // Scroll to top on mount
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
 
-  // Get authenticated user
+  // Get authenticated user — runs only once
   useEffect(() => {
+    if (hasInitialized.current) return;
+    hasInitialized.current = true;
+
     const getUser = async () => {
       if (!config.supabaseClient) {
         navigate('/login');
@@ -46,23 +50,27 @@ export default function OnboardingFinancialLink() {
       setUserEmail(user.email || undefined);
 
       // Check if user already completed financial link
-      const { data: financialData } = await config.supabaseClient
-        .from('user_financial_data')
-        .select('status')
-        .eq('user_id', user.id)
-        .single();
+      try {
+        const { data: financialData } = await config.supabaseClient
+          .from('user_financial_data')
+          .select('status')
+          .eq('user_id', user.id)
+          .single();
 
-      // If already completed, skip to step 1
-      if (financialData?.status === 'complete' || financialData?.status === 'partial') {
-        navigate('/onboarding/step-1', { replace: true });
-        return;
+        // If already completed, skip to step 1
+        if (financialData?.status === 'complete' || financialData?.status === 'partial') {
+          navigate('/onboarding/step-1', { replace: true });
+          return;
+        }
+      } catch {
+        // Table may not exist yet — continue anyway
       }
 
       setIsReady(true);
     };
 
     getUser();
-  }, [navigate]);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Handle financial verification complete → go to Step 1
   const handleContinue = (result: FinancialVerificationResult) => {

--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -91,6 +91,7 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
   // Store access token in ref (not in state — it's sensitive)
   const accessTokenRef = useRef<string | null>(null);
   const assetPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hasInitializedRef = useRef(false);
 
   // =====================================================
   // Step 1: Create Link Token
@@ -117,12 +118,13 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
     }
   }, [userId, userEmail]);
 
-  // Auto-initialize on mount
+  // Auto-initialize on mount — only once per hook instance
   useEffect(() => {
-    if (userId) {
+    if (userId && !hasInitializedRef.current) {
+      hasInitializedRef.current = true;
       initializeLinkToken();
     }
-  }, [initializeLinkToken]);
+  }, [userId, initializeLinkToken]);
 
   // =====================================================
   // Step 2 & 3: Plaid Link Success Handler
@@ -313,6 +315,7 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
       productsAvailable: 0,
     });
     accessTokenRef.current = null;
+    hasInitializedRef.current = false;
     initializeLinkToken();
   }, [initializeLinkToken]);
 


### PR DESCRIPTION
### Changes:
1. **Screen refresh fix** — Added `hasInitialized` refs to both `FinancialLink.tsx` and `usePlaidLink.ts` to prevent double-initialization when navigating back to the page
2. **Sandbox mode** — Updated Supabase edge function secrets to use `PLAID_ENV=sandbox` for testing
3. **Error handling** — Wrapped `user_financial_data` query in try/catch (table may not exist yet)

### Testing:
- Navigate to financial link → go forward → go back → should NOT re-initialize
- Use test credentials: `user_good` / `pass_good` with any sandbox bank

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization reliability by preventing duplicate execution during component re-renders
  * Enhanced authentication flow with proper checks and login redirects
  * Added error handling for edge cases in data retrieval
  * Fixed retry logic for payment linking to properly handle re-initialization scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->