### PR TITLE
fix: standardize progress bar across Steps 1, 4, 5

### DIFF
--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -288,17 +288,14 @@ export default function OnboardingStep1() {
       <main className="px-4 pt-4 max-w-md mx-auto">
         {/* ═══ Progress Bar ═══ */}
         <div className="mb-6">
-          <div className="flex justify-between items-end mb-2">
-            <span className="text-[13px] font-medium text-[#3C3C4399] uppercase tracking-wide">
-              Step 1 of {TOTAL_STEPS}
-            </span>
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-[13px] font-medium text-[#8E8E93] uppercase tracking-wide">Onboarding Progress</span>
+            <span className="text-[13px] text-[#8E8E93]">Step 1/{TOTAL_STEPS}</span>
           </div>
-          <div className="flex gap-1 h-1">
-            <div className="bg-[#007AFF] h-full w-full rounded-full" />
-            {Array.from({ length: TOTAL_STEPS - 1 }).map((_, i) => (
-              <div key={i} className="bg-gray-300 h-full w-full rounded-full" />
-            ))}
+          <div className="h-1 w-full bg-gray-200 rounded-full overflow-hidden">
+            <div className="h-full bg-[#007AFF] rounded-full transition-all duration-500" style={{ width: `${Math.round((1 / TOTAL_STEPS) * 100)}%` }} />
           </div>
+          <p className="mt-2 text-[13px] font-medium text-[#007AFF]">{Math.round((1 / TOTAL_STEPS) * 100)}% complete</p>
         </div>
 
         {/* ═══ Title Block ═══ */}

--- a/src/pages/onboarding/Step4.tsx
+++ b/src/pages/onboarding/Step4.tsx
@@ -234,7 +234,7 @@ export default function OnboardingStep4() {
           </button>
           <h1 className="text-[17px] font-semibold text-black absolute left-1/2 transform -translate-x-1/2">
             Setup
-          </h1>
+          </span>
           <button onClick={handleSkip} className="text-[#007AFF] font-medium text-[17px]">Skip</button>
         </nav>
 
@@ -242,19 +242,19 @@ export default function OnboardingStep4() {
           {/* ─── Progress Bar ─── */}
           <div className="mb-6">
             <div className="flex justify-between items-center mb-2">
-              <span className="text-xs font-semibold tracking-wide text-[#3C3C4399] uppercase">Onboarding Progress</span>
-              <span className="text-xs font-medium text-[#3C3C4399]">Step {CURRENT_STEP}/{TOTAL_STEPS}</span>
+              <span className="text-[13px] font-medium text-[#8E8E93] uppercase tracking-wide">Onboarding Progress</span>
+              <span className="text-[13px] text-[#8E8E93]">Step {CURRENT_STEP}/{TOTAL_STEPS}</span>
             </div>
-            <div className="w-full bg-gray-200 rounded-full h-1.5">
-              <div className="bg-[#007AFF] h-1.5 rounded-full transition-all duration-500" style={{ width: `${PROGRESS_PCT}%` }} />
+            <div className="w-full bg-gray-200 rounded-full h-1 overflow-hidden">
+              <div className="bg-[#007AFF] h-1 rounded-full transition-all duration-500" style={{ width: `${PROGRESS_PCT}%` }} />
             </div>
-            <p className="text-[#007AFF] text-xs font-medium mt-2">{PROGRESS_PCT}% complete</p>
+            <p className="mt-2 text-[13px] font-medium text-[#007AFF]">{PROGRESS_PCT}% complete</p>
           </div>
 
           {/* ─── Title ─── */}
           <h1 className="text-[34px] leading-[41px] font-bold text-black mb-2 tracking-tight">
             Confirm your residence
-          </h1>
+          </span>
           <p className="text-[17px] text-[#8E8E93] mb-8 leading-snug">
             We need to know where you live and pay taxes to open your investment account.
           </p>

--- a/src/pages/onboarding/Step5.tsx
+++ b/src/pages/onboarding/Step5.tsx
@@ -214,21 +214,23 @@ export default function OnboardingStep5() {
           </span>
           <span className="text-[17px] leading-none pb-[2px]">Back</span>
         </button>
+        <span className="font-semibold text-[17px] text-black">Setup</span>
         <button onClick={handleSkip} className="text-[#007AFF] font-normal text-[17px] active:opacity-50 transition-opacity">
           Skip
         </button>
       </nav>
 
-      <main className="flex-1 flex flex-col max-w-md mx-auto w-full px-4 pt-6 pb-48">
+      <main className="flex-1 flex flex-col max-w-md mx-auto w-full px-4 pt-4 pb-48">
         {/* ─── Progress Bar ─── */}
-        <div className="mb-8">
-          <div className="h-1 w-full bg-gray-200 rounded-full overflow-hidden mb-2">
+        <div className="mb-6">
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-[13px] font-medium text-[#8E8E93] uppercase tracking-wide">Onboarding Progress</span>
+            <span className="text-[13px] text-[#8E8E93]">Step {CURRENT_STEP}/{TOTAL_STEPS}</span>
+          </div>
+          <div className="h-1 w-full bg-gray-200 rounded-full overflow-hidden">
             <div className="h-full bg-[#007AFF] rounded-full transition-all duration-500" style={{ width: `${PROGRESS_PCT}%` }} />
           </div>
-          <div className="flex justify-between items-center text-xs font-medium text-[#8E8E93] uppercase tracking-wide">
-            <span>{PROGRESS_PCT}% complete</span>
-            <span>Step {CURRENT_STEP} of {TOTAL_STEPS}</span>
-          </div>
+          <p className="mt-2 text-[13px] font-medium text-[#007AFF]">{PROGRESS_PCT}% complete</p>
         </div>
 
         {/* ─── Title ─── */}


### PR DESCRIPTION
All steps now use identical progress bar: 'Onboarding Progress' header + single bar + '% complete'. Also added 'Setup' nav center title to Step5.