### PR TITLE
fix: cities not loading — was sending state name instead of ISO code

### DIFF
--- a/src/hooks/useLocationDropdowns.ts
+++ b/src/hooks/useLocationDropdowns.ts
@@ -109,9 +109,8 @@ export function useLocationDropdowns(
       setLoadingCities(true);
       setCitiesError(false);
       try {
-        const stateObj = states.find(s => s.isoCode === state);
-        const stateName = stateObj?.name || state;
-        const list = await getCitiesOfState(country, stateName);
+        // Edge function expects ISO code (e.g. "MH"), not name ("Maharashtra")
+        const list = await getCitiesOfState(country, state);
         if (!cancelled) setCities(list);
       } catch {
         if (!cancelled) setCitiesError(true);


### PR DESCRIPTION
**Root cause:** The hook converted state isoCode (MH) to state name (Maharashtra) before calling getCitiesOfState. But the Edge Function expects the ISO code. Result: empty city list for all states.

**Fix:** Pass state isoCode directly instead of converting to name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state parameter handling in the location dropdown logic to ensure proper city data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->