### PR TITLE
fix: Prevent stale OAuth flag from triggering invalid Plaid Link flow

### DIFF
--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -96,9 +96,9 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
   // =====================================================
   // OAuth Redirect Detection
   // When banks like Chase use OAuth, the browser redirects away and back.
-  // We detect this by checking for:
-  // 1. oauth_state_id in the URL (standard Plaid OAuth redirect)
-  // 2. plaid_oauth_pending flag in sessionStorage (set before OAuth opens)
+  // We ONLY treat it as an OAuth redirect if oauth_state_id is in the URL.
+  // The plaid_oauth_pending flag alone is NOT sufficient — without
+  // oauth_state_id, Plaid Link will reject with INVALID_FIELD error.
   // =====================================================
 
   const isOAuthRedirect = useRef(false);
@@ -111,15 +111,19 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
     const hasOAuthStateId = !!params.get('oauth_state_id');
     const hasOAuthPending = sessionStorage.getItem('plaid_oauth_pending') === 'true';
 
-    if (hasOAuthStateId || hasOAuthPending) {
+    if (hasOAuthStateId) {
+      // Valid OAuth redirect — oauth_state_id present in URL
       console.log('[Plaid] 🔄 OAuth redirect detected!', {
         oauth_state_id: params.get('oauth_state_id'),
-        oauth_pending_flag: hasOAuthPending,
       });
       isOAuthRedirect.current = true;
       receivedRedirectUri.current = window.location.href;
-      // Clear the flag
       sessionStorage.removeItem('plaid_oauth_pending');
+    } else if (hasOAuthPending) {
+      // Stale flag without oauth_state_id — clear it and start fresh
+      console.log('[Plaid] ⚠️ Stale OAuth pending flag found (no oauth_state_id). Clearing and starting fresh.');
+      sessionStorage.removeItem('plaid_oauth_pending');
+      // Do NOT set isOAuthRedirect — let normal flow proceed
     }
   }, []);
 


### PR DESCRIPTION
## Summary
Fixes OAuth redirect detection bug that caused INVALID_FIELD error when selecting OAuth banks (like Chase) and navigating back.

## Root Cause
The `plaid_oauth_pending` sessionStorage flag alone was triggering OAuth redirect detection (using `||` condition), even without `oauth_state_id` in the URL. Plaid Link requires a valid `oauth_state_id` to complete OAuth flow.

## Fix
- Only treat as OAuth redirect when `oauth_state_id` is present in URL
- Clear stale `plaid_oauth_pending` flags silently and proceed with normal flow
- Added clear console logging for debugging

## Error Fixed
```
Error: oauth uri does not contain a valid oauth_state_id query parameter
POST https://sandbox.plaid.com/link/workflow/start 400 (Bad Request)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth redirect detection to prevent stale state misclassification, ensuring the authentication flow proceeds correctly without unintended side effects.

* **Refactor**
  * Simplified OAuth redirect validation logic for cleaner state management and more reliable authentication handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->