### PR TITLE
fix: enable page-level scrolling on onboarding steps 5, 8, 11, 13

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -364,9 +364,10 @@ html {
   color: #0f172a;
 }
 
-/* Step 1 uses page-level scrolling (no .onboarding-shell main scroller), so allow scroll there. */
-html.onboarding-step1-scroll,
-body.onboarding-step1-scroll {
+/* Onboarding pages that use page-level scrolling (no .onboarding-shell main scroller).
+   Add/remove "onboarding-page-scroll" on html & body via useEffect in each step. */
+html.onboarding-page-scroll,
+body.onboarding-page-scroll {
   height: auto !important;
   min-height: 100dvh;
   overflow-y: auto !important;

--- a/src/pages/onboarding/Step1.tsx
+++ b/src/pages/onboarding/Step1.tsx
@@ -105,11 +105,11 @@ export default function OnboardingStep1() {
   /* ─── Scroll & body class ─── */
   useEffect(() => {
     window.scrollTo(0, 0);
-    document.documentElement.classList.add('onboarding-step1-scroll');
-    document.body.classList.add('onboarding-step1-scroll');
+    document.documentElement.classList.add('onboarding-page-scroll');
+    document.body.classList.add('onboarding-page-scroll');
     return () => {
-      document.documentElement.classList.remove('onboarding-step1-scroll');
-      document.body.classList.remove('onboarding-step1-scroll');
+      document.documentElement.classList.remove('onboarding-page-scroll');
+      document.body.classList.remove('onboarding-page-scroll');
     };
   }, []);
 

--- a/src/pages/onboarding/Step11.tsx
+++ b/src/pages/onboarding/Step11.tsx
@@ -200,8 +200,15 @@ function OnboardingStep11() {
     localShareUnits.class_b_units !== shareUnits.class_b_units ||
     localShareUnits.class_c_units !== shareUnits.class_c_units;
 
+  /* ─── Enable page-level scrolling ─── */
   useEffect(() => {
     window.scrollTo(0, 0);
+    document.documentElement.classList.add('onboarding-page-scroll');
+    document.body.classList.add('onboarding-page-scroll');
+    return () => {
+      document.documentElement.classList.remove('onboarding-page-scroll');
+      document.body.classList.remove('onboarding-page-scroll');
+    };
   }, []);
 
   useEffect(() => {

--- a/src/pages/onboarding/Step13.tsx
+++ b/src/pages/onboarding/Step13.tsx
@@ -414,8 +414,15 @@ function OnboardingStep13() {
   };
 
   // Load existing data
+  /* ─── Enable page-level scrolling ─── */
   useEffect(() => {
     window.scrollTo(0, 0);
+    document.documentElement.classList.add('onboarding-page-scroll');
+    document.body.classList.add('onboarding-page-scroll');
+    return () => {
+      document.documentElement.classList.remove('onboarding-page-scroll');
+      document.body.classList.remove('onboarding-page-scroll');
+    };
   }, []);
 
   useEffect(() => {

--- a/src/pages/onboarding/Step5.tsx
+++ b/src/pages/onboarding/Step5.tsx
@@ -74,7 +74,16 @@ export default function OnboardingStep5() {
   const [showDialPicker, setShowDialPicker] = useState(false);
   const isFooterVisible = useFooterVisibility();
 
-  useEffect(() => { window.scrollTo(0, 0); }, []);
+  /* ─── Enable page-level scrolling ─── */
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    document.documentElement.classList.add('onboarding-page-scroll');
+    document.body.classList.add('onboarding-page-scroll');
+    return () => {
+      document.documentElement.classList.remove('onboarding-page-scroll');
+      document.body.classList.remove('onboarding-page-scroll');
+    };
+  }, []);
 
   /* ─── Load user + existing data ─── */
   useEffect(() => {

--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -58,7 +58,16 @@ export default function OnboardingStep8() {
   const [touched, setTouched] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
 
-  useEffect(() => { window.scrollTo(0, 0); }, []);
+  /* ─── Enable page-level scrolling ─── */
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    document.documentElement.classList.add('onboarding-page-scroll');
+    document.body.classList.add('onboarding-page-scroll');
+    return () => {
+      document.documentElement.classList.remove('onboarding-page-scroll');
+      document.body.classList.remove('onboarding-page-scroll');
+    };
+  }, []);
 
   /* ─── Auto-detect location ─── */
   const detectAndApply = async (userId?: string) => {


### PR DESCRIPTION
Steps 5, 8, 11, 13 were not scrollable because they lacked the overflow-y override that Step 1 had. Renamed CSS class to generic onboarding-page-scroll and added useEffect to all affected steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced and standardized page scrolling behavior across onboarding steps for a more consistent and smoother user experience during the onboarding process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->