### PR TITLE
feat: Step 13 auto-fill wire transfer details from Plaid Auth API

### DIFF
--- a/src/pages/onboarding/Step13.tsx
+++ b/src/pages/onboarding/Step13.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import config from '../../resources/config/config';
 import { useFooterVisibility } from '../../utils/useFooterVisibility';
+import { fetchAuthNumbers } from '../../services/plaid/plaidService';
 
 // SVG Icons
 const BackIcon = () => (
@@ -134,6 +135,9 @@ function OnboardingStep13() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   
+  // Plaid auto-fill status
+  const [autoFillMessage, setAutoFillMessage] = useState<string | null>(null);
+
   // Banking form state
   const [bankName, setBankName] = useState('');
   const [accountHolderName, setAccountHolderName] = useState('');
@@ -218,6 +222,58 @@ function OnboardingStep13() {
         if (data.bank_routing_number) setRoutingNumber(data.bank_routing_number);
         if (data.bank_address_city) setBankCity(data.bank_address_city);
         if (data.bank_address_country) setBankCountry(data.bank_address_country);
+      }
+
+      // --- Plaid Auto-Fill: fetch auth numbers if user linked a bank ---
+      // Only auto-fill fields that are still empty (don't overwrite saved data)
+      const hasBankDataAlready = data?.bank_routing_number;
+      if (!hasBankDataAlready) {
+        try {
+          const { data: financialData } = await config.supabaseClient
+            .from('user_financial_data')
+            .select('plaid_access_token, institution_name')
+            .eq('user_id', user.id)
+            .maybeSingle();
+
+          if (financialData?.plaid_access_token) {
+            setAutoFillMessage('📍 Auto-filling from your linked bank...');
+            console.log('[Step13] Plaid access_token found, fetching auth numbers...');
+
+            const authData = await fetchAuthNumbers(financialData.plaid_access_token);
+
+            if (authData?.numbers?.ach?.[0]) {
+              const ach = authData.numbers.ach[0];
+              if (ach.account) {
+                setAccountNumber(ach.account);
+                setConfirmAccountNumber(ach.account);
+              }
+              if (ach.routing) setRoutingNumber(ach.routing);
+            }
+
+            if (authData?.accounts?.[0]) {
+              const acct = authData.accounts[0];
+              if (acct.subtype === 'checking' || acct.subtype === 'savings') {
+                setAccountType(acct.subtype);
+              }
+            }
+
+            if (financialData.institution_name && !bankName) {
+              setBankName(financialData.institution_name);
+            }
+
+            // Default country to US for Plaid-linked banks (US-only for ACH)
+            if (!bankCountry) setBankCountry('US');
+
+            setAutoFillMessage('✅ Bank details auto-filled from Plaid');
+            console.log('[Step13] Plaid auto-fill complete');
+
+            // Clear message after 4 seconds
+            setTimeout(() => setAutoFillMessage(null), 4000);
+          }
+        } catch (err) {
+          console.warn('[Step13] Plaid auto-fill failed (non-blocking):', err);
+          setAutoFillMessage(null);
+        }
       }
     };
 
