### PR TITLE
feat: integrate Auth Numbers + Identity Match into financial data flow

### DIFF
--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -23,6 +23,8 @@ export interface FinancialDataResponse {
   assets: ProductResult;
   investments: ProductResult;
   identity: ProductResult;
+  authNumbers: ProductResult;
+  identityMatch: ProductResult;
   summary: {
     products_available: number;
     products_total: number;
@@ -231,28 +233,44 @@ export const fetchIdentityMatch = async (
   }
 };
 
-/** Fetch all 4 products in parallel */
+/** Wrap fetchAuthNumbers as a ProductResult */
+const fetchAuth = async (accessToken: string): Promise<ProductResult> => {
+  try {
+    const data = await fetchAuthNumbers(accessToken);
+    if (!data) return { available: false, data: null, error: null, reason: 'not_supported' };
+    return { available: true, data, error: null, reason: null };
+  } catch (e: any) {
+    return { available: false, data: null, error: e.message, reason: 'error' };
+  }
+};
+
+/** Fetch all 6 products in parallel */
 export const fetchAllFinancialData = async (
   accessToken: string, userId: string,
 ): Promise<FinancialDataResponse> => {
-  const [b, a, i, id] = await Promise.allSettled([
+  const [b, a, i, id, auth, idMatch] = await Promise.allSettled([
     fetchBalance(accessToken, userId),
     fetchAssets(accessToken, userId),
     fetchInvestments(accessToken, userId),
     fetchIdentity(accessToken),
+    fetchAuth(accessToken),
+    fetchIdentityMatch(accessToken),
   ]);
 
-  const balance = b.status === 'fulfilled' ? b.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
-  const assets = a.status === 'fulfilled' ? a.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
-  const investments = i.status === 'fulfilled' ? i.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
-  const identity = id.status === 'fulfilled' ? id.value : { available: false, data: null, error: 'Network error', reason: 'error' as const };
+  const errResult = { available: false, data: null, error: 'Network error', reason: 'error' as const };
+  const balance = b.status === 'fulfilled' ? b.value : errResult;
+  const assets = a.status === 'fulfilled' ? a.value : errResult;
+  const investments = i.status === 'fulfilled' ? i.value : errResult;
+  const identity = id.status === 'fulfilled' ? id.value : errResult;
+  const authNumbers = auth.status === 'fulfilled' ? auth.value : errResult;
+  const identityMatch = idMatch.status === 'fulfilled' ? idMatch.value : errResult;
 
-  const count = [balance, assets, investments, identity].filter(r => r.available).length;
+  const count = [balance, assets, investments, identity, authNumbers, identityMatch].filter(r => r.available).length;
 
   return {
-    status: count === 4 ? 'complete' : count > 0 ? 'partial' : 'failed',
-    balance, assets, investments, identity,
-    summary: { products_available: count, products_total: 4, can_proceed: count >= 1 },
+    status: count >= 4 ? 'complete' : count > 0 ? 'partial' : 'failed',
+    balance, assets, investments, identity, authNumbers, identityMatch,
+    summary: { products_available: count, products_total: 6, can_proceed: count >= 1 },
   };
 };
 
@@ -282,6 +300,8 @@ export const saveFinancialDataToSupabase = async (
     if (data.assets.error) errors.assets = data.assets.error;
     if (data.investments.error) errors.investments = data.investments.error;
     if (data.identity?.error) errors.identity = data.identity.error;
+    if (data.authNumbers?.error) errors.auth = data.authNumbers.error;
+    if (data.identityMatch?.error) errors.identity_match = data.identityMatch.error;
 
     await supabase.from('user_financial_data').upsert({
       user_id: userId,
@@ -294,11 +314,15 @@ export const saveFinancialDataToSupabase = async (
       asset_report_token: data.assets.data?.asset_report_token || null,
       investments: data.investments.available ? data.investments.data : null,
       identity_data: data.identity?.available ? data.identity.data : null,
+      auth_numbers: data.authNumbers?.available ? data.authNumbers.data : null,
+      identity_match: data.identityMatch?.available ? data.identityMatch.data : null,
       available_products: {
         balance: data.balance.available,
         assets: data.assets.available,
         investments: data.investments.available,
         identity: data.identity?.available || false,
+        auth: data.authNumbers?.available || false,
+        identity_match: data.identityMatch?.available || false,
       },
       status: data.status,
       fetch_errors: Object.keys(errors).length > 0 ? errors : null,

--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -202,6 +202,18 @@ const loadFromDatabase = async (userId: string): Promise<PlaidLinkState | null> 
             error: data.fetch_errors?.identity || null,
             reason: data.fetch_errors?.identity ? 'error' as const : null,
           },
+          authNumbers: {
+            available: available.auth || false,
+            data: data.auth_numbers || null,
+            error: data.fetch_errors?.auth || null,
+            reason: data.fetch_errors?.auth ? 'error' as const : null,
+          },
+          identityMatch: {
+            available: available.identity_match || false,
+            data: data.identity_match || null,
+            error: data.fetch_errors?.identity_match || null,
+            reason: data.fetch_errors?.identity_match ? 'error' as const : null,
+          },
           summary: {
             products_available: productsAvailable,
             products_total: 3,

--- a/supabase/migrations/20260222200000_add_auth_and_identity_match_columns.sql
+++ b/supabase/migrations/20260222200000_add_auth_and_identity_match_columns.sql
@@ -1,0 +1,8 @@
+-- Add auth_numbers and identity_match columns to user_financial_data
+ALTER TABLE user_financial_data
+  ADD COLUMN IF NOT EXISTS auth_numbers jsonb DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS identity_match jsonb DEFAULT NULL;
+
+-- Add comments
+COMMENT ON COLUMN user_financial_data.auth_numbers IS 'Plaid Auth: account numbers, routing numbers (ACH/EFT)';
+COMMENT ON COLUMN user_financial_data.identity_match IS 'Plaid Identity Match: score comparing user input vs bank records';


### PR DESCRIPTION
## What
- Auth Numbers (account/routing numbers) and Identity Match (name/phone/email match scores) are now fetched alongside Balance, Identity, Assets, and Investments.

## Changes
- `fetchAllFinancialData` now calls 6 products in parallel (was 4)
- `saveFinancialDataToSupabase` saves `auth_numbers` and `identity_match` to DB
- `usePlaidLink` DB restore includes new fields
- Migration: `auth_numbers` + `identity_match` JSONB columns

## Migration Required
Run in Supabase SQL Editor:
```sql
ALTER TABLE user_financial_data ADD COLUMN IF NOT EXISTS auth_numbers jsonb DEFAULT NULL, ADD COLUMN IF NOT EXISTS identity_match jsonb DEFAULT NULL;
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication numbers (account and routing information) now available for connected financial accounts
  * Identity match verification introduced to validate account ownership and identity details
  * Financial data sync now captures six comprehensive data points for more complete account information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->