### PR TITLE
fix: always show sticky CTA on onboarding pages

### DIFF
--- a/src/utils/useFooterVisibility.ts
+++ b/src/utils/useFooterVisibility.ts
@@ -9,7 +9,16 @@ import { useState, useEffect } from 'react';
 export function useFooterVisibility(): boolean {
   const [isFooterVisible, setIsFooterVisible] = useState(false);
 
+  // On onboarding pages, always keep CTA visible — never hide it
+  const isOnboarding = typeof window !== 'undefined' && window.location.pathname.startsWith('/onboarding');
+
   useEffect(() => {
+    // Skip footer detection on onboarding pages — CTA must always be sticky
+    if (isOnboarding) {
+      setIsFooterVisible(false);
+      return;
+    }
+
     // Find the main footer element (it has id="main-footer" or class containing "footer")
     const findFooter = (): Element | null => {
       // Try to find footer by ID first
@@ -68,7 +77,7 @@ export function useFooterVisibility(): boolean {
     return () => {
       clearTimeout(timeoutId);
     };
-  }, []);
+  }, [isOnboarding]);
 
   return isFooterVisible;
 }


### PR DESCRIPTION
## Problem
The Continue/CTA button on onboarding pages (financial-link through step-15) would disappear when the site footer scrolled into view due to the useFooterVisibility hook hiding it.

## Fix
Modified `src/utils/useFooterVisibility.ts` to skip footer detection on `/onboarding/*` pages. The CTA now stays fixed at the bottom of the viewport at all times during onboarding.

**Single file change** — automatically fixes all 15+ onboarding steps.

## Verified
- Vite build passes
- No TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved footer and call-to-action visibility behavior on onboarding pages to ensure the elements remain consistently visible throughout the onboarding experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->