### PR TITLE
fix: investor profile page 406 + CORS errors — deploy edge functions + .maybeSingle()

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -123,14 +123,14 @@ export default function Hero() {
           .from('investor_profiles')
           .select('id, user_confirmed')
           .eq('user_id', session.user.id)
-          .single();
+          .maybeSingle();
 
         // Check onboarding_data status
         const { data: onboarding, error: onboardingError } = await config.supabaseClient
           .from('onboarding_data')
           .select('is_completed, current_step')
           .eq('user_id', session.user.id)
-          .single();
+          .maybeSingle();
 
         setOnboardingStatus({
           hasProfile: !!profile && !profileError,

--- a/src/components/profile/AIDetectedPreferences.tsx
+++ b/src/components/profile/AIDetectedPreferences.tsx
@@ -151,7 +151,7 @@ const AIDetectedPreferences: React.FC<AIDetectedPreferencesProps> = ({ userId, o
           .from('user_enriched_profiles')
           .select('*')
           .eq('user_id', userId)
-          .single();
+          .maybeSingle();
 
         if (fetchError) {
           if (fetchError.code === 'PGRST116') {

--- a/src/components/profile/profilePage.tsx
+++ b/src/components/profile/profilePage.tsx
@@ -140,14 +140,14 @@ const ProfilePage: React.FC = () => {
           .from('investor_profiles')
           .select('id, user_confirmed')
           .eq('user_id', session.user.id)
-          .single();
+          .maybeSingle();
 
         // Check onboarding_data status
         const { data: onboarding, error: onboardingError } = await config.supabaseClient
           .from('onboarding_data')
           .select('is_completed, current_step')
           .eq('user_id', session.user.id)
-          .single();
+          .maybeSingle();
 
         setOnboardingStatus({
           hasProfile: !!profile && !profileError,

--- a/src/pages/hushh-user-profile/index.tsx
+++ b/src/pages/hushh-user-profile/index.tsx
@@ -276,7 +276,7 @@ const HushhUserProfilePage: React.FC = () => {
           .from("investor_profiles")
           .select("*")
           .eq("user_id", user.id)
-          .single();
+          .maybeSingle();
 
         if (existingProfile) {
           // Always load the slug if it exists (regardless of investor_profile)
@@ -312,7 +312,7 @@ const HushhUserProfilePage: React.FC = () => {
           .from("onboarding_data")
           .select("*")
           .eq("user_id", user.id)
-          .single();
+          .maybeSingle();
 
         if (onboardingData) {
           // Mark that user has completed onboarding
@@ -370,7 +370,7 @@ const HushhUserProfilePage: React.FC = () => {
                 user_confirmed: false,
               })
               .select("slug")
-              .single();
+              .maybeSingle();
 
             // Set the slug immediately if created
             if (newProfile?.slug) {
@@ -492,7 +492,7 @@ const HushhUserProfilePage: React.FC = () => {
             .from("investor_profiles")
             .upsert(updatePayload)
             .select("slug")
-            .single();
+            .maybeSingle();
 
           // Set profile slug if returned
           if (upsertData?.slug) {

--- a/src/pages/hushh-user-profile/privacy.tsx
+++ b/src/pages/hushh-user-profile/privacy.tsx
@@ -49,7 +49,7 @@ const PrivacyControlsPage: React.FC = () => {
         .from("investor_profiles")
         .select("privacy_settings")
         .eq("user_id", user.id)
-        .single();
+        .maybeSingle();
 
       if (error) throw error;
 

--- a/src/pages/hushh-user-profile/view.tsx
+++ b/src/pages/hushh-user-profile/view.tsx
@@ -61,7 +61,7 @@ const ViewPreferencesPage: React.FC = () => {
           .from("investor_profiles")
           .select("*")
           .eq("user_id", userIdToFetch)
-          .single();
+          .maybeSingle();
 
         if (error) {
           throw error;

--- a/src/services/investorProfile/index.ts
+++ b/src/services/investorProfile/index.ts
@@ -80,7 +80,7 @@ export async function createInvestorProfile(
       user_confirmed: false,
     })
     .select()
-    .single();
+    .maybeSingle();
   
   if (insertError) {
     throw new Error(`Failed to save investor profile: ${insertError.message}`);
@@ -180,7 +180,7 @@ export async function updateInvestorProfile(
     .update(updateData)
     .eq("user_id", user.id)
     .select()
-    .single();
+    .maybeSingle();
   
   if (updateError) {
     throw new Error(`Failed to update investor profile: ${updateError.message}`);
@@ -271,7 +271,7 @@ export async function fetchPublicInvestorProfileBySlug(slug: string): Promise<an
     .eq('slug', slug)
     .eq('is_public', true)
     .eq('user_confirmed', true)
-    .single();
+    .maybeSingle();
 
   if (error) {
     throw new Error(`Public profile not found: ${error.message}`);
@@ -318,7 +318,7 @@ export async function regenerateProfileSlug(): Promise<string> {
     .update({ slug: '' })
     .eq('user_id', user.id)
     .select('slug')
-    .single();
+    .maybeSingle();
 
   if (error) {
     throw new Error(`Failed to regenerate slug: ${error.message}`);


### PR DESCRIPTION
Fixes all errors on the /hushh-user-profile page:

1. .single() → .maybeSingle() across 7 files (12 occurrences) — PostgREST 406 on empty results
2. Deployed generate-investor-profile edge function with new OPENAI_API_KEY
3. Deployed shadow-investigator edge function
4. Set OPENAI_API_KEY as Supabase secret

Files changed: Hero.tsx, profilePage.tsx, AIDetectedPreferences.tsx, hushh-user-profile/index.tsx, view.tsx, privacy.tsx, investorProfile/index.ts