### PR TITLE
fix: Skip for now actually working + proper sticky footer

### DIFF
--- a/src/components/kyc/screens/KycFinancialLinkScreen.tsx
+++ b/src/components/kyc/screens/KycFinancialLinkScreen.tsx
@@ -639,10 +639,11 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
       <Box
         position="fixed"
         bottom={0}
-        left="50%"
-        transform="translateX(-50%)"
+        left={0}
+        right={0}
         w="100%"
         maxW="500px"
+        mx="auto"
         bg="rgba(255,255,255,0.95)"
         backdropFilter="blur(20px)"
         sx={{ WebkitBackdropFilter: 'blur(20px)' }}
@@ -650,8 +651,8 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
         borderColor={COLORS.border}
         px={5}
         pt={4}
-        pb="env(safe-area-inset-bottom, 24px)"
-        zIndex={10}
+        pb={6}
+        zIndex={50}
         boxShadow="0 -4px 20px rgba(0,0,0,0.03)"
         data-onboarding-footer=""
       >

--- a/src/pages/onboarding/FinancialLink.tsx
+++ b/src/pages/onboarding/FinancialLink.tsx
@@ -51,19 +51,25 @@ export default function OnboardingFinancialLink() {
 
       // Check if user already completed financial link
       try {
-        const { data: financialData } = await config.supabaseClient
+        const { data: financialData, error: fetchError } = await config.supabaseClient
           .from('user_financial_data')
           .select('status')
           .eq('user_id', user.id)
           .maybeSingle();
+
+        // Ignore errors (table may not exist, 406, RLS, etc.)
+        if (fetchError) {
+          console.warn('[FinancialLink] Supabase query error (ignoring):', fetchError.message);
+        }
 
         // If already completed, skip to step 1
         if (financialData?.status === 'complete' || financialData?.status === 'partial') {
           navigate('/onboarding/step-1', { replace: true });
           return;
         }
-      } catch {
+      } catch (err) {
         // Table may not exist yet — continue anyway
+        console.warn('[FinancialLink] Error checking financial data (ignoring):', err);
       }
 
       setIsReady(true);


### PR DESCRIPTION
## Fixes
1. **Sticky footer**: Changed from `left:50%; transform:translateX(-50%)` to `left:0; right:0; mx:auto` — transform was breaking Chakra fixed positioning
2. **zIndex**: Increased to 50 for reliable stacking
3. **FinancialLink.tsx**: Handle Supabase 406 error gracefully (warn + continue) so component always renders
4. **Skip for now**: Button properly clickable with correct positioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for financial data retrieval to provide better visibility into potential issues.

* **Style**
  * Refined footer layout on the financial link screen with improved element centering, enhanced z-index layering, and adjusted safe area padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->