### PR TITLE
fix: Add OAuth redirect support for Plaid Link (Chase, Wells Fargo)

### DIFF
--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -61,13 +61,22 @@ const getHeaders = (token?: string) => ({
 // API Calls
 // =====================================================
 
-/** Create a Plaid Link token */
-export const createLinkToken = async (userId: string, userEmail?: string) => {
+/** Create a Plaid Link token (supports OAuth redirect/resume) */
+export const createLinkToken = async (
+  userId: string,
+  userEmail?: string,
+  redirectUri?: string,
+  receivedRedirectUri?: string,
+) => {
   const token = await getUserAccessToken();
+  const body: Record<string, any> = { userId, userEmail };
+  if (redirectUri) body.redirectUri = redirectUri;
+  if (receivedRedirectUri) body.receivedRedirectUri = receivedRedirectUri;
+
   const res = await fetch(`${SUPABASE_URL}/create-link-token`, {
     method: 'POST',
     headers: getHeaders(token),
-    body: JSON.stringify({ userId, userEmail }),
+    body: JSON.stringify(body),
   });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));

--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -1,8 +1,8 @@
 /**
- * usePlaidLink — Clean Plaid Link hook
+ * usePlaidLink — Plaid Link hook with OAuth support
  * 
- * Simple flow: Create token → Open Link → Exchange → Fetch data
- * No OAuth complexity. Works with non-OAuth banks (First Platypus, etc.)
+ * Flow: Create token → Open Link → Exchange → Fetch data
+ * OAuth: Detects oauth_state_id in URL → resumes session automatically
  */
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { usePlaidLink as usePlaidLinkSDK, PlaidLinkOnSuccess, PlaidLinkOnExit, PlaidLinkOnEvent } from 'react-plaid-link';
@@ -62,20 +62,47 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
   const accessTokenRef = useRef<string | null>(null);
   const assetPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const initializedRef = useRef(false);
+  const isOAuthResumeRef = useRef(false);
 
-  // Step 1: Create link token
+  // Detect OAuth redirect: URL has ?oauth_state_id=...
+  const getOAuthState = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('oauth_state_id');
+  }, []);
+
+  // Get the redirect URI (current page without query params)
+  const getRedirectUri = useCallback(() => {
+    return `${window.location.origin}${window.location.pathname}`;
+  }, []);
+
+  // Step 1: Create link token (with OAuth support)
   const initToken = useCallback(async () => {
     if (!userId) return;
     setState(s => ({ ...s, step: 'creating_token', error: null }));
 
     try {
-      console.log('[Plaid] Creating link token...');
-      const { link_token } = await createLinkToken(userId, userEmail);
-      setState(s => ({ ...s, step: 'ready', linkToken: link_token }));
+      const oauthStateId = getOAuthState();
+      const redirectUri = getRedirectUri();
+
+      if (oauthStateId) {
+        // OAuth RESUME — returning from bank website
+        const receivedRedirectUri = window.location.href;
+        console.log('[Plaid] 🔄 OAuth resume detected:', { oauthStateId, receivedRedirectUri });
+        isOAuthResumeRef.current = true;
+
+        const { link_token } = await createLinkToken(userId, userEmail, undefined, receivedRedirectUri);
+        setState(s => ({ ...s, step: 'ready', linkToken: link_token }));
+      } else {
+        // Normal flow — include redirect_uri for OAuth banks
+        console.log('[Plaid] Creating link token with redirect_uri:', redirectUri);
+        const { link_token } = await createLinkToken(userId, userEmail, redirectUri);
+        setState(s => ({ ...s, step: 'ready', linkToken: link_token }));
+      }
     } catch (err: any) {
+      console.error('[Plaid] ❌ Token creation failed:', err);
       setState(s => ({ ...s, step: 'error', error: err.message || 'Failed to initialize' }));
     }
-  }, [userId, userEmail]);
+  }, [userId, userEmail, getOAuthState, getRedirectUri]);
 
   // Auto-init once
   useEffect(() => {
@@ -187,13 +214,27 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
   // Cleanup
   useEffect(() => () => { if (assetPollRef.current) clearInterval(assetPollRef.current); }, []);
 
-  // Plaid SDK
+  // Plaid SDK — receivedRedirectUri tells SDK this is an OAuth resume
   const { open, ready } = usePlaidLinkSDK({
     token: state.linkToken,
     onSuccess: handleSuccess,
     onExit: handleExit,
     onEvent: handleEvent,
+    receivedRedirectUri: isOAuthResumeRef.current ? window.location.href : undefined,
   });
+
+  // Auto-open on OAuth resume: when token is ready and it's an OAuth return
+  useEffect(() => {
+    if (ready && isOAuthResumeRef.current && state.step === 'ready') {
+      console.log('[Plaid] 🔄 Auto-opening Plaid Link for OAuth resume...');
+      setState(s => ({ ...s, step: 'linking' }));
+      open();
+      // Clean up the oauth_state_id from URL without reload
+      const cleanUrl = `${window.location.origin}${window.location.pathname}`;
+      window.history.replaceState({}, '', cleanUrl);
+      isOAuthResumeRef.current = false;
+    }
+  }, [ready, state.step, open]);
 
   // Public API
   const openPlaidLink = useCallback(() => {

--- a/supabase/functions/create-link-token/index.ts
+++ b/supabase/functions/create-link-token/index.ts
@@ -8,7 +8,7 @@ Deno.serve(async (req) => {
 
   try {
     const body = await req.json();
-    const { userId, userEmail } = body;
+    const { userId, userEmail, redirectUri, receivedRedirectUri } = body;
 
     if (!userId) {
       return new Response(
@@ -22,18 +22,39 @@ Deno.serve(async (req) => {
     const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
     const baseUrl = `https://${PLAID_ENV}.plaid.com`;
 
+    // Build Plaid request body
+    const plaidBody: Record<string, any> = {
+      client_id: PLAID_CLIENT_ID,
+      secret: PLAID_SECRET,
+      user: { client_user_id: userId, email_address: userEmail },
+      client_name: 'Hushh',
+      products: ['auth', 'transactions', 'investments', 'assets'],
+      country_codes: ['US'],
+      language: 'en',
+    };
+
+    // OAuth support: redirect_uri for initial call
+    if (redirectUri) {
+      plaidBody.redirect_uri = redirectUri;
+    }
+
+    // OAuth resume: receivedRedirectUri for returning from bank OAuth
+    // When resuming, products must NOT be included per Plaid docs
+    if (receivedRedirectUri) {
+      plaidBody.redirect_uri = receivedRedirectUri;
+      delete plaidBody.products; // Plaid requires no products on OAuth resume
+    }
+
+    console.log('[create-link-token] OAuth params:', {
+      redirectUri: redirectUri || 'none',
+      receivedRedirectUri: receivedRedirectUri || 'none',
+      isResume: !!receivedRedirectUri,
+    });
+
     const response = await fetch(`${baseUrl}/link/token/create`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        client_id: PLAID_CLIENT_ID,
-        secret: PLAID_SECRET,
-        user: { client_user_id: userId, email_address: userEmail },
-        client_name: 'Hushh',
-        products: ['auth', 'transactions', 'investments', 'assets'],
-        country_codes: ['US'],
-        language: 'en',
-      }),
+      body: JSON.stringify(plaidBody),
     });
 
     const data = await response.json();


### PR DESCRIPTION
Fixes OAuth redirect loop for banks using OAuth (Chase, Wells Fargo, BofA). Edge function accepts redirect_uri/receivedRedirectUri. Frontend detects oauth_state_id in URL and auto-resumes Plaid session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth authentication support for Plaid Link integration
  * Automatic resumption of authentication sessions after bank redirects
  * Improved URL state handling following OAuth completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->