### PR TITLE
fix: meet-ceo page 406 error and CORS — deploy edge functions + .maybeSingle()

### DIFF
--- a/src/pages/onboarding/MeetCeo.tsx
+++ b/src/pages/onboarding/MeetCeo.tsx
@@ -174,7 +174,7 @@ function MeetCeoPage() {
         .from('ceo_meeting_payments')
         .select('*')
         .eq('user_id', user.id)
-        .single();
+        .maybeSingle();
 
       if (payment?.payment_status === 'completed') {
         setHushhCoins(payment.hushh_coins_awarded || 100);


### PR DESCRIPTION
Fixes the 406 and CORS errors on /onboarding/meet-ceo page.

Root causes:
1. ceo_meeting_payments query used .single() which throws 406 on empty results → changed to .maybeSingle()
2. Edge functions were not deployed → deployed onboarding-create-checkout, onboarding-verify-payment, ceo-calendar-booking
3. ceo_meeting_payments table + RLS policies created in Supabase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for CEO meeting payment records. The system now gracefully handles cases where payment records don't exist, instead of throwing an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->