@@ -460,6 +516,13 @@ function OnboardingStep13() {
           {error && (
             <div className="mx-5 mb-4 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
               {error}
+            </div>
+          )}
+
+          {/* Plaid Auto-Fill Banner */}
+          {autoFillMessage && (
+            <div className="mx-5 mb-4 p-3 bg-[#F0F7FF] border border-[#2b8cee]/20 rounded-xl text-[#2b8cee] text-sm font-medium text-center animate-pulse">
+              {autoFillMessage}
             </div>
           )}
 

--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -103,6 +103,32 @@ export const exchangeToken = async (
   return res.json() as Promise<{ access_token: string; item_id: string }>;
 };
 
+/** Fetch auth numbers (account number, routing number, account type) from Plaid */
+export const fetchAuthNumbers = async (accessToken: string) => {
+  try {
+    const token = await getUserAccessToken();
+    const res = await fetch(`${SUPABASE_URL}/get-auth-numbers`, {
+      method: 'POST',
+      headers: getHeaders(token),
+      body: JSON.stringify({ accessToken }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      console.error('[Plaid] Auth numbers error:', err);
+      return null;
+    }
+    const data = await res.json();
+    console.log('[Plaid] Auth numbers fetched successfully');
+    return data as {
+      accounts: Array<{ account_id: string; name: string; subtype: string; type: string }>;
+      numbers: { ach: Array<{ account: string; routing: string; wire_routing: string; account_id: string }> };
+    };
+  } catch (e: any) {
+    console.error('[Plaid] Auth numbers fetch failed:', e.message);
+    return null;
+  }
+};
+
 /** Fetch balance */
 const fetchBalance = async (accessToken: string, userId: string): Promise<ProductResult> => {
   try {
@@ -200,7 +226,7 @@ export const checkAssetReport = async (assetReportToken: string, userId: string)
 /** Save financial data to Supabase */
 export const saveFinancialDataToSupabase = async (
   userId: string, data: FinancialDataResponse,
-  institutionName?: string, institutionId?: string, itemId?: string,
+  institutionName?: string, institutionId?: string, itemId?: string, accessToken?: string,
 ) => {
   try {
     const config = (await import('../../resources/config/config')).default;
@@ -215,6 +241,7 @@ export const saveFinancialDataToSupabase = async (
     await supabase.from('user_financial_data').upsert({
       user_id: userId,
       plaid_item_id: itemId || null,
+      plaid_access_token: accessToken || null,
       institution_name: institutionName || null,
       institution_id: institutionId || null,
       balances: data.balance.available ? data.balance.data : null,

--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -417,7 +417,7 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
       }));
 
       // Save to Supabase (background)
-      saveFinancialDataToSupabase(userId, result, inst.name, inst.id, exchange.item_id)
+      saveFinancialDataToSupabase(userId, result, inst.name, inst.id, exchange.item_id, exchange.access_token)
         .catch(e => console.warn('[Plaid] Save failed:', e));
 
       // Poll assets if pending

--- a/supabase/functions/get-auth-numbers/index.ts
+++ b/supabase/functions/get-auth-numbers/index.ts
@@ -1,0 +1,57 @@
+// get-auth-numbers — Fetch account & routing numbers from Plaid Auth API
+import { corsHeaders } from '../_shared/cors.ts';
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const body = await req.json();
+    const accessToken = body.accessToken || body.access_token;
+
+    if (!accessToken) {
+      return new Response(
+        JSON.stringify({ error: 'accessToken is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const PLAID_CLIENT_ID = Deno.env.get('PLAID_CLIENT_ID');
+    const PLAID_SECRET = Deno.env.get('PLAID_SECRET');
+    const PLAID_ENV = Deno.env.get('PLAID_ENV') || 'sandbox';
+    const baseUrl = `https://${PLAID_ENV}.plaid.com`;
+
+    const response = await fetch(`${baseUrl}/auth/get`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: PLAID_CLIENT_ID,
+        secret: PLAID_SECRET,
+        access_token: accessToken,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return new Response(
+        JSON.stringify({ error: data.error_message, error_code: data.error_code }),
+        { status: response.status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+      );
+    }
+
+    // Return accounts + ACH numbers (account number, routing number, wire routing)
+    return new Response(JSON.stringify({
+      accounts: data.accounts,
+      numbers: data.numbers,
+    }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  } catch (err: any) {
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+});

--- a/supabase/migrations/20260216_add_plaid_access_token.sql
+++ b/supabase/migrations/20260216_add_plaid_access_token.sql
@@ -1,0 +1,7 @@
+-- Add plaid_access_token column to user_financial_data table
+-- This stores the Plaid access_token so Step 13 can call /auth/get for auto-fill
+ALTER TABLE user_financial_data
+ADD COLUMN IF NOT EXISTS plaid_access_token TEXT;
+
+-- Add comment for documentation
+COMMENT ON COLUMN user_financial_data.plaid_access_token IS 'Plaid access_token for calling Auth/Identity APIs to auto-fill wire transfer details';


### PR DESCRIPTION
Step 13 auto-fills banking fields from Plaid Auth API. New Edge Function get-auth-numbers, fetchAuthNumbers in plaidService, saves plaid_access_token to DB, auto-fills account/routing numbers on mount. DB migration adds plaid_access_token column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-fill banking details (account number, routing number, bank name, account type) from linked Plaid accounts to streamline onboarding.
  * Status banner displays auto-fill progress near the form with automatic dismissal.
  * Enhanced error handling ensures auto-fill failures don't block user actions; gracefully clears on errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->