### PR TITLE
fix: remove .select().single() from upsert in saveFinancialDataToSupabase

### DIFF
--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -358,9 +358,7 @@ export const saveFinancialDataToSupabase = async (
     // Upsert — update if user already has a record, insert otherwise
     const { error } = await supabase
       .from('user_financial_data')
-      .upsert(row, { onConflict: 'user_id' })
-      .select()
-      .single();
+      .upsert(row, { onConflict: 'user_id' });
 
     if (error) {
       // If upsert with onConflict fails (no unique constraint), try insert


### PR DESCRIPTION
The `.select().single()` after upsert was unnecessary and could cause PGRST116 errors. Simple `.upsert()` is sufficient — we don't need the returned data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized financial data save operation by streamlining the retrieval process, improving efficiency without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->