### PR TITLE
fix: use maybeSingle() to avoid PGRST116 on empty financial data

### DIFF
--- a/src/pages/onboarding/FinancialLink.tsx
+++ b/src/pages/onboarding/FinancialLink.tsx
@@ -55,7 +55,7 @@ export default function OnboardingFinancialLink() {
           .from('user_financial_data')
           .select('status')
           .eq('user_id', user.id)
-          .single();
+          .maybeSingle();
 
         // If already completed, skip to step 1
         if (financialData?.status === 'complete' || financialData?.status === 'partial') {


### PR DESCRIPTION
Fixes 406 error when new users visit /onboarding/financial-link. `.single()` requires exactly 1 row — fails when user has no financial data yet. `.maybeSingle()` returns null gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability in the onboarding financial linking process to gracefully handle cases where financial data may be unavailable, preventing errors and ensuring a smoother account setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->