### PR TITLE
fix: Financial verification is mandatory before KYC step-1

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -139,7 +139,7 @@ const AuthCallback: React.FC = () => {
       return customRedirect;
     }
     // Otherwise, default behavior: onboarding or profile
-    return hasCompletedOnboarding ? '/hushh-user-profile' : '/onboarding/step-1';
+    return hasCompletedOnboarding ? '/hushh-user-profile' : '/onboarding/financial-link';
   };
 
   useEffect(() => {

--- a/src/pages/onboarding/InvestorGuide.tsx
+++ b/src/pages/onboarding/InvestorGuide.tsx
@@ -183,9 +183,9 @@ export default function InvestorGuide() {
 
   const handleStartJourney = () => {
     if (isLoggedIn) {
-      navigate('/onboarding/step-1');
+      navigate('/onboarding/financial-link');
     } else {
-      navigate('/login', { state: { redirectTo: '/onboarding/step-1' } });
+      navigate('/login', { state: { redirectTo: '/onboarding/financial-link' } });
     }
   };
 

--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -58,6 +58,18 @@ export default function OnboardingStep1() {
       }
       setUserId(user.id);
 
+      // Gate: redirect to financial-link if not yet verified
+      const { data: financialData } = await config.supabaseClient
+        .from('user_financial_data')
+        .select('status')
+        .eq('user_id', user.id)
+        .single();
+
+      if (!financialData || (financialData.status !== 'complete' && financialData.status !== 'partial')) {
+        navigate('/onboarding/financial-link', { replace: true });
+        return;
+      }
+
       // Check if user already has onboarding data
       const { data: onboardingData } = await config.supabaseClient
         .from('onboarding_data')


### PR DESCRIPTION
All entry points now route through /onboarding/financial-link first:

- **Step1.tsx**: Checks `user_financial_data` table. If no record with status 'complete' or 'partial', redirects to financial-link
- **AuthCallback.tsx**: Post-login redirect → /onboarding/financial-link (was step-1)
- **InvestorGuide.tsx**: 'Start Onboarding' → /onboarding/financial-link (was step-1)

No user can reach step-1 without completing financial verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the onboarding sequence to require financial data completion earlier in the process. Users are now directed to link financial accounts before proceeding to other onboarding steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->