### PR TITLE
feat: Wire Plaid Financial Link as mandatory pre-step before onboarding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,7 @@ import PrivacyControlsPage from './pages/hushh-user-profile/privacy';
 import PublicHushhProfilePage from './pages/hushhid';
 import PublicInvestorProfilePage from './pages/investor/PublicInvestorProfile';
 import HushhIDHeroDemo from './pages/hushhid-hero-demo';
-// Financial Link removed from onboarding flow
+import FinancialLinkPage from './pages/onboarding/FinancialLink';
 import OnboardingStep1 from './pages/onboarding/Step1';
 import OnboardingStep2 from './pages/onboarding/Step2';
 import OnboardingStep3 from './pages/onboarding/Step3';
@@ -223,6 +223,12 @@ function App() {
             <Route path="/auth/callback" element={<AuthCallback />} />
             {/* Investor Onboarding Guide - Public landing page */}
             <Route path="/investor-guide" element={<InvestorGuidePage />} />
+            {/* Financial Link — mandatory pre-step before onboarding */}
+            <Route path="/onboarding/financial-link" element={
+              <ProtectedRoute>
+                <FinancialLinkPage />
+              </ProtectedRoute>
+            } />
             <Route path="/onboarding/step-1" element={
               <ProtectedRoute>
                 <OnboardingStep1 />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -182,7 +182,7 @@ export default function Hero() {
     }
     return { 
       text: "Complete Your Hushh Profile", 
-      action: () => navigate("/onboarding/step-1"),
+      action: () => navigate("/onboarding/financial-link"),
       loading: false
     };
   };

--- a/src/components/profile/profilePage.tsx
+++ b/src/components/profile/profilePage.tsx
@@ -270,7 +270,8 @@ const ProfilePage: React.FC = () => {
     }
     return { 
       text: "Complete Your Hushh Profile", 
-      action: () => navigate("/onboarding/step-1")
+      action: () => navigate("/onboarding/financial-link"),
+      loading: false
     };
   };
 


### PR DESCRIPTION
## Summary
- Re-add `/onboarding/financial-link` route in App.tsx (was previously removed)
- Hero.tsx: 'Complete Your Hushh Profile' CTA now navigates to `/onboarding/financial-link` instead of `/onboarding/step-1`
- profilePage.tsx: Same CTA update for consistency

## New Flow
```
Complete Your Profile button → /onboarding/financial-link (Plaid) → /onboarding/step-1 → ... → Step 15
```

User MUST complete Plaid financial linking before they can proceed to onboarding Step 1.

## Files Changed (3 files, +10 -3 lines)
- src/App.tsx — Re-added FinancialLinkPage import + route
- src/components/Hero.tsx — CTA navigation updated
- src/components/profile/profilePage.tsx — CTA navigation updated