### PR TITLE
feat: add app version tracking system (v1.1.0)

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -25,6 +25,10 @@ declare module "*.webp" {
 
 /// <reference types="vite/client" />
 
+// Vite define globals (injected at build time from package.json)
+declare const __APP_VERSION__: string;
+declare const __BUILD_TIMESTAMP__: string;
+
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       gtag('config', 'G-R58S9WWPM0');
     </script>
 
+    <meta name="app-version" content="1.1.0" />
     <title>Hushh Technologies</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hushh-technologies",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,17 @@ import './i18n'
 import initDevToolsGuard from './utils/devtools-guard'
 initDevToolsGuard()
 
+// ─── App Version ────────────────────────────────────────────────────────────
+// Expose version globally so team can check via DevTools console:
+//   Type: __HUSHH_VERSION__  →  { version, built }
+// This survives production minification (unlike console.log which is stripped)
+;(window as any).__HUSHH_VERSION__ = {
+  version: __APP_VERSION__,
+  built: __BUILD_TIMESTAMP__,
+}
+// Also update the HTML meta tag dynamically
+document.querySelector('meta[name="app-version"]')?.setAttribute('content', __APP_VERSION__)
+
 // Import DM Sans font weights
 import "@fontsource/dm-sans/400.css";
 import "@fontsource/dm-sans/500.css";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,16 @@ import mdx from '@mdx-js/rollup'
 import remarkFrontmatter from 'remark-frontmatter'
 import remarkGfm from 'remark-gfm'
 import rehypeSlug from 'rehype-slug'
+import { readFileSync } from 'fs'
+
+// Read version from package.json at build time
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_TIMESTAMP__: JSON.stringify(new Date().toISOString()),
+  },
   plugins: [
     react(),
     mdx({


### PR DESCRIPTION
Adds version tracking so the team can instantly tell which build they're running.

### How to check version:
- **Browser console**: Type `__HUSHH_VERSION__` → shows `{version: '1.1.0', built: '2026-02-19T...'}`
- **HTML source**: `<meta name='app-version' content='1.1.0'>`

### Changes:
- `package.json`: version → 1.1.0
- `vite.config.ts`: injects `__APP_VERSION__` and `__BUILD_TIMESTAMP__` at build time
- `main.tsx`: sets `window.__HUSHH_VERSION__` (survives production minification)
- `index.html`: meta tag for version
- `custom.d.ts`: TypeScript declarations