### PR TITLE
fix: Resume onboarding from current_step instead of always step-1

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -57,7 +57,9 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 
       if (!onboardingData || !onboardingData.is_completed) {
         if (!isOnOnboardingPage) {
-          navigate('/onboarding/step-1', { replace: true });
+          // Resume from where user left off
+          const step = onboardingData?.current_step || 1;
+          navigate(`/onboarding/step-${step}`, { replace: true });
           return;
         }
       }


### PR DESCRIPTION
Users who partially completed onboarding now resume from where they left off (e.g., step-8) instead of being sent back to step-1 every time.

1-line fix in ProtectedRoute: uses current_step from onboarding_data table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated onboarding redirect logic to resume from the user's last saved step instead of always restarting from the beginning. Users returning to complete their onboarding will now seamlessly continue from where they left off, improving the overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->