### PR TITLE
fix: iOS design standardization across all onboarding steps

### DIFF
--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -279,7 +279,7 @@ export default function OnboardingStep1() {
           <span className="material-symbols-outlined text-3xl -mr-1" style={{ fontVariationSettings: "'FILL' 0, 'wght' 400" }}>chevron_left</span>
           <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
-        <h1 className="text-[17px] font-semibold text-black absolute left-1/2 transform -translate-x-1/2">Onboarding</h1>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
         <button onClick={() => navigate('/dashboard')} className="text-[#007AFF] text-[17px] font-normal active:opacity-50 transition-opacity">
           Skip
         </button>

--- a/src/pages/onboarding/Step2.tsx
+++ b/src/pages/onboarding/Step2.tsx
@@ -125,16 +125,16 @@ export default function OnboardingStep2() {
         {/* ─── Progress Bar ─── */}
         <div className="mb-6">
           <div className="flex justify-between items-center mb-2">
-            <span className="text-xs font-semibold tracking-wide text-[#3C3C4399] uppercase">
+            <span className="text-[13px] font-medium tracking-wide text-[#8E8E93] uppercase">
               Onboarding Progress
             </span>
-            <span className="text-xs font-medium text-[#3C3C4399]">
+            <span className="text-[13px] font-medium text-[#8E8E93]">
               Step {CURRENT_STEP}/{TOTAL_STEPS}
             </span>
           </div>
-          <div className="w-full bg-gray-200 rounded-full h-1.5">
+          <div className="w-full bg-gray-200 rounded-full h-1">
             <div
-              className="bg-[#007AFF] h-1.5 rounded-full transition-all duration-500"
+              className="bg-[#007AFF] h-1 rounded-full transition-all duration-500"
               style={{ width: `${PROGRESS_PCT}%` }}
             />
           </div>
@@ -144,7 +144,7 @@ export default function OnboardingStep2() {
         </div>
 
         {/* ─── Title ─── */}
-        <h1 className="text-[28px] leading-[34px] font-bold text-black mb-8 tracking-tight">
+        <h1 className="text-[34px] leading-[41px] font-bold text-black mb-8 tracking-tight">
           How did you hear about Hushh Fund&nbsp;A?
         </h1>
 
@@ -206,27 +206,24 @@ export default function OnboardingStep2() {
           style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 16px)' }}
           data-onboarding-footer
         >
-          <div className="max-w-md mx-auto">
-            {/* Next Button */}
+          <div className="max-w-md mx-auto flex gap-3">
+            <button
+              onClick={handleSkip}
+              className="flex-1 h-[50px] rounded-xl bg-gray-100 text-[#007AFF] font-semibold text-[17px] active:bg-gray-200 transition-colors flex items-center justify-center"
+            >
+              Skip
+            </button>
             <button
               onClick={handleContinue}
               disabled={!selectedSource || isLoading}
               data-onboarding-cta
-              className={`w-full font-semibold text-[17px] h-12 rounded-xl shadow-sm transition-all flex items-center justify-center ${
-                !selectedSource || isLoading
-                  ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
-                  : 'bg-[#007AFF] text-white active:opacity-90 active:scale-[0.98]'
+              className={`flex-[2] h-[50px] rounded-xl font-semibold text-[17px] shadow-sm active:scale-[0.98] transition-all flex items-center justify-center ${
+                selectedSource && !isLoading
+                  ? 'bg-[#007AFF] text-white'
+                  : 'bg-gray-200 text-gray-400 cursor-not-allowed'
               }`}
             >
-              {isLoading ? 'Saving...' : 'Next'}
-            </button>
-
-            {/* Skip Button */}
-            <button
-              onClick={handleSkip}
-              className="w-full mt-4 text-[#007AFF] font-medium text-[17px] h-12 flex items-center justify-center hover:opacity-70 transition-opacity"
-            >
-              Skip
+              {isLoading ? 'Saving...' : 'Continue'}
             </button>
           </div>
         </div>

--- a/src/pages/onboarding/Step4.tsx
+++ b/src/pages/onboarding/Step4.tsx
@@ -233,7 +233,7 @@ export default function OnboardingStep4() {
             <span className="text-[17px] leading-none pb-[2px]">Back</span>
           </button>
           <h1 className="text-[17px] font-semibold text-black absolute left-1/2 transform -translate-x-1/2">
-            Verification
+            Setup
           </h1>
           <button onClick={handleSkip} className="text-[#007AFF] font-medium text-[17px]">Skip</button>
         </nav>


### PR DESCRIPTION
Consistent iOS design tokens: nav title 'Setup', 34px Large Title, h-1 progress bar, side-by-side Skip+Continue footer, #8E8E93 system gray