### PR TITLE
feat: Fresh Plaid integration — clean rewrite, no OAuth

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -6,9 +6,7 @@ interface ProtectedRouteProps {
   children: React.ReactNode;
 }
 
-const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
-  children
-}) => {
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
   const [isLoading, setIsLoading] = useState(true);
@@ -19,17 +17,13 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     let subscription: any = null;
     try {
       if (!config.supabaseClient) {
-        console.error("Supabase client is not initialized");
         navigate("/login", { replace: true });
         return;
       }
 
       const supabase = config.supabaseClient;
-
-      // 1. Session Check
       let { data: { session } } = await supabase.auth.getSession();
 
-      // Wait for session logic (same as before)
       if (!session?.user) {
         await new Promise<void>((resolve) => {
           const { data } = supabase.auth.onAuthStateChange((_, newSession) => {
@@ -53,7 +47,6 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         return;
       }
 
-      // 2. Onboarding Check
       const { data: onboardingData } = await supabase
         .from('onboarding_data')
         .select('is_completed, current_step')
@@ -69,9 +62,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         }
       }
 
-      // 2FA/MFA check has been removed - users can proceed directly
-      console.log('[ProtectedRoute] Authorization check passed (2FA disabled)');
-
+      console.log('[ProtectedRoute] Authorization check passed');
       setIsAuthorized(true);
     } catch (error) {
       console.error("Error checking auth:", error);
@@ -82,18 +73,6 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   };
 
   useEffect(() => {
-    // OAuth Guard: When Plaid OAuth is in progress, the SDK manipulates browser
-    // history which triggers location changes. Skip auth re-check to prevent
-    // interfering with the OAuth flow (which crashes the Plaid SDK iframe).
-    const oauthTimestamp = localStorage.getItem('plaid_oauth_pending');
-    if (oauthTimestamp && isAuthorized) {
-      const flagAge = Date.now() - Number(oauthTimestamp);
-      if (flagAge < 120_000) { // Within 2 minutes — OAuth is in progress
-        console.log('[ProtectedRoute] OAuth in progress — skipping auth re-check');
-        return;
-      }
-    }
-
     checkAuthAndOnboarding();
   }, [navigate, location.pathname]);
 
@@ -108,9 +87,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     );
   }
 
-  if (!isAuthorized) {
-    return null;
-  }
+  if (!isAuthorized) return null;
 
   return <>{children}</>;
 };

--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -1,30 +1,15 @@
 /**
- * Plaid Service — Client-side API calls to Supabase Edge Functions
+ * Plaid Service — Clean API calls to Supabase Edge Functions
  * 
- * Calls production Supabase Edge Functions for Plaid operations.
- * All sensitive operations happen server-side in Edge Functions.
- * This service only sends requests with proper auth headers.
+ * Simple, no-frills service. All sensitive operations happen server-side.
  */
 
 // =====================================================
 // Types
 // =====================================================
 
-export interface PlaidLinkTokenResponse {
-  link_token: string;
-  expiration: string;
-}
-
-export interface PlaidExchangeResponse {
-  access_token: string;
-  item_id: string;
-  record_id?: string | null;
-}
-
-/** Status of a single financial product fetch */
 export type ProductFetchStatus = 'idle' | 'loading' | 'success' | 'unavailable' | 'error' | 'pending';
 
-/** Result for a single product */
 export interface ProductResult {
   available: boolean;
   data: any | null;
@@ -32,7 +17,6 @@ export interface ProductResult {
   reason: 'not_supported' | 'error' | null;
 }
 
-/** Full financial data response */
 export interface FinancialDataResponse {
   status: 'complete' | 'partial' | 'failed';
   balance: ProductResult;
@@ -45,306 +29,181 @@ export interface FinancialDataResponse {
   };
 }
 
-/** Asset report poll response */
-export interface AssetReportPollResponse {
-  status: 'complete' | 'pending';
-  data?: any;
-  message?: string;
-}
-
 // =====================================================
-// Supabase Edge Function Base URL + Auth
+// Config
 // =====================================================
 
 const SUPABASE_URL = 'https://ibsisfnjxeowvdtvgzff.supabase.co/functions/v1';
 
-/** Get the Supabase anon key from env */
 const getAnonKey = (): string => {
   try {
-    // @ts-ignore - Vite env
+    // @ts-ignore
     return import.meta.env?.VITE_SUPABASE_ANON_KEY || '';
-  } catch {
-    return '';
-  }
+  } catch { return ''; }
 };
 
-/** Get the user's auth session token (required by Edge Functions that verify JWT) */
 const getUserAccessToken = async (): Promise<string> => {
   try {
     const config = (await import('../../resources/config/config')).default;
     const supabase = config.supabaseClient;
     if (!supabase) return getAnonKey();
-
     const { data: { session } } = await supabase.auth.getSession();
     return session?.access_token || getAnonKey();
-  } catch {
-    return getAnonKey();
-  }
+  } catch { return getAnonKey(); }
 };
 
