### PR TITLE
fix: Connect another account always visible

### DIFF
--- a/src/components/kyc/screens/KycFinancialLinkScreen.tsx
+++ b/src/components/kyc/screens/KycFinancialLinkScreen.tsx
@@ -393,22 +393,6 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
 
         {/* Secondary actions: Skip + Connect another */}
         <Flex mt={3} justify="center" gap={4}>
-          {isDone && (
-            <Button
-              variant="ghost"
-              color={IOS.primary}
-              fontSize="15px"
-              fontWeight="600"
-              h="auto"
-              py={2}
-              _active={{ opacity: 0.6 }}
-              onClick={plaid.retry}
-              aria-label="Connect another account"
-            >
-              Connect another account
-            </Button>
-          )}
-
           {onSkip && (
             <Button
               variant="ghost"
@@ -425,6 +409,20 @@ const KycFinancialLinkScreen: React.FC<KycFinancialLinkScreenProps> = ({
               Skip for now
             </Button>
           )}
+
+          <Button
+            variant="ghost"
+            color={IOS.primary}
+            fontSize="15px"
+            fontWeight="600"
+            h="auto"
+            py={2}
+            _active={{ opacity: 0.6 }}
+            onClick={isDone ? plaid.retry : () => plaid.isReady && plaid.openPlaidLink()}
+            aria-label="Connect another account"
+          >
+            Connect another account
+          </Button>
         </Flex>
       </Box>
     </Box>


### PR DESCRIPTION
Shows 'Connect another account' next to 'Skip for now' in all states, not just after bank linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined "Connect another account" button behavior in KYC financial linking to be consistently accessible with improved logic for handling retry and new account connection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->