### PR TITLE
fix: Step 13 footer padding for mobile safe area

### DIFF
--- a/src/pages/onboarding/Step13.tsx
+++ b/src/pages/onboarding/Step13.tsx
@@ -928,7 +928,7 @@ function OnboardingStep13() {
         {/* Fixed Footer - matching Step3 pattern */}
         {!isFooterVisible && (
           <div
-            className="fixed bottom-0 left-0 right-0 z-50 w-full max-w-[500px] mx-auto border-t border-slate-100 bg-white/90 backdrop-blur-md shadow-[0_-4px_20px_rgba(0,0,0,0.04)]"
+            className="fixed bottom-0 left-0 right-0 z-50 w-full max-w-[500px] mx-auto border-t border-slate-100 bg-white/90 backdrop-blur-md px-4 sm:px-6 pt-4 sm:pt-5 pb-[calc(env(safe-area-inset-bottom)+16px)] shadow-[0_-4px_20px_rgba(0,0,0,0.04)]"
             data-onboarding-footer
           >
             <div className="flex flex-col gap-3 sm:gap-4">


### PR DESCRIPTION
Footer was missing px/py/safe-area padding. Buttons touched edges on mobile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the onboarding footer's spacing and responsiveness, with improved padding on mobile devices and notched screens for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->