### PR TITLE
feat: add Plaid Supabase edge functions (already deployed)

### DIFF
--- a/supabase/functions/asset-report-create/index.ts
+++ b/supabase/functions/asset-report-create/index.ts
@@ -1,0 +1,92 @@
+// asset-report-create — Create or get Plaid asset report
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json();
+    const PLAID_CLIENT_ID = Deno.env.get('PLAID_CLIENT_ID');
+    const PLAID_SECRET = Deno.env.get('PLAID_SECRET');
+    const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
+    const baseUrl = `https://${PLAID_ENV}.plaid.com`;
+
+    // If assetReportToken is provided, get existing report
+    if (body.assetReportToken && body.action === 'get') {
+      const response = await fetch(`${baseUrl}/asset_report/get`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          client_id: PLAID_CLIENT_ID,
+          secret: PLAID_SECRET,
+          asset_report_token: body.assetReportToken,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (data.error_code === 'PRODUCT_NOT_READY') {
+          return new Response(
+            JSON.stringify({ status: 'pending', message: 'Asset report not ready yet' }),
+            { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response(
+          JSON.stringify({ error: data.error_message, error_code: data.error_code }),
+          { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+        );
+      }
+
+      return new Response(
+        JSON.stringify({ status: 'complete', data: data.report }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    // Create new asset report
+    const accessToken = body.accessToken || body.access_token;
+    if (!accessToken) {
+      return new Response(
+        JSON.stringify({ error: 'accessToken is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const response = await fetch(`${baseUrl}/asset_report/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        access_tokens: [accessToken],
+        days_requested: 60,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return new Response(
+        JSON.stringify({ error: data.error_message, error_code: data.error_code }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        status: 'pending',
+        asset_report_token: data.asset_report_token,
+        asset_report_id: data.asset_report_id,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (err: any) {
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/functions/create-link-token/index.ts
+++ b/supabase/functions/create-link-token/index.ts
@@ -1,0 +1,59 @@
+// create-link-token — Creates a Plaid Link token for initializing Plaid Link
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const { userId, userEmail } = await req.json();
+
+    if (!userId) {
+      return new Response(
+        JSON.stringify({ error: 'userId is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const PLAID_CLIENT_ID = Deno.env.get('PLAID_CLIENT_ID');
+    const PLAID_SECRET = Deno.env.get('PLAID_SECRET');
+    const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
+    const baseUrl = `https://${PLAID_ENV}.plaid.com`;
+
+    const response = await fetch(`${baseUrl}/link/token/create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        user: { client_user_id: userId, email_address: userEmail },
+        client_name: 'Hushh',
+        products: ['auth', 'transactions', 'investments', 'assets'],
+        country_codes: ['US'],
+        language: 'en',
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      console.error('[create-link-token] Plaid error:', data);
+      return new Response(
+        JSON.stringify({ error: data.error_message || 'Failed to create link token', details: data }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ link_token: data.link_token, expiration: data.expiration }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (err) {
+    console.error('[create-link-token] Error:', err);
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/functions/exchange-public-token/index.ts
+++ b/supabase/functions/exchange-public-token/index.ts
@@ -1,0 +1,60 @@
+// exchange-public-token — Exchange Plaid public token for access token
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json();
+    const publicToken = body.publicToken || body.public_token;
+    const userId = body.userId || body.user_id;
+
+    if (!publicToken) {
+      return new Response(
+        JSON.stringify({ error: 'publicToken is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const PLAID_CLIENT_ID = Deno.env.get('PLAID_CLIENT_ID');
+    const PLAID_SECRET = Deno.env.get('PLAID_SECRET');
+    const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
+    const baseUrl = `https://${PLAID_ENV}.plaid.com`;
+
+    const response = await fetch(`${baseUrl}/item/public_token/exchange`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        public_token: publicToken,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      console.error('[exchange-public-token] Plaid error:', data);
+      return new Response(
+        JSON.stringify({ error: data.error_message || 'Failed to exchange token', details: data }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        access_token: data.access_token,
+        item_id: data.item_id,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  } catch (err: any) {
+    console.error('[exchange-public-token] Error:', err);
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/functions/get-balance/index.ts
+++ b/supabase/functions/get-balance/index.ts
@@ -1,0 +1,53 @@
+// get-balance — Fetch account balances from Plaid
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json();
+    const accessToken = body.accessToken || body.access_token;
+
+    if (!accessToken) {
+      return new Response(
+        JSON.stringify({ error: 'accessToken is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const PLAID_CLIENT_ID = Deno.env.get('PLAID_CLIENT_ID');
+    const PLAID_SECRET = Deno.env.get('PLAID_SECRET');
+    const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
+    const baseUrl = `https://${PLAID_ENV}.plaid.com`;
+
+    const response = await fetch(`${baseUrl}/accounts/balance/get`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return new Response(
+        JSON.stringify({ error: data.error_message, error_code: data.error_code }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/functions/investments-holdings/index.ts
+++ b/supabase/functions/investments-holdings/index.ts
@@ -1,0 +1,53 @@
+// investments-holdings — Fetch investment holdings from Plaid
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json();
+    const accessToken = body.accessToken || body.access_token;
+
+    if (!accessToken) {
+      return new Response(
+        JSON.stringify({ error: 'accessToken is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const PLAID_CLIENT_ID = Deno.env.get('PLAID_CLIENT_ID');
+    const PLAID_SECRET = Deno.env.get('PLAID_SECRET');
+    const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
+    const baseUrl = `https://${PLAID_ENV}.plaid.com`;
+
+    const response = await fetch(`${baseUrl}/investments/holdings/get`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return new Response(
+        JSON.stringify({ error: data.error_message, error_code: data.error_code }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response(JSON.stringify(data), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});


### PR DESCRIPTION
All 5 Plaid edge functions have been deployed to Supabase with --no-verify-jwt. This PR adds the source code to the repo for future reference and redeployment.

Functions: create-link-token, exchange-public-token, get-balance, asset-report-create, investments-holdings

**Already deployed and tested** - create-link-token returns valid link tokens with anon key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Plaid integration for securely connecting financial accounts
* Enabled asset report creation and retrieval for comprehensive account verification
* Implemented account balance inquiry functionality for real-time account data access
* Added investment holdings data retrieval for complete portfolio visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->