### PR TITLE
fix: Replace ALL financial-link references — AuthCallback, Hero, InvestorGuide, Profile

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -182,7 +182,7 @@ export default function Hero() {
     }
     return { 
       text: "Complete Your Hushh Profile", 
-      action: () => navigate("/onboarding/financial-link"),
+      action: () => navigate("/onboarding/step-1"),
       loading: false
     };
   };

--- a/src/components/profile/profilePage.tsx
+++ b/src/components/profile/profilePage.tsx
@@ -270,7 +270,7 @@ const ProfilePage: React.FC = () => {
     }
     return { 
       text: "Complete Your Hushh Profile", 
-      action: () => navigate("/onboarding/financial-link")
+      action: () => navigate("/onboarding/step-1")
     };
   };
 

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -139,7 +139,7 @@ const AuthCallback: React.FC = () => {
       return customRedirect;
     }
     // Otherwise, default behavior: onboarding or profile
-    return hasCompletedOnboarding ? '/hushh-user-profile' : '/onboarding/financial-link';
+    return hasCompletedOnboarding ? '/hushh-user-profile' : '/onboarding/step-1';
   };
 
   useEffect(() => {

--- a/src/pages/onboarding/InvestorGuide.tsx
+++ b/src/pages/onboarding/InvestorGuide.tsx
@@ -183,9 +183,9 @@ export default function InvestorGuide() {
 
   const handleStartJourney = () => {
     if (isLoggedIn) {
-      navigate('/onboarding/financial-link');
+      navigate('/onboarding/step-1');
     } else {
-      navigate('/login', { state: { redirectTo: '/onboarding/financial-link' } });
+      navigate('/login', { state: { redirectTo: '/onboarding/step-1' } });
     }
   };
 


### PR DESCRIPTION
4 files still redirected to the removed /onboarding/financial-link route:
- AuthCallback.tsx (post-login redirect)
- InvestorGuide.tsx (Start button)
- Hero.tsx (CTA button)
- profilePage.tsx (profile action)

All now point to /onboarding/step-1.