### PR TITLE
fix: Step8 scroll issue

### DIFF
--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -227,7 +227,7 @@ export default function OnboardingStep8() {
         <button onClick={handleSkip} className="text-[17px] text-[#007AFF] font-normal active:opacity-50 transition-opacity">Skip</button>
       </nav>
 
-      <main className="flex-1 flex flex-col max-w-md mx-auto w-full px-4 pt-4 pb-48">
+      <main className="flex-1 overflow-y-auto max-w-md mx-auto w-full px-4 pt-4 pb-48">
         {/* ─── Progress Bar ─── */}
         <div className="mb-6 space-y-2">
           <span className="text-[13px] text-[#8E8E93] font-medium uppercase tracking-wide">Onboarding Progress</span>


### PR DESCRIPTION
Fixed scroll on Step8 by changing main from flex-col to overflow-y-auto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the onboarding step layout to enable vertical scrolling for the main content area, improving content accessibility while maintaining layout structure and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->