### PR TITLE
fix: White background across all onboarding steps

### DIFF
--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -270,11 +270,11 @@ export default function OnboardingStep1() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] pb-52"
+      className="bg-white min-h-[100dvh] pb-52"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}
-      <nav className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2" style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}>
+      <nav className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2" style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}>
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
           <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
           <span className="text-[17px] leading-none pb-[2px]">Back</span>
@@ -500,7 +500,7 @@ export default function OnboardingStep1() {
 
       {/* ═══ Fixed Footer ═══ */}
       {!isFooterVisible && (
-        <footer className="fixed bottom-0 left-0 right-0 bg-[#F2F2F7]/80 backdrop-blur-xl border-t border-[#C6C6C8]/30 z-40 pt-4 px-4 pb-[calc(env(safe-area-inset-bottom,0px)+16px)]">
+        <footer className="fixed bottom-0 left-0 right-0 bg-white/80 backdrop-blur-xl border-t border-[#C6C6C8]/30 z-40 pt-4 px-4 pb-[calc(env(safe-area-inset-bottom,0px)+16px)]">
           <div className="max-w-md mx-auto">
             <div className="flex justify-between items-center mb-4">
               <span className="text-[13px] font-bold text-[#3C3C4399] uppercase tracking-wide">

--- a/src/pages/onboarding/Step11.tsx
+++ b/src/pages/onboarding/Step11.tsx
@@ -495,12 +495,12 @@ function OnboardingStep11() {
 
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] flex flex-col"
+      className="bg-white min-h-[100dvh] flex flex-col"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">

--- a/src/pages/onboarding/Step13.tsx
+++ b/src/pages/onboarding/Step13.tsx
@@ -661,12 +661,12 @@ function OnboardingStep13() {
 
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] flex flex-col"
+      className="bg-white min-h-[100dvh] flex flex-col"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">

--- a/src/pages/onboarding/Step2.tsx
+++ b/src/pages/onboarding/Step2.tsx
@@ -104,12 +104,12 @@ export default function OnboardingStep2() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] flex flex-col"
+      className="bg-white min-h-[100dvh] flex flex-col"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">
@@ -202,7 +202,7 @@ export default function OnboardingStep2() {
       {/* ═══ Fixed Footer ═══ */}
       {!isFooterVisible && (
         <div
-          className="fixed bottom-0 left-0 right-0 p-4 bg-[#F2F2F7]/90 backdrop-blur-md border-t border-[#C6C6C8]/30 z-40"
+          className="fixed bottom-0 left-0 right-0 p-4 bg-white/90 backdrop-blur-md border-t border-[#C6C6C8]/30 z-40"
           style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 16px)' }}
           data-onboarding-footer
         >

--- a/src/pages/onboarding/Step4.tsx
+++ b/src/pages/onboarding/Step4.tsx
@@ -216,7 +216,7 @@ export default function OnboardingStep4() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] flex flex-col relative overflow-hidden"
+      className="bg-white min-h-[100dvh] flex flex-col relative overflow-hidden"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ Background layer (blurs when modal is open) ═══ */}
@@ -428,7 +428,7 @@ export default function OnboardingStep4() {
       {/* ═══ Fixed Footer ═══ */}
       {!isFooterVisible && !showLocationModal && (
         <div
-          className="fixed bottom-0 left-0 right-0 p-4 bg-[#F2F2F7]/90 backdrop-blur-md border-t border-[#C6C6C8]/30 z-40"
+          className="fixed bottom-0 left-0 right-0 p-4 bg-white/90 backdrop-blur-md border-t border-[#C6C6C8]/30 z-40"
           style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 16px)' }}
           data-onboarding-footer
         >

--- a/src/pages/onboarding/Step7.tsx
+++ b/src/pages/onboarding/Step7.tsx
@@ -111,7 +111,7 @@ export default function OnboardingStep7() {
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">

--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -211,12 +211,12 @@ export default function OnboardingStep8() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] flex flex-col"
+      className="bg-white min-h-[100dvh] flex flex-col"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">

--- a/src/pages/onboarding/Step9.tsx
+++ b/src/pages/onboarding/Step9.tsx
@@ -154,12 +154,12 @@ export default function OnboardingStep9() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-[#F2F2F7] min-h-[100dvh] flex flex-col"
+      className="bg-white min-h-[100dvh] flex flex-col"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}
       <nav
-        className="sticky top-0 z-30 bg-[#F2F2F7]/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
+        className="sticky top-0 z-30 bg-white/95 backdrop-blur-md border-b border-[#C6C6C8]/30 flex items-end justify-between px-4 pb-2"
         style={{ paddingTop: 'calc(env(safe-area-inset-top, 12px) + 4px)', minHeight: '48px' }}
       >
         <button onClick={handleBack} className="text-[#007AFF] flex items-center -ml-2 active:opacity-50 transition-opacity" aria-label="Go back">


### PR DESCRIPTION
- Main container bg: #F2F2F7 → white for all Steps 1-13
- Nav bar bg: white/95 for consistent Apple-like clean design
- Footer bg: white/90 standardized