### PR TITLE
fix: Continue to KYC navigation — race condition fix

### DIFF
--- a/src/pages/onboarding/FinancialLink.tsx
+++ b/src/pages/onboarding/FinancialLink.tsx
@@ -81,6 +81,8 @@ export default function OnboardingFinancialLink() {
   // Handle financial verification complete → go to Step 1
   const handleContinue = (result: FinancialVerificationResult) => {
     console.log('[FinancialLink] Verification complete:', result);
+    // Set flag so Step 1 skips DB check (save runs in background, may not be done yet)
+    sessionStorage.setItem('financial_verification_complete', 'true');
     navigate('/onboarding/step-1', { replace: true });
   };
 

--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -141,9 +141,10 @@ export default function OnboardingStep1() {
       setUserId(user.id);
 
       const hasSkipped = sessionStorage.getItem('financial_link_skipped') === 'true';
+      const hasCompleted = sessionStorage.getItem('financial_verification_complete') === 'true';
 
-      if (hasSkipped) {
-        console.log('[Step1] User skipped financial verification - allowing access');
+      if (hasSkipped || hasCompleted) {
+        console.log('[Step1] Financial verification bypassed via sessionStorage flag');
       } else {
         const { data: financialData, error: finError } = await config.supabaseClient
           .from('user_financial_data')
@@ -302,6 +303,7 @@ export default function OnboardingStep1() {
       }
 
       sessionStorage.removeItem('financial_link_skipped');
+      sessionStorage.removeItem('financial_verification_complete');
       navigate('/onboarding/step-2');
     } catch (error) {
       console.error('Error:', error);


### PR DESCRIPTION
**Problem:** `saveFinancialDataToSupabase` runs in background (fire-and-forget). When user clicks Continue to KYC, Step1 queries the DB before the write completes → no row found → redirect back to financial-link → infinite loop.

**Fix:** FinancialLink sets `sessionStorage('financial_verification_complete', 'true')` before navigating. Step1 checks this flag (same as `financial_link_skipped`) to bypass the DB check. Flag is cleaned up on Step1 save.