-/** Standard headers for all Supabase Edge Function calls */
-const getHeaders = (accessToken?: string): Record<string, string> => ({
+const getHeaders = (token?: string) => ({
   'Content-Type': 'application/json',
-  'Authorization': `Bearer ${accessToken || getAnonKey()}`,
+  'Authorization': `Bearer ${token || getAnonKey()}`,
 });
 
 // =====================================================
-// Service Functions
+// API Calls
 // =====================================================
 
-/**
- * Create a Plaid Link token for initializing Plaid Link
- * Calls: Supabase Edge Function `create-link-token`
- */
-export const createLinkToken = async (
-  userId: string,
-  userEmail?: string,
-  redirectUri?: string,
-): Promise<PlaidLinkTokenResponse> => {
+/** Create a Plaid Link token */
+export const createLinkToken = async (userId: string, userEmail?: string) => {
   const token = await getUserAccessToken();
-  const response = await fetch(`${SUPABASE_URL}/create-link-token`, {
+  const res = await fetch(`${SUPABASE_URL}/create-link-token`, {
     method: 'POST',
     headers: getHeaders(token),
-    body: JSON.stringify({ userId, userEmail, redirectUri }),
+    body: JSON.stringify({ userId, userEmail }),
   });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to create link token' }));
-    throw new Error(error.details || error.error || 'Failed to create link token');
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to create link token');
   }
-
-  return response.json();
+  return res.json() as Promise<{ link_token: string; expiration: string }>;
 };
 
-/**
- * Exchange public_token for access_token after Plaid Link success
- * Calls: Supabase Edge Function `exchange-public-token`
- */
+/** Exchange public token for access token */
 export const exchangeToken = async (
-  publicToken: string,
-  userId: string,
-  institutionName?: string,
-  institutionId?: string,
-): Promise<PlaidExchangeResponse> => {
+  publicToken: string, userId: string,
+  institutionName?: string, institutionId?: string,
+) => {
   const token = await getUserAccessToken();
-  const response = await fetch(`${SUPABASE_URL}/exchange-public-token`, {
+  const res = await fetch(`${SUPABASE_URL}/exchange-public-token`, {
     method: 'POST',
     headers: getHeaders(token),
-    body: JSON.stringify({
-      publicToken,
-      userId,
-      institutionName,
-      institutionId,
-    }),
+    body: JSON.stringify({ publicToken, userId, institutionName, institutionId }),
   });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to exchange token' }));
-    throw new Error(error.details || error.error || 'Failed to exchange token');
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Failed to exchange token');
   }
-
-  return response.json();
+  return res.json() as Promise<{ access_token: string; item_id: string }>;
 };
 
-/**
- * Fetch account balances
- * Calls: Supabase Edge Function `get-balance`
- */
-export const fetchBalance = async (
-  accessToken: string,
-  userId: string,
-): Promise<ProductResult> => {
+/** Fetch balance */
+const fetchBalance = async (accessToken: string, userId: string): Promise<ProductResult> => {
   try {
-    const userToken = await getUserAccessToken();
-    const response = await fetch(`${SUPABASE_URL}/get-balance`, {
-      method: 'POST',
-      headers: getHeaders(userToken),
+    const token = await getUserAccessToken();
+    const res = await fetch(`${SUPABASE_URL}/get-balance`, {
+      method: 'POST', headers: getHeaders(token),
       body: JSON.stringify({ accessToken, userId }),
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      // Check if product not supported
-      if (err.error_code === 'PRODUCTS_NOT_SUPPORTED' || response.status === 400) {
-        return { available: false, data: null, error: null, reason: 'not_supported' };
-      }
-      return { available: false, data: null, error: err.error || 'Failed to fetch balance', reason: 'error' };
+    if (!res.ok) {
+      if (res.status === 400) return { available: false, data: null, error: null, reason: 'not_supported' };
+      const err = await res.json().catch(() => ({}));
+      return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
-
-    const data = await response.json();
-    return { available: true, data, error: null, reason: null };
-  } catch (err: any) {
-    return { available: false, data: null, error: err.message, reason: 'error' };
+    return { available: true, data: await res.json(), error: null, reason: null };
+  } catch (e: any) {
+    return { available: false, data: null, error: e.message, reason: 'error' };
   }
 };
 
-/**
- * Create an asset report
- * Calls: Supabase Edge Function `asset-report-create`
- */
-export const fetchAssets = async (
-  accessToken: string,
-  userId: string,
-): Promise<ProductResult> => {
+/** Fetch assets */
+const fetchAssets = async (accessToken: string, userId: string): Promise<ProductResult> => {
   try {
-    const userToken = await getUserAccessToken();
-    const response = await fetch(`${SUPABASE_URL}/asset-report-create`, {
-      method: 'POST',
-      headers: getHeaders(userToken),
+    const token = await getUserAccessToken();
+    const res = await fetch(`${SUPABASE_URL}/asset-report-create`, {
+      method: 'POST', headers: getHeaders(token),
       body: JSON.stringify({ accessToken, userId }),
     });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({}));
-      if (err.error_code === 'PRODUCTS_NOT_SUPPORTED' || response.status === 400) {
-        return { available: false, data: null, error: null, reason: 'not_supported' };
-      }
-      return { available: false, data: null, error: err.error || 'Failed to fetch assets', reason: 'error' };
+    if (!res.ok) {
+      if (res.status === 400) return { available: false, data: null, error: null, reason: 'not_supported' };
+      const err = await res.json().catch(() => ({}));
+      return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
-
-    const data = await response.json();
-
-    // Asset reports can be async (pending)
-    if (data.status === 'pending') {
-      return { available: false, data, error: null, reason: null };
-    }
-
+    const data = await res.json();
+    if (data.status === 'pending') return { available: false, data, error: null, reason: null };
     return { available: true, data, error: null, reason: null };
-  } catch (err: any) {
-    return { available: false, data: null, error: err.message, reason: 'error' };
+  } catch (e: any) {
+    return { available: false, data: null, error: e.message, reason: 'error' };
   }
 };
 
-/**
- * Fetch investment holdings
- * Calls: Supabase Edge Function `investments-holdings`
- */
-export const fetchInvestments = async (
-  accessToken: string,
-  userId: string,
-): Promise<ProductResult> => {
+/** Fetch investments */
+const fetchInvestments = async (accessToken: string, userId: string): Promise<ProductResult> => {
   try {
-    const userToken = await getUserAccessToken();
-    const response = await fetch(`${SUPABASE_URL}/investments-holdings`, {
-      method: 'POST',
-      headers: getHeaders(userToken),
+    const token = await getUserAccessToken();
+    const res = await fetch(`${SUPABASE_URL}/investments-holdings`, {
+      method: 'POST', headers: getHeaders(token),
       body: JSON.stringify({ accessToken, userId }),
     });
-
-    if (!response.ok) {
-      // Handle 404 (function not deployed) gracefully
-      if (response.status === 404) {
-        console.warn('[Plaid] investments-holdings function not found (404). May need deployment.');
-        return { available: false, data: null, error: 'Investment service temporarily unavailable', reason: 'error' };
-      }
-
-      const err = await response.json().catch(() => ({}));
-      if (err.error_code === 'PRODUCTS_NOT_SUPPORTED' || response.status === 400) {
-        return { available: false, data: null, error: null, reason: 'not_supported' };
-      }
-      return { available: false, data: null, error: err.error || err.error_message || 'Failed to fetch investments', reason: 'error' };
+    if (!res.ok) {
+      if (res.status === 404) return { available: false, data: null, error: 'Service unavailable', reason: 'error' };
+      if (res.status === 400) return { available: false, data: null, error: null, reason: 'not_supported' };
+      const err = await res.json().catch(() => ({}));
+      return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
-
-    const data = await response.json();
-    return { available: true, data, error: null, reason: null };
-  } catch (err: any) {
-    console.error('[Plaid] fetchInvestments error:', err.message);
-    return { available: false, data: null, error: err.message, reason: 'error' };
+    return { available: true, data: await res.json(), error: null, reason: null };
+  } catch (e: any) {
+    return { available: false, data: null, error: e.message, reason: 'error' };
   }
 };
 
-/**
- * Fetch all 3 financial products in parallel
- * Calls get-balance, asset-report-create, investments-holdings simultaneously
- */
+/** Fetch all 3 products in parallel */
 export const fetchAllFinancialData = async (
-  accessToken: string,
-  userId: string,
+  accessToken: string, userId: string,
 ): Promise<FinancialDataResponse> => {
-  const [balanceResult, assetsResult, investmentsResult] = await Promise.allSettled([
+  const [b, a, i] = await Promise.allSettled([
     fetchBalance(accessToken, userId),
     fetchAssets(accessToken, userId),
     fetchInvestments(accessToken, userId),
   ]);
 
-  // Parse settled results
-  const balance: ProductResult = balanceResult.status === 'fulfilled'
-    ? balanceResult.value
-    : { available: false, data: null, error: 'Network error', reason: 'error' };
+  const balance = b.status === 'fulfilled' ? b.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
+  const assets = a.status === 'fulfilled' ? a.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
+  const investments = i.status === 'fulfilled' ? i.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
 
-  const assets: ProductResult = assetsResult.status === 'fulfilled'
-    ? assetsResult.value
-    : { available: false, data: null, error: 'Network error', reason: 'error' };
-
-  const investments: ProductResult = investmentsResult.status === 'fulfilled'
-    ? investmentsResult.value
-    : { available: false, data: null, error: 'Network error', reason: 'error' };
-
-  // Count available products
-  const productsAvailable = [balance, assets, investments].filter((r) => r.available).length;
+  const count = [balance, assets, investments].filter(r => r.available).length;
 
   return {
-    status: productsAvailable === 3 ? 'complete' : productsAvailable > 0 ? 'partial' : 'failed',
-    balance,
-    assets,
-    investments,
-    summary: {
-      products_available: productsAvailable,
-      products_total: 3,
-      can_proceed: productsAvailable >= 1,
-    },
+    status: count === 3 ? 'complete' : count > 0 ? 'partial' : 'failed',
+    balance, assets, investments,
+    summary: { products_available: count, products_total: 3, can_proceed: count >= 1 },
   };
 };
 
-/**
- * Check asset report status (for async asset reports)
- * Calls: Supabase Edge Function `asset-report-create` with report token
- */
-export const checkAssetReport = async (
-  assetReportToken: string,
-  userId: string,
-): Promise<AssetReportPollResponse> => {
-  const userToken = await getUserAccessToken();
-  const response = await fetch(`${SUPABASE_URL}/asset-report-create`, {
-    method: 'POST',
-    headers: getHeaders(userToken),
+/** Check asset report status */
+export const checkAssetReport = async (assetReportToken: string, userId: string) => {
+  const token = await getUserAccessToken();
+  const res = await fetch(`${SUPABASE_URL}/asset-report-create`, {
+    method: 'POST', headers: getHeaders(token),
     body: JSON.stringify({ assetReportToken, userId, action: 'get' }),
   });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to check asset report' }));
-    throw new Error(error.details || error.error || 'Failed to check asset report');
-  }
-
-  return response.json();
+  if (!res.ok) throw new Error('Failed to check asset report');
+  return res.json() as Promise<{ status: 'complete' | 'pending'; data?: any }>;
 };
 
-// =====================================================
-// Save to Supabase
-// =====================================================
-
-/**
- * Save financial data (Balance, Assets, Investments) to Supabase
- * Upserts into `user_financial_data` table
- */
+/** Save financial data to Supabase */
 export const saveFinancialDataToSupabase = async (
-  userId: string,
-  data: FinancialDataResponse,
-  institutionName?: string,
-  institutionId?: string,
-  itemId?: string,
-): Promise<{ success: boolean; error?: string }> => {
+  userId: string, data: FinancialDataResponse,
+  institutionName?: string, institutionId?: string, itemId?: string,
+) => {
   try {
-    // Dynamic import to avoid circular deps
     const config = (await import('../../resources/config/config')).default;
     const supabase = config.supabaseClient;
+    if (!supabase) return;
 
-    if (!supabase) {
-      console.warn('[Plaid] Supabase client not available — skipping save');
-      return { success: false, error: 'Supabase client not initialized' };
-    }
+    const errors: Record<string, string> = {};
+    if (data.balance.error) errors.balance = data.balance.error;
+    if (data.assets.error) errors.assets = data.assets.error;
+    if (data.investments.error) errors.investments = data.investments.error;
 
-    const row = {
+    await supabase.from('user_financial_data').upsert({
       user_id: userId,
       plaid_item_id: itemId || null,
       institution_name: institutionName || null,
@@ -359,105 +218,39 @@ export const saveFinancialDataToSupabase = async (
         investments: data.investments.available,
       },
       status: data.status,
-      fetch_errors: buildFetchErrors(data),
+      fetch_errors: Object.keys(errors).length > 0 ? errors : null,
       updated_at: new Date().toISOString(),
-    };
+    }, { onConflict: 'user_id' });
 
-    // Upsert — update if user already has a record, insert otherwise
-    const { error } = await supabase
-      .from('user_financial_data')
-      .upsert(row, { onConflict: 'user_id' });
-
-    if (error) {
-      // If upsert with onConflict fails (no unique constraint), try insert
-      if (error.code === '42P10' || error.message?.includes('unique')) {
-        const { error: insertError } = await supabase
-          .from('user_financial_data')
-          .insert(row);
-
-        if (insertError) {
-          console.error('[Plaid] Failed to save financial data:', insertError);
-          return { success: false, error: insertError.message };
-        }
-      } else {
-        console.error('[Plaid] Failed to save financial data:', error);
-        return { success: false, error: error.message };
-      }
-    }
-
-    console.log('[Plaid] ✅ Financial data saved to Supabase', {
-      userId,
-      institution: institutionName,
-      balance: data.balance.available,
-      assets: data.assets.available,
-      investments: data.investments.available,
-    });
-
-    return { success: true };
-  } catch (err: any) {
-    console.error('[Plaid] Error saving financial data:', err);
-    return { success: false, error: err.message };
+    console.log('[Plaid] ✅ Data saved to Supabase');
+  } catch (err) {
+    console.warn('[Plaid] Save failed:', err);
   }
 };
 
-/**
- * Build fetch_errors JSONB from product results
- */
-const buildFetchErrors = (data: FinancialDataResponse): Record<string, string> | null => {
-  const errors: Record<string, string> = {};
-
-  if (data.balance.error) errors.balance = data.balance.error;
-  if (data.assets.error) errors.assets = data.assets.error;
-  if (data.investments.error) errors.investments = data.investments.error;
-
-  if (data.balance.reason === 'not_supported') errors.balance = 'Product not supported';
-  if (data.assets.reason === 'not_supported') errors.assets = 'Product not supported';
-  if (data.investments.reason === 'not_supported') errors.investments = 'Product not supported';
-
-  return Object.keys(errors).length > 0 ? errors : null;
-};
-
 // =====================================================
-// Utility Functions
+// Utilities
 // =====================================================
 
-/**
- * Format currency amount for display
- */
 export const formatCurrency = (amount: number | null | undefined, currency = 'USD'): string => {
-  if (amount === null || amount === undefined) return '—';
+  if (amount == null) return '—';
   return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
+    style: 'currency', currency,
+    minimumFractionDigits: 0, maximumFractionDigits: 2,
   }).format(amount);
 };
 
-/**
- * Get display-friendly status for a product
- */
-export const getProductStatus = (product: ProductResult): ProductFetchStatus => {
-  if (product.available) {
-    if (product.data?.status === 'pending') return 'pending';
-    return 'success';
-  }
-  if (product.reason === 'not_supported') return 'unavailable';
-  if (product.error) return 'error';
-  // Check if it's a pending asset report
-  if (product.data?.status === 'pending') return 'pending';
-  return 'idle';
+export const getHeaderTitle = (count: number): string => {
+  if (count === 3) return '✨ Complete Financial Profile';
+  if (count === 2) return '📊 Financial Profile Verified';
+  if (count === 1) return '💰 Account Verified';
+  return '⚠️ Unable to Verify';
 };
 
-/**
- * Get the header title based on how many products are available
- */
-export const getHeaderTitle = (availableCount: number): string => {
-  switch (availableCount) {
-    case 3: return '✨ Complete Financial Profile';
-    case 2: return '📊 Financial Profile Verified';
-    case 1: return '💰 Account Verified';
-    case 0: return '⚠️ Unable to Verify';
-    default: return '💰 Financial Verification';
-  }
+export const getProductStatus = (product: ProductResult): ProductFetchStatus => {
+  if (product.available) return product.data?.status === 'pending' ? 'pending' : 'success';
+  if (product.reason === 'not_supported') return 'unavailable';
+  if (product.error) return 'error';
+  if (product.data?.status === 'pending') return 'pending';
+  return 'idle';
 };

--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -1,12 +1,8 @@
 /**
- * usePlaidLink — Custom React hook for Plaid Link integration
+ * usePlaidLink — Clean Plaid Link hook
  * 
- * Manages the full flow:
- * 1. Create link token
- * 2. Open Plaid Link
- * 3. Exchange token on success
- * 4. Fetch financial data (Balance, Assets, Investments)
- * 5. Track status of each product independently
+ * Simple flow: Create token → Open Link → Exchange → Fetch data
+ * No OAuth complexity. Works with non-OAuth banks (First Platypus, etc.)
  */
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { usePlaidLink as usePlaidLinkSDK, PlaidLinkOnSuccess, PlaidLinkOnExit, PlaidLinkOnEvent } from 'react-plaid-link';
@@ -26,47 +22,22 @@ import {
 // =====================================================
 
 export interface PlaidLinkState {
-  /** Current step in the flow */
   step: 'idle' | 'creating_token' | 'ready' | 'linking' | 'exchanging' | 'fetching' | 'done' | 'error';
-
-  /** Link token for Plaid Link SDK */
   linkToken: string | null;
-
-  /** Error message if something went wrong */
   error: string | null;
-
-  /** Institution info from Plaid Link */
-  institution: {
-    name: string;
-    id: string;
-  } | null;
-
-  /** Status of each product fetch */
+  institution: { name: string; id: string } | null;
   balanceStatus: ProductFetchStatus;
   assetsStatus: ProductFetchStatus;
   investmentsStatus: ProductFetchStatus;
-
-  /** Full financial data response */
   financialData: FinancialDataResponse | null;
-
-  /** Whether user can proceed to KYC */
   canProceed: boolean;
-
-  /** Number of products successfully fetched */
   productsAvailable: number;
 }
 
 export interface UsePlaidLinkReturn extends PlaidLinkState {
-  /** Initialize and open Plaid Link */
   openPlaidLink: () => void;
-
-  /** Retry the entire flow */
   retry: () => void;
-
-  /** Whether Plaid Link is ready to open */
   isReady: boolean;
-
-  /** Open the Plaid Link modal */
   open: () => void;
 }
 
@@ -88,390 +59,160 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
     productsAvailable: 0,
   });
 
-  // Store access token in ref (not in state — it's sensitive)
   const accessTokenRef = useRef<string | null>(null);
-  const assetPollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const hasInitializedRef = useRef(false);
+  const assetPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const initializedRef = useRef(false);
 
-  // =====================================================
-  // OAuth Redirect Detection
-  // When banks like Chase use OAuth, the browser redirects away and back.
-  // We use localStorage (NOT sessionStorage) because OAuth banks may
-  // open in a NEW TAB — sessionStorage is per-tab and wouldn't persist.
-  // We ONLY treat it as an OAuth redirect if oauth_state_id is in the URL.
-  // =====================================================
-
-  const isOAuthRedirect = useRef(false);
-  const receivedRedirectUri = useRef<string | undefined>(undefined);
-
-  useEffect(() => {
-    console.log('[Plaid] 🔍 Mount URL:', window.location.href);
-
-    const params = new URLSearchParams(window.location.search);
-    const hasOAuthStateId = !!params.get('oauth_state_id');
-    const oauthPendingTimestamp = localStorage.getItem('plaid_oauth_pending');
-    const hasOAuthPending = !!oauthPendingTimestamp;
-
-    if (hasOAuthStateId) {
-      // Valid OAuth redirect — oauth_state_id present in URL
-      console.log('[Plaid] 🔄 OAuth redirect detected!', {
-        oauth_state_id: params.get('oauth_state_id'),
-      });
-      isOAuthRedirect.current = true;
-      receivedRedirectUri.current = window.location.href;
-      localStorage.removeItem('plaid_oauth_pending');
-    } else if (hasOAuthPending) {
-      // Check if OAuth is still in progress (within 2 min) or stale
-      const flagAge = Date.now() - Number(oauthPendingTimestamp);
-      const isOAuthInProgress = flagAge < 120_000; // 2 minutes — enough for OAuth flow
-
-      if (isOAuthInProgress) {
-        // OAuth is in progress — do NOT clear the flag or link token!
-        // The user may be on the bank's OAuth page or completing the flow.
-        console.log('[Plaid] 🔑 OAuth in progress (flag age:', Math.round(flagAge / 1000), 's). Preserving state for redirect.');
-      } else {
-        // Stale flag (>2 min old) — user abandoned OAuth
-        console.log('[Plaid] ⚠️ Stale OAuth flag (', Math.round(flagAge / 1000), 's old). Clearing and starting fresh.');
-        localStorage.removeItem('plaid_oauth_pending');
-        localStorage.removeItem('plaid_link_token');
-      }
-    }
-  }, []);
-
-  // =====================================================
-  // Step 1: Create Link Token
-  // =====================================================
-
-  const initializeLinkToken = useCallback(async () => {
+  // Step 1: Create link token
+  const initToken = useCallback(async () => {
     if (!userId) return;
-
-    // If OAuth is in progress, don't create a new token — preserve the existing one
-    const pendingTimestamp = localStorage.getItem('plaid_oauth_pending');
-    if (pendingTimestamp && (Date.now() - Number(pendingTimestamp)) < 120_000) {
-      console.log('[Plaid] ⏳ OAuth in progress. Skipping link token creation.');
-      return;
-    }
-
-    // If returning from OAuth redirect, restore the stored link token
-    if (isOAuthRedirect.current) {
-      const storedToken = localStorage.getItem('plaid_link_token');
-      if (storedToken) {
-        console.log('[Plaid] 🔄 Restoring link token from localStorage for OAuth completion');
-        setState((prev) => ({
-          ...prev,
-          step: 'ready',
-          linkToken: storedToken,
-        }));
-        return;
-      }
-    }
-
-    setState((prev) => ({ ...prev, step: 'creating_token', error: null }));
+    setState(s => ({ ...s, step: 'creating_token', error: null }));
 
     try {
-      // Pass redirect_uri for OAuth banks (Chase, Wells Fargo, etc.)
-      // Registered in Plaid Dashboard → Developers → API → Allowed redirect URIs
-      const redirectUri = 'https://www.hushhtech.com/onboarding/financial-link';
-      console.log('[Plaid] Creating link token with redirectUri:', redirectUri);
-      const response = await createLinkToken(userId, userEmail, redirectUri);
-
-      // Store link token in localStorage for cross-tab OAuth redirect recovery
-      localStorage.setItem('plaid_link_token', response.link_token);
-
-      setState((prev) => ({
-        ...prev,
-        step: 'ready',
-        linkToken: response.link_token,
-      }));
+      console.log('[Plaid] Creating link token...');
+      const { link_token } = await createLinkToken(userId, userEmail);
+      setState(s => ({ ...s, step: 'ready', linkToken: link_token }));
     } catch (err: any) {
-      setState((prev) => ({
-        ...prev,
-        step: 'error',
-        error: err.message || 'Failed to initialize bank connection',
-      }));
+      setState(s => ({ ...s, step: 'error', error: err.message || 'Failed to initialize' }));
     }
   }, [userId, userEmail]);
 
-  // Auto-initialize on mount — only once per hook instance
+  // Auto-init once
   useEffect(() => {
-    if (userId && !hasInitializedRef.current) {
-      hasInitializedRef.current = true;
-      initializeLinkToken();
+    if (userId && !initializedRef.current) {
+      initializedRef.current = true;
+      initToken();
     }
-  }, [userId, initializeLinkToken]);
+  }, [userId, initToken]);
 
-  // =====================================================
-  // Step 2 & 3: Plaid Link Success Handler
-  // =====================================================
+  // Step 2: Handle Plaid Link success
+  const handleSuccess: PlaidLinkOnSuccess = useCallback(async (publicToken, metadata) => {
+    console.log('[Plaid] ✅ onSuccess', { token: publicToken?.slice(0, 20), institution: metadata?.institution?.name });
 
-  const handlePlaidSuccess: PlaidLinkOnSuccess = useCallback(async (publicToken, metadata) => {
-    console.log('[Plaid] ✅ onSuccess called', { publicToken: publicToken?.substring(0, 20), metadata: metadata?.institution });
-
-    // Clean up OAuth storage after successful connection
-    localStorage.removeItem('plaid_oauth_pending');
-    localStorage.removeItem('plaid_link_token');
-
-    const institutionInfo = {
+    const inst = {
       name: metadata.institution?.name || 'Unknown',
       id: metadata.institution?.institution_id || '',
     };
 
-    setState((prev) => ({
-      ...prev,
-      step: 'exchanging',
-      institution: institutionInfo,
-      balanceStatus: 'loading',
-      assetsStatus: 'loading',
-      investmentsStatus: 'loading',
+    setState(s => ({
+      ...s, step: 'exchanging', institution: inst,
+      balanceStatus: 'loading', assetsStatus: 'loading', investmentsStatus: 'loading',
     }));
 
     try {
       // Exchange token
       console.log('[Plaid] Exchanging token...');
-      const exchangeResult = await exchangeToken(
-        publicToken,
-        userId,
-        institutionInfo.name,
-        institutionInfo.id,
-      );
-      console.log('[Plaid] ✅ Exchange success:', { item_id: exchangeResult.item_id, hasAccessToken: !!exchangeResult.access_token });
+      const exchange = await exchangeToken(publicToken, userId, inst.name, inst.id);
+      console.log('[Plaid] ✅ Exchange done:', { item_id: exchange.item_id });
+      accessTokenRef.current = exchange.access_token;
 
-      accessTokenRef.current = exchangeResult.access_token;
+      setState(s => ({ ...s, step: 'fetching' }));
 
-      setState((prev) => ({ ...prev, step: 'fetching' }));
-
-      // Fetch all financial data in parallel (Balance, Assets, Investments)
+      // Fetch financial data
       console.log('[Plaid] Fetching financial data...');
-      const financialResult = await fetchAllFinancialData(
-        exchangeResult.access_token,
-        userId,
-      );
-      console.log('[Plaid] ✅ Financial data result:', {
-        status: financialResult.status,
-        balance: financialResult.balance.available,
-        assets: financialResult.assets.available,
-        investments: financialResult.investments.available,
-        errors: {
-          balance: financialResult.balance.error,
-          assets: financialResult.assets.error,
-          investments: financialResult.investments.error,
-        },
+      const result = await fetchAllFinancialData(exchange.access_token, userId);
+      console.log('[Plaid] ✅ Result:', {
+        status: result.status,
+        balance: result.balance.available,
+        assets: result.assets.available,
+        investments: result.investments.available,
       });
 
-      // Determine individual statuses
-      const balanceStatus = getProductStatus(financialResult.balance);
-      const assetsStatus = getProductStatus(financialResult.assets);
-      const investmentsStatus = getProductStatus(financialResult.investments);
-
-      setState((prev) => ({
-        ...prev,
-        step: 'done',
-        financialData: financialResult,
-        balanceStatus,
-        assetsStatus,
-        investmentsStatus,
-        canProceed: financialResult.summary.can_proceed,
-        productsAvailable: financialResult.summary.products_available,
+      setState(s => ({
+        ...s, step: 'done', financialData: result,
+        balanceStatus: getProductStatus(result.balance),
+        assetsStatus: getProductStatus(result.assets),
+        investmentsStatus: getProductStatus(result.investments),
+        canProceed: result.summary.can_proceed,
+        productsAvailable: result.summary.products_available,
       }));
 
-      // Save financial data to Supabase (fire-and-forget, non-blocking)
-      saveFinancialDataToSupabase(
-        userId,
-        financialResult,
-        institutionInfo.name,
-        institutionInfo.id,
-        exchangeResult.item_id,
-      ).catch((err) => console.warn('[Plaid] Background save failed:', err));
+      // Save to Supabase (background)
+      saveFinancialDataToSupabase(userId, result, inst.name, inst.id, exchange.item_id)
+        .catch(e => console.warn('[Plaid] Save failed:', e));
 
-      // If assets are pending, start polling
-      if (assetsStatus === 'pending' && financialResult.assets.data?.asset_report_token) {
-        startAssetPolling(financialResult.assets.data.asset_report_token);
+      // Poll assets if pending
+      if (getProductStatus(result.assets) === 'pending' && result.assets.data?.asset_report_token) {
+        pollAssets(result.assets.data.asset_report_token);
       }
     } catch (err: any) {
-      console.error('[Plaid] ❌ Error in handlePlaidSuccess:', err);
-      setState((prev) => ({
-        ...prev,
-        step: 'error',
-        error: err.message || 'Failed to connect to your bank',
-        balanceStatus: 'error',
-        assetsStatus: 'error',
-        investmentsStatus: 'error',
+      console.error('[Plaid] ❌ Error:', err);
+      setState(s => ({
+        ...s, step: 'error', error: err.message || 'Failed to connect',
+        balanceStatus: 'error', assetsStatus: 'error', investmentsStatus: 'error',
       }));
     }
   }, [userId]);
 
-  // =====================================================
-  // Plaid Link Exit Handler
-  // =====================================================
-
-  const handlePlaidExit: PlaidLinkOnExit = useCallback((err, metadata) => {
-    console.log('[Plaid] 🚪 onExit called', {
-      error: err,
-      status: metadata?.status,
-      institution: metadata?.institution,
-      linkSessionId: metadata?.link_session_id,
-    });
-
-    // OAuth Guard: If OAuth is in progress, the Plaid SDK fires onExit
-    // because its iframe crashes during the OAuth redirect. This is NOT
-    // a user-initiated exit — ignore it to prevent state corruption.
-    const oauthTimestamp = localStorage.getItem('plaid_oauth_pending');
-    if (oauthTimestamp) {
-      const flagAge = Date.now() - Number(oauthTimestamp);
-      if (flagAge < 120_000) { // Within 2 minutes
-        console.log('[Plaid] 🔑 OAuth is in progress — ignoring onExit (SDK crash during redirect)');
-        return; // Do NOT reset state
-      }
-    }
-
+  // Handle exit
+  const handleExit: PlaidLinkOnExit = useCallback((err, metadata) => {
+    console.log('[Plaid] 🚪 onExit', { error: err, status: metadata?.status });
     if (err) {
-      setState((prev) => ({
-        ...prev,
-        step: 'error',
-        error: `Bank connection was interrupted: ${err.display_message || err.error_message || 'Unknown error'}`,
+      setState(s => ({
+        ...s, step: 'error',
+        error: `Connection interrupted: ${err.display_message || err.error_message || 'Unknown error'}`,
       }));
-    } else {
-      console.log('[Plaid] User closed Plaid Link without error. Status:', metadata?.status);
     }
-    // If user just closed, stay in 'ready' state
   }, []);
 
-  // =====================================================
-  // Asset Report Polling
-  // =====================================================
+  // Log events
+  const handleEvent: PlaidLinkOnEvent = useCallback((eventName, metadata) => {
+    console.log(`[Plaid] 📡 ${eventName}`, metadata);
+  }, []);
 
-  const startAssetPolling = useCallback((assetReportToken: string) => {
-    // Clear any existing interval
-    if (assetPollIntervalRef.current) {
-      clearInterval(assetPollIntervalRef.current);
-    }
-
+  // Asset polling
+  const pollAssets = useCallback((token: string) => {
+    if (assetPollRef.current) clearInterval(assetPollRef.current);
     let attempts = 0;
-    const maxAttempts = 10; // Max ~50 seconds of polling
 
-    assetPollIntervalRef.current = setInterval(async () => {
-      attempts++;
-
-      if (attempts > maxAttempts) {
-        clearInterval(assetPollIntervalRef.current!);
-        assetPollIntervalRef.current = null;
-        return;
-      }
-
+    assetPollRef.current = setInterval(async () => {
+      if (++attempts > 10) { clearInterval(assetPollRef.current!); return; }
       try {
-        const result = await checkAssetReport(assetReportToken, userId);
-
+        const result = await checkAssetReport(token, userId);
         if (result.status === 'complete') {
-          clearInterval(assetPollIntervalRef.current!);
-          assetPollIntervalRef.current = null;
-
-          setState((prev) => ({
-            ...prev,
-            assetsStatus: 'success',
-            financialData: prev.financialData
-              ? {
-                  ...prev.financialData,
-                  assets: { available: true, data: result.data, error: null, reason: null },
-                  summary: {
-                    ...prev.financialData.summary,
-                    products_available: prev.financialData.summary.products_available + 1,
-                  },
-                }
-              : prev.financialData,
-            productsAvailable: (prev.productsAvailable || 0) + 1,
+          clearInterval(assetPollRef.current!);
+          setState(s => ({
+            ...s, assetsStatus: 'success',
+            productsAvailable: (s.productsAvailable || 0) + 1,
+            financialData: s.financialData ? {
+              ...s.financialData,
+              assets: { available: true, data: result.data, error: null, reason: null },
+            } : s.financialData,
           }));
         }
-      } catch {
-        // Silent fail on poll — don't disrupt user
-      }
-    }, 5000); // Poll every 5 seconds
+      } catch { /* silent */ }
+    }, 5000);
   }, [userId]);
 
-  // Cleanup polling on unmount
-  useEffect(() => {
-    return () => {
-      if (assetPollIntervalRef.current) {
-        clearInterval(assetPollIntervalRef.current);
-      }
-    };
-  }, []);
+  // Cleanup
+  useEffect(() => () => { if (assetPollRef.current) clearInterval(assetPollRef.current); }, []);
 
-  // =====================================================
-  // Plaid Link Event Handler — logs ALL events
-  // =====================================================
-
-  const handlePlaidEvent: PlaidLinkOnEvent = useCallback((eventName, metadata) => {
-    console.log(`[Plaid] 📡 Event: ${eventName}`, metadata);
-
-    // When OAuth opens, set a flag WITH TIMESTAMP so we can detect the redirect back
-    // The timestamp prevents the stale-flag detection from clearing it during
-    // the same render cycle (before the browser actually navigates away)
-    if (eventName === 'OPEN_OAUTH') {
-      console.log('[Plaid] 🔑 Setting OAuth pending flag in localStorage (cross-tab)');
-      localStorage.setItem('plaid_oauth_pending', Date.now().toString());
-    }
-  }, []);
-
-  // =====================================================
-  // Plaid Link SDK
-  // =====================================================
-
+  // Plaid SDK
   const { open, ready } = usePlaidLinkSDK({
     token: state.linkToken,
-    onSuccess: handlePlaidSuccess,
-    onExit: handlePlaidExit,
-    onEvent: handlePlaidEvent,
-    // Pass receivedRedirectUri when returning from OAuth redirect
-    // This tells the SDK to complete the OAuth flow
-    receivedRedirectUri: receivedRedirectUri.current,
+    onSuccess: handleSuccess,
+    onExit: handleExit,
+    onEvent: handleEvent,
   });
 
-  // Auto-open Plaid Link when returning from OAuth redirect
-  useEffect(() => {
-    if (isOAuthRedirect.current && ready && state.linkToken) {
-      console.log('[Plaid] 🔄 Auto-opening Plaid Link to complete OAuth flow');
-      setState((prev) => ({ ...prev, step: 'linking' }));
-      open();
-      // Clean up the URL to remove oauth_state_id
-      const cleanUrl = new URL(window.location.href);
-      cleanUrl.searchParams.delete('oauth_state_id');
-      window.history.replaceState({}, '', cleanUrl.toString());
-    }
-  }, [ready, state.linkToken, open]);
-
-  // =====================================================
-  // Public Methods
-  // =====================================================
-
+  // Public API
   const openPlaidLink = useCallback(() => {
-    if (ready) {
-      setState((prev) => ({ ...prev, step: 'linking' }));
-      open();
-    }
+    if (ready) { setState(s => ({ ...s, step: 'linking' })); open(); }
   }, [ready, open]);
 
   const retry = useCallback(() => {
     setState({
-      step: 'idle',
-      linkToken: null,
-      error: null,
-      institution: null,
-      balanceStatus: 'idle',
-      assetsStatus: 'idle',
-      investmentsStatus: 'idle',
-      financialData: null,
-      canProceed: false,
-      productsAvailable: 0,
+      step: 'idle', linkToken: null, error: null, institution: null,
+      balanceStatus: 'idle', assetsStatus: 'idle', investmentsStatus: 'idle',
+      financialData: null, canProceed: false, productsAvailable: 0,
     });
     accessTokenRef.current = null;
-    hasInitializedRef.current = false;
-    initializeLinkToken();
-  }, [initializeLinkToken]);
+    initializedRef.current = false;
+    initToken();
+  }, [initToken]);
 
   return {
-    ...state,
-    openPlaidLink,
-    retry,
+    ...state, openPlaidLink, retry,
     isReady: ready && state.step === 'ready',
     open: openPlaidLink,
   };

--- a/supabase/functions/create-link-token/index.ts
+++ b/supabase/functions/create-link-token/index.ts
@@ -1,4 +1,4 @@
-// create-link-token — Creates a Plaid Link token for initializing Plaid Link
+// create-link-token — Creates a Plaid Link token
 import { corsHeaders } from '../_shared/cors.ts';
 
 Deno.serve(async (req) => {
@@ -22,28 +22,18 @@ Deno.serve(async (req) => {
     const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
     const baseUrl = `https://${PLAID_ENV}.plaid.com`;
 
-    // Support OAuth redirect URI for banks that use OAuth (e.g., Chase)
-    const redirectUri = body.redirectUri || null;
-
-    const linkConfig: Record<string, any> = {
-      client_id: PLAID_CLIENT_ID,
-      secret: PLAID_SECRET,
-      user: { client_user_id: userId, email_address: userEmail },
-      client_name: 'Hushh',
-      products: ['auth', 'transactions', 'investments', 'assets'],
-      country_codes: ['US'],
-      language: 'en',
-    };
-
-    // Add redirect_uri for OAuth flow — required for banks like Chase, Wells Fargo
-    if (redirectUri) {
-      linkConfig.redirect_uri = redirectUri;
-    }
-
     const response = await fetch(`${baseUrl}/link/token/create`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(linkConfig),
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        user: { client_user_id: userId, email_address: userEmail },
+        client_name: 'Hushh',
+        products: ['auth', 'transactions', 'investments', 'assets'],
+        country_codes: ['US'],
+        language: 'en',
+      }),
     });
 
     const data = await response.json();
@@ -51,7 +41,7 @@ Deno.serve(async (req) => {
     if (!response.ok) {
       console.error('[create-link-token] Plaid error:', data);
       return new Response(
-        JSON.stringify({ error: data.error_message || 'Failed to create link token', details: data }),
+        JSON.stringify({ error: data.error_message || 'Failed to create link token' }),
         { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
       );
     }


### PR DESCRIPTION
Complete fresh start. Removed 716 lines, added 217.

**Changes:**
- `plaidService.ts`: Clean API service (~180 lines)
- `usePlaidLink.ts`: Simple hook (~170 lines) — no OAuth flags, no localStorage tricks
- `ProtectedRoute.tsx`: Removed OAuth guard
- `create-link-token`: Removed redirect_uri

**Flow:** Create token → Open Link → Exchange → Fetch data. Simple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authentication and Plaid account linking workflow
  * Simplified error handling during authentication

* **Bug Fixes**
  * Removed OAuth redirect functionality from Plaid integration to improve stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->