### PR TITLE
fix: deploy Edge Functions + remove broken query (v1.2.1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       gtag('config', 'G-R58S9WWPM0');
     </script>
 
-    <meta name="app-version" content="1.2.0" />
+    <meta name="app-version" content="1.2.1" />
     <title>Hushh Technologies</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hushh-technologies",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -4,7 +4,7 @@
  * Collects user's residential address. Auto-detects location via GPS
  * (reverse geocoded through GCP / Supabase Edge Function) with IP fallback.
  *
- * Data priority: Saved address → GPS detection → Enriched profile → Step 6 country.
+ * Data priority: Saved address → GPS detection → Step 6 country.
  */
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -106,28 +106,7 @@ function OnboardingStep8() {
       // Priority 2: GPS / IP auto-detection
       await detectAndApply(user.id);
 
-      // Priority 3: Enriched profile fallback
-      if (!addressLine1) {
-        try {
-          const { data: profile } = await config.supabaseClient
-            .from('user_enriched_profiles')
-            .select('address')
-            .eq('user_id', user.id)
-            .maybeSingle();
-
-          if (profile?.address) {
-            const addr = profile.address as Record<string, string>;
-            if (addr.line1) setAddressLine1(addr.line1);
-            if (addr.line2) setAddressLine2(addr.line2);
-            if (addr.zipCode) setZipCode(addr.zipCode);
-            const code = locationService.mapCountryToIsoCode(addr.countryCode || addr.country || '');
-            dropdowns.applyDetectedLocation(code, undefined, addr.state, addr.city);
-            return;
-          }
-        } catch { /* ignore */ }
-      }
-
-      // Priority 4: Residence country from Step 6
+      // Priority 3: Residence country from Step 6
       if (saved?.residence_country) {
         const code = locationService.mapCountryToIsoCode(saved.residence_country);
         dropdowns.applyDetectedLocation(code);


### PR DESCRIPTION
### Root causes fixed:
1. **`hushh-location-geocode`** Edge Function was never deployed (404) → GPS reverse geocoding failed
2. **`get-locations`** Edge Function was never deployed → State/City dropdowns failed
3. **`user_enriched_profiles`** query selecting non-existent `address` column → 400 error

### What's deployed now:
- Both Edge Functions are live and tested
- GPS → Supabase Edge Function → Nominatim → structured address ✅
- Country → States → Cities cascade ✅
- Version: v1.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patched to version 1.2.1.

* **Bug Fixes**
  * Simplified address data retrieval during account setup by refining the fallback data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->