### PR TITLE
fix: PGRST116 — .single() → .maybeSingle() (fixes Continue to KYC)

### DIFF
--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -145,11 +145,16 @@ export default function OnboardingStep1() {
       if (hasSkipped) {
         console.log('[Step1] User skipped financial verification - allowing access');
       } else {
-        const { data: financialData } = await config.supabaseClient
+        const { data: financialData, error: finError } = await config.supabaseClient
           .from('user_financial_data')
           .select('status')
           .eq('user_id', user.id)
-          .single();
+          .maybeSingle();
+
+        // If query errored or no row found, redirect to financial link
+        if (finError) {
+          console.warn('[Step1] Financial data query error:', finError.message);
+        }
 
         if (!financialData || (financialData.status !== 'complete' && financialData.status !== 'partial')) {
           navigate('/onboarding/financial-link', { replace: true });
@@ -161,7 +166,7 @@ export default function OnboardingStep1() {
         .from('onboarding_data')
         .select('class_a_units, class_b_units, class_c_units, recurring_frequency, recurring_day_of_month, recurring_amount')
         .eq('user_id', user.id)
-        .single();
+        .maybeSingle();
 
       if (onboardingData) {
         setUnits({

--- a/src/pages/onboarding/Step13.tsx
+++ b/src/pages/onboarding/Step13.tsx
@@ -436,7 +436,7 @@ function OnboardingStep13() {
           bank_routing_number, bank_address_city, bank_address_country
         `)
         .eq('user_id', user.id)
-        .single();
+        .maybeSingle();
 
       // Track what DB already has so we know what's "pre-filled" vs "empty"
       let dbHasBankName = false;


### PR DESCRIPTION
**Root cause:** `.single()` returns 406 when no row exists for the user. Step1 got a 406 error, treated it as 'no financial data', and redirected back to financial-link — creating an infinite loop.

**Fix:** Changed all `.single()` calls on `user_financial_data` and `onboarding_data` to `.maybeSingle()` which returns null instead of erroring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the onboarding process by adding enhanced error handling and graceful fallbacks for situations where data is unavailable or missing.
  * Strengthened the financial data retrieval mechanism with better error tracking to ensure uninterrupted user experience during onboarding.
  * Made all onboarding steps more resilient and robust to edge cases and missing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->