### PR TITLE
fix: Clear stale link token on aborted OAuth to prevent Plaid SDK errors

### DIFF
--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -120,10 +120,11 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
       receivedRedirectUri.current = window.location.href;
       sessionStorage.removeItem('plaid_oauth_pending');
     } else if (hasOAuthPending) {
-      // Stale flag without oauth_state_id — clear it and start fresh
+      // Stale flag without oauth_state_id — clear everything and start fresh
       console.log('[Plaid] ⚠️ Stale OAuth pending flag found (no oauth_state_id). Clearing and starting fresh.');
       sessionStorage.removeItem('plaid_oauth_pending');
-      // Do NOT set isOAuthRedirect — let normal flow proceed
+      sessionStorage.removeItem('plaid_link_token');
+      // Do NOT set isOAuthRedirect — let normal flow create a fresh link token
     }
   }, []);
 


### PR DESCRIPTION
## Summary
Clears the stored `plaid_link_token` from sessionStorage when an aborted OAuth flow is detected. This prevents the Plaid Link SDK from using a stale token that causes 'Cannot go back. Current pane does not exist' internal errors.

## Fix
When detecting stale `plaid_oauth_pending` flag (no `oauth_state_id` in URL), now also removes `plaid_link_token` from sessionStorage so a completely fresh link token is created.