### PR TITLE
fix: Remove financial-link from onboarding — restore step-1 entry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,7 @@ import PrivacyControlsPage from './pages/hushh-user-profile/privacy';
 import PublicHushhProfilePage from './pages/hushhid';
 import PublicInvestorProfilePage from './pages/investor/PublicInvestorProfile';
 import HushhIDHeroDemo from './pages/hushhid-hero-demo';
-import OnboardingFinancialLink from './pages/onboarding/FinancialLink';
+// Financial Link removed from onboarding flow
 import OnboardingStep1 from './pages/onboarding/Step1';
 import OnboardingStep2 from './pages/onboarding/Step2';
 import OnboardingStep3 from './pages/onboarding/Step3';
@@ -223,11 +223,6 @@ function App() {
             <Route path="/auth/callback" element={<AuthCallback />} />
             {/* Investor Onboarding Guide - Public landing page */}
             <Route path="/investor-guide" element={<InvestorGuidePage />} />
-            <Route path="/onboarding/financial-link" element={
-              <ProtectedRoute>
-                <OnboardingFinancialLink />
-              </ProtectedRoute>
-            } />
             <Route path="/onboarding/step-1" element={
               <ProtectedRoute>
                 <OnboardingStep1 />

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -57,7 +57,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 
       if (!onboardingData || !onboardingData.is_completed) {
         if (!isOnOnboardingPage) {
-          navigate('/onboarding/financial-link', { replace: true });
+          navigate('/onboarding/step-1', { replace: true });
           return;
         }
       }


### PR DESCRIPTION
Removes the Plaid financial-link step from the onboarding flow. Users now go directly to step-1 after login (as before).

- ProtectedRoute: redirect to /onboarding/step-1
- App.tsx: removed financial-link route and import