### PR TITLE
fix: Skip now working + sticky CTA centered across all onboarding steps

### DIFF
--- a/src/components/kyc/screens/KycFinancialLinkScreen.tsx
+++ b/src/components/kyc/screens/KycFinancialLinkScreen.tsx
@@ -635,23 +635,27 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
         </VStack>
       </Box>
 
-      {/* Sticky Bottom CTA — fixed to viewport bottom with glassmorphism */}
+      {/* Sticky Bottom CTA — fixed, centered, connected to footer */}
       <Box
         position="fixed"
         bottom={0}
-        left={0}
-        right={0}
-        bg="rgba(255,255,255,0.92)"
+        left="50%"
+        transform="translateX(-50%)"
+        w="100%"
+        maxW="500px"
+        bg="rgba(255,255,255,0.95)"
         backdropFilter="blur(20px)"
         sx={{ WebkitBackdropFilter: 'blur(20px)' }}
         borderTop="1px solid"
         borderColor={COLORS.border}
         px={5}
         pt={4}
-        pb={6}
+        pb="env(safe-area-inset-bottom, 24px)"
         zIndex={10}
+        boxShadow="0 -4px 20px rgba(0,0,0,0.03)"
+        data-onboarding-footer=""
       >
-        <Box maxW="390px" mx="auto" w="100%">
+        <Box w="100%">
         {/* "Continue to KYC" — gradient CTA */}
         {plaid.step === 'done' && plaid.canProceed && (
           <Button

--- a/src/components/kyc/screens/KycFlowContainer.tsx
+++ b/src/components/kyc/screens/KycFlowContainer.tsx
@@ -437,6 +437,16 @@ export const KycFlowContainer: React.FC<KycFlowContainerProps> = ({
             userId={userId}
             userEmail={userEmail}
             onContinue={handleFinancialLinkComplete}
+            onSkip={() => {
+              // Skip financial verification — proceed to KYC intro
+              console.log('[KYC Flow] User skipped financial verification');
+              setState(prev => ({
+                ...prev,
+                step: 'INTRO',
+                financialVerified: true,
+                financialData: null,
+              }));
+            }}
             bankName={bankName}
           />
         );

--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -266,7 +266,7 @@ export default function OnboardingStep1() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Continue Button */}
             <button
               onClick={handleContinue}

--- a/src/pages/onboarding/Step10.tsx
+++ b/src/pages/onboarding/Step10.tsx
@@ -964,7 +964,7 @@ function OnboardingStep10() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white/80 backdrop-blur-md border-t border-slate-100 p-4 flex flex-col gap-3" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white/80 backdrop-blur-md border-t border-slate-100 p-4 flex flex-col gap-3" data-onboarding-footer>
             {/* Continue Button */}
             <button
               onClick={handleContinue}

--- a/src/pages/onboarding/Step11.tsx
+++ b/src/pages/onboarding/Step11.tsx
@@ -396,7 +396,7 @@ function OnboardingStep11() {
 
         {/* Fixed Footer - Hidden when main footer is visible (matching Step3 exactly) */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Buttons */}
             <div className="flex flex-col gap-4">
               {/* Continue Button */}

--- a/src/pages/onboarding/Step2.tsx
+++ b/src/pages/onboarding/Step2.tsx
@@ -115,7 +115,7 @@ export default function OnboardingStep2() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Get Started Button */}
             <button
               onClick={handleGetStarted}

--- a/src/pages/onboarding/Step3.tsx
+++ b/src/pages/onboarding/Step3.tsx
@@ -303,7 +303,7 @@ export default function OnboardingStep3() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Total Investment */}
             <div className="flex items-center justify-between mb-6">
               <span className="text-xs font-bold text-slate-500 tracking-wider uppercase">

--- a/src/pages/onboarding/Step4.tsx
+++ b/src/pages/onboarding/Step4.tsx
@@ -193,7 +193,7 @@ export default function OnboardingStep4() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Buttons */}
             <div className="flex flex-col gap-4">
               {/* Continue Button */}

--- a/src/pages/onboarding/Step5.tsx
+++ b/src/pages/onboarding/Step5.tsx
@@ -111,7 +111,7 @@ export default function OnboardingStep5() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Buttons */}
             <div className="flex flex-col gap-4">
               {/* Continue Button */}

--- a/src/pages/onboarding/Step6.tsx
+++ b/src/pages/onboarding/Step6.tsx
@@ -339,7 +339,7 @@ export default function OnboardingStep6() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Buttons */}
             <div className="flex flex-col gap-4">
               {/* Continue Button */}

--- a/src/pages/onboarding/Step7.tsx
+++ b/src/pages/onboarding/Step7.tsx
@@ -146,7 +146,7 @@ export default function OnboardingStep7() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white border-t border-slate-100 p-6 shadow-[0_-4px_20px_rgba(0,0,0,0.03)]" data-onboarding-footer>
             {/* Buttons */}
             <div className="flex flex-col gap-4">
               {/* Continue Button */}

--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -329,7 +329,7 @@ export default function OnboardingStep8() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white/80 backdrop-blur-md border-t border-slate-100 p-4 flex flex-col gap-3" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white/80 backdrop-blur-md border-t border-slate-100 p-4 flex flex-col gap-3" data-onboarding-footer>
             {/* Continue Button */}
             <button
               onClick={handleContinue}

--- a/src/pages/onboarding/Step9.tsx
+++ b/src/pages/onboarding/Step9.tsx
@@ -185,7 +185,7 @@ export default function OnboardingStep9() {
 
         {/* Fixed Footer - Hidden when main footer is visible */}
         {!isFooterVisible && (
-          <div className="fixed bottom-0 z-20 w-full max-w-[500px] bg-white/80 backdrop-blur-md border-t border-slate-100 p-4 flex flex-col gap-3" data-onboarding-footer>
+          <div className="fixed bottom-0 left-0 right-0 z-20 w-full max-w-[500px] mx-auto bg-white/80 backdrop-blur-md border-t border-slate-100 p-4 flex flex-col gap-3" data-onboarding-footer>
             {/* Continue Button */}
             <button
               onClick={handleContinue}


### PR DESCRIPTION
## Fixes

### 1. Skip Now Working on Financial Link
- Added `onSkip` handler to `KycFlowContainer` for the FINANCIAL_LINK step
- Clicking 'Skip for now →' now navigates to the KYC Intro step

### 2. Financial Link Sticky Footer Fixed
- Centered with `left: 50%; transform: translateX(-50%)` + `maxW: 500px`
- Added `safe-area-inset-bottom` for iOS notch devices
- Added shadow for connected look with content above

### 3. Steps 1-11 CTA Bar Centered
- Added `left-0 right-0 mx-auto` for proper centering on wide screens
- Now matches Steps 13-15 pattern
- All steps now have consistent sticky CTA positioning

## Files Changed (13)
- `src/components/kyc/screens/KycFlowContainer.tsx`
- `src/components/kyc/screens/KycFinancialLinkScreen.tsx`
- `src/pages/onboarding/Step{1-11}.tsx`