### PR TITLE
fix: Standardize iOS nav bars across all onboarding steps

### DIFF
--- a/src/pages/onboarding/Step11.tsx
+++ b/src/pages/onboarding/Step11.tsx
@@ -460,6 +460,10 @@ function OnboardingStep11() {
     navigate('/onboarding/step-9');
   };
 
+  const handleSkip = () => {
+    navigate('/onboarding/step-13');
+  };
+
   // Generate units summary text
   const getUnitsSummary = () => {
     const parts = [];
@@ -503,6 +507,8 @@ function OnboardingStep11() {
           <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
           <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
+        <button onClick={handleSkip} className="text-[17px] text-[#007AFF] font-normal active:opacity-50 transition-opacity">Skip</button>
       </nav>
 
       <main className="flex-1 overflow-y-auto max-w-lg mx-auto w-full px-4 pt-4 pb-48">

--- a/src/pages/onboarding/Step2.tsx
+++ b/src/pages/onboarding/Step2.tsx
@@ -109,24 +109,15 @@ export default function OnboardingStep2() {
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
-        <button
-          onClick={handleBack}
-          className="text-[#007AFF] hover:opacity-70 transition-opacity flex items-center -ml-2"
-          aria-label="Go back"
-        >
-          <span className="material-symbols-outlined text-3xl" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>
-            chevron_left
-          </span>
+        <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
+          <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
+          <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
-        <button
-          onClick={handleSkip}
-          className="text-[#007AFF] font-medium text-[17px] hover:opacity-70 transition-opacity"
-        >
-          Skip
-        </button>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
+        <button onClick={handleSkip} className="text-[17px] text-[#007AFF] font-normal active:opacity-50 transition-opacity">Skip</button>
       </nav>
 
       {/* ═══ Main Content ═══ */}

--- a/src/pages/onboarding/Step7.tsx
+++ b/src/pages/onboarding/Step7.tsx
@@ -111,15 +111,15 @@ export default function OnboardingStep7() {
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-white/90 backdrop-blur-md flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
-        <button onClick={handleBack} className="text-[#007AFF] p-2 -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
-          <span className="material-symbols-outlined text-3xl" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
+        <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
+          <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
+          <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
-        <button onClick={handleSkip} className="text-[#007AFF] font-semibold text-[17px] active:opacity-50 transition-opacity">
-          Skip
-        </button>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
+        <button onClick={handleSkip} className="text-[17px] text-[#007AFF] font-normal active:opacity-50 transition-opacity">Skip</button>
       </nav>
 
       <main className="flex-1 flex flex-col max-w-md mx-auto w-full px-4 pb-48">

--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -216,13 +216,15 @@ export default function OnboardingStep8() {
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
           <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
           <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
+        <button onClick={handleSkip} className="text-[17px] text-[#007AFF] font-normal active:opacity-50 transition-opacity">Skip</button>
       </nav>
 
       <main className="flex-1 flex flex-col max-w-md mx-auto w-full px-4 pt-4 pb-48">

--- a/src/pages/onboarding/Step9.tsx
+++ b/src/pages/onboarding/Step9.tsx
@@ -159,12 +159,14 @@ export default function OnboardingStep9() {
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-white/90 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
-        <button onClick={handleBack} className="text-[#007AFF] p-2 -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
-          <span className="material-symbols-outlined text-[28px]" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
+        <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
+          <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
+          <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
         <button onClick={handleSkip} className="text-[17px] text-[#007AFF] font-normal active:opacity-50 transition-opacity">Skip</button>
       </nav>
 


### PR DESCRIPTION
All steps now have consistent nav bar pattern:
- **Left**: chevron_left + 'Back' text
- **Center**: 'Setup' title
- **Right**: 'Skip' button

Steps fixed: 2, 7, 8, 9, 11
- Consistent bg color (#F2F2F7/95), z-index, border-b
- Step8 & Step11: Added missing Skip button
- Step11: Added handleSkip function