### PR TITLE
fix: enable scrolling on KYC steps 5, 8, 11, 13

### DIFF
--- a/src/components/profile/NWSScoreBadge.tsx
+++ b/src/components/profile/NWSScoreBadge.tsx
@@ -1,0 +1,135 @@
+/**
+ * NWS Score Badge — Circular progress indicator for Network Worth Score
+ * Shows score 0–100 with grade and color coding
+ */
+
+import { NWSResult, NWSBreakdown } from '../../services/networkScore/calculateNWS';
+
+interface NWSScoreBadgeProps {
+  result: NWSResult | null;
+  loading?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  showBreakdown?: boolean;
+}
+
+// Color based on grade
+const getColor = (grade: string): string => {
+  switch (grade) {
+    case 'A+': return '#34C759';
+    case 'A': return '#30D158';
+    case 'B+': return '#007AFF';
+    case 'B': return '#5856D6';
+    case 'C+': return '#FF9500';
+    case 'C': return '#FF9500';
+    case 'D': return '#FF3B30';
+    default: return '#8E8E93';
+  }
+};
+
+// Breakdown category labels
+const BREAKDOWN_LABELS: Record<keyof NWSBreakdown, { label: string; max: number }> = {
+  liquidity: { label: 'Liquidity', max: 20 },
+  investments: { label: 'Investments', max: 25 },
+  assetDepth: { label: 'Asset Depth', max: 20 },
+  diversification: { label: 'Diversification', max: 15 },
+  identityConfidence: { label: 'Identity', max: 10 },
+  accountHealth: { label: 'Health', max: 10 },
+};
+
+const NWSScoreBadge = ({ result, loading = false, size = 'md', showBreakdown = false }: NWSScoreBadgeProps) => {
+  // Loading shimmer
+  if (loading) {
+    const dim = size === 'sm' ? 64 : size === 'md' ? 96 : 128;
+    return (
+      <div className="flex flex-col items-center gap-2">
+        <div className="rounded-full bg-gray-100 animate-pulse" style={{ width: dim, height: dim }} />
+        <div className="h-3 w-16 bg-gray-100 rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  // No data
+  if (!result) {
+    return (
+      <div className="flex flex-col items-center gap-1 opacity-50">
+        <div className="w-16 h-16 rounded-full border-4 border-dashed border-gray-200 flex items-center justify-center">
+          <span className="text-[11px] text-gray-400 font-medium">NWS</span>
+        </div>
+        <p className="text-[11px] text-gray-400">No data</p>
+      </div>
+    );
+  }
+
+  const { score, grade, label } = result;
+  const color = getColor(grade);
+  const pct = score / 100;
+
+  // SVG dimensions based on size
+  const dim = size === 'sm' ? 64 : size === 'md' ? 96 : 128;
+  const strokeWidth = size === 'sm' ? 5 : size === 'md' ? 6 : 8;
+  const radius = (dim - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - pct);
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {/* Circular Progress */}
+      <div className="relative" style={{ width: dim, height: dim }}>
+        <svg width={dim} height={dim} className="-rotate-90">
+          {/* Background track */}
+          <circle
+            cx={dim / 2} cy={dim / 2} r={radius}
+            fill="none" stroke="#F2F2F7"
+            strokeWidth={strokeWidth}
+          />
+          {/* Progress arc */}
+          <circle
+            cx={dim / 2} cy={dim / 2} r={radius}
+            fill="none" stroke={color}
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            style={{ transition: 'stroke-dashoffset 1s ease-out' }}
+          />
+        </svg>
+        {/* Center text */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="font-bold text-black leading-none" style={{ fontSize: dim * 0.28 }}>{score}</span>
+          <span className="font-bold leading-none mt-0.5" style={{ fontSize: dim * 0.14, color }}>{grade}</span>
+        </div>
+      </div>
+
+      {/* Label */}
+      <div className="text-center">
+        <p className="text-[13px] font-semibold text-black">NWS</p>
+        <p className="text-[11px]" style={{ color }}>{label}</p>
+      </div>
+
+      {/* Breakdown bars (optional) */}
+      {showBreakdown && result.breakdown && (
+        <div className="w-full max-w-[220px] mt-2 space-y-1.5">
+          {(Object.keys(BREAKDOWN_LABELS) as (keyof NWSBreakdown)[]).map((key) => {
+            const { label: lbl, max } = BREAKDOWN_LABELS[key];
+            const val = result.breakdown[key];
+            const barPct = max > 0 ? (val / max) * 100 : 0;
+            return (
+              <div key={key} className="flex items-center gap-2">
+                <span className="text-[10px] text-[#8E8E93] w-[70px] text-right shrink-0">{lbl}</span>
+                <div className="flex-1 h-[6px] bg-[#F2F2F7] rounded-full overflow-hidden">
+                  <div
+                    className="h-full rounded-full transition-all duration-700"
+                    style={{ width: `${barPct}%`, backgroundColor: color }}
+                  />
+                </div>
+                <span className="text-[10px] font-mono text-[#8E8E93] w-[30px] shrink-0">{val}/{max}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default NWSScoreBadge;

--- a/src/pages/hushh-user-profile/index.tsx
+++ b/src/pages/hushh-user-profile/index.tsx
@@ -12,6 +12,8 @@ import { generateInvestorProfile } from "../../services/investorProfile/apiClien
 import { downloadHushhGoldPass, launchGoogleWalletPass } from "../../services/walletPass";
 import { InvestorProfile, FIELD_LABELS, VALUE_LABELS } from "../../types/investorProfile";
 import AIDetectedPreferences from "../../components/profile/AIDetectedPreferences";
+import NWSScoreBadge from "../../components/profile/NWSScoreBadge";
+import { calculateNWSFromDB, NWSResult } from "../../services/networkScore/calculateNWS";
 import { invokeShadowInvestigator, formatPhoneContact, ShadowProfile, SHADOW_FIELD_LABELS } from "../../services/shadowInvestigator";
 
 // Complete country list matching Step 6 onboarding - using full country names
@@ -107,6 +109,9 @@ const HushhUserProfilePage: React.FC = () => {
   // Shadow Investigator state
   const [shadowProfile, setShadowProfile] = useState<ShadowProfile | null>(null);
   const [shadowLoading, setShadowLoading] = useState(false);
+  // NWS Score state
+  const [nwsResult, setNwsResult] = useState<NWSResult | null>(null);
+  const [nwsLoading, setNwsLoading] = useState(true);
 
   // Field options for AI-generated profile editing
   const FIELD_OPTIONS: Record<string, { value: string; label: string }[]> = {
@@ -378,8 +383,39 @@ const HushhUserProfilePage: React.FC = () => {
             }
           }
         }
+        // Load NWS score from user_financial_data (pure math, no API)
+        try {
+          const { data: financialData } = await supabase
+            .from('user_financial_data')
+            .select('balance_data, investments_data, identity_match_data, nws_score')
+            .eq('user_id', user.id)
+            .maybeSingle();
+
+          if (financialData) {
+            const nws = calculateNWSFromDB(financialData);
+            setNwsResult(nws);
+            console.log('[Profile] NWS Score calculated:', nws.score, nws.grade);
+
+            // Persist NWS score if not already saved
+            if (!financialData.nws_score || financialData.nws_score !== nws.score) {
+              supabase.from('user_financial_data').update({
+                nws_score: nws.score,
+                nws_breakdown: nws.breakdown,
+                nws_grade: nws.grade,
+                nws_calculated_at: new Date().toISOString(),
+              }).eq('user_id', user.id).then(() => {
+                console.log('[Profile] NWS score persisted to DB');
+              });
+            }
+          }
+        } catch (nwsErr) {
+          console.warn('[Profile] NWS calculation skipped:', nwsErr);
+        } finally {
+          setNwsLoading(false);
+        }
       } catch (error) {
         console.error("Authentication check failed:", error);
+        setNwsLoading(false);
       }
     };
 
@@ -744,20 +780,24 @@ const HushhUserProfilePage: React.FC = () => {
           <section className="relative overflow-hidden rounded-[1.5rem] bg-gradient-to-br from-blue-50 to-indigo-50 px-6 py-6">
             <div className="pointer-events-none absolute -right-12 -top-14 h-44 w-44 rounded-full bg-[#3A63B8]/10 blur-2xl" />
             <div className="pointer-events-none absolute -left-10 -bottom-14 h-36 w-36 rounded-full bg-[#1A365D]/10 blur-2xl" />
-            <div className="relative z-10">
-              <div className="mb-3 flex items-center">
-                <span className="rounded-full border border-[#3A63B8]/20 bg-[#3A63B8]/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#3A63B8]">
-                  Premium Member
-                </span>
+            <div className="relative z-10 flex items-start justify-between">
+              <div className="flex-1">
+                <div className="mb-3 flex items-center">
+                  <span className="rounded-full border border-[#3A63B8]/20 bg-[#3A63B8]/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wide text-[#3A63B8]">
+                    Premium Member
+                  </span>
+                </div>
+                <h2 className="mb-1.5 text-2xl font-bold tracking-tight text-slate-900">
+                  Welcome back, {form.name?.split(' ')[0] || 'Alex'}
+                </h2>
+                <p className="max-w-2xl text-sm leading-relaxed text-slate-500">
+                  Complete your profile to unlock personalized investment insights tailored to your financial goals.
+                </p>
               </div>
-            </div>
-            <div className="relative z-10">
-              <h2 className="mb-1.5 text-2xl font-bold tracking-tight text-slate-900">
-                Welcome back, {form.name?.split(' ')[0] || 'Alex'}
-              </h2>
-              <p className="max-w-2xl text-sm leading-relaxed text-slate-500">
-                Complete your profile to unlock personalized investment insights tailored to your financial goals.
-              </p>
+              {/* NWS Score Badge */}
+              <div className="ml-4 shrink-0">
+                <NWSScoreBadge result={nwsResult} loading={nwsLoading} size="sm" />
+              </div>
             </div>
           </section>
 

--- a/src/pages/onboarding/Step11.tsx
+++ b/src/pages/onboarding/Step11.tsx
@@ -502,7 +502,7 @@ function OnboardingStep11() {
 
   return (
     <div
-      className="bg-white min-h-[100dvh]"
+      className="bg-white min-h-[100dvh] pb-52"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}

--- a/src/pages/onboarding/Step13.tsx
+++ b/src/pages/onboarding/Step13.tsx
@@ -675,7 +675,7 @@ function OnboardingStep13() {
 
   return (
     <div
-      className="bg-white min-h-[100dvh]"
+      className="bg-white min-h-[100dvh] pb-52"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}

--- a/src/pages/onboarding/Step5.tsx
+++ b/src/pages/onboarding/Step5.tsx
@@ -209,7 +209,7 @@ export default function OnboardingStep5() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-white min-h-[100dvh] flex flex-col relative"
+      className="bg-white min-h-[100dvh] pb-52 relative"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}

--- a/src/pages/onboarding/Step8.tsx
+++ b/src/pages/onboarding/Step8.tsx
@@ -220,7 +220,7 @@ export default function OnboardingStep8() {
      ═══════════════════════════════════════════════ */
   return (
     <div
-      className="bg-white min-h-[100dvh]"
+      className="bg-white min-h-[100dvh] pb-52"
       style={{ fontFamily: "-apple-system, BlinkMacSystemFont, 'Inter', sans-serif", WebkitFontSmoothing: 'antialiased' }}
     >
       {/* ═══ iOS Navigation Bar ═══ */}

--- a/src/services/networkScore/calculateNWS.ts
+++ b/src/services/networkScore/calculateNWS.ts
@@ -1,0 +1,342 @@
+/**
+ * Network Worth Score (NWS) Calculator
+ * 
+ * Calculates a score 0–100 from Plaid financial data.
+ * Pure math — no API calls, no AI.
+ * 
+ * Breakdown (100 points total):
+ *   Liquidity Score       (20 pts) — checking + savings balances
+ *   Investment Score      (25 pts) — investment holdings value
+ *   Asset Depth           (20 pts) — total assets from balances
+ *   Diversification       (15 pts) — variety of account types
+ *   Identity Confidence   (10 pts) — Plaid identity match scores
+ *   Account Health        (10 pts) — available vs current ratio
+ */
+
+// ── Types ──
+
+export interface NWSInput {
+  balanceData: any | null;       // Plaid balance response
+  investmentsData: any | null;   // Plaid investments holdings
+  identityMatchData: any | null; // Plaid identity match scores
+}
+
+export interface NWSResult {
+  score: number;           // 0–100 total
+  breakdown: NWSBreakdown;
+  grade: 'A+' | 'A' | 'B+' | 'B' | 'C+' | 'C' | 'D' | 'F';
+  label: string;           // "Excellent", "Good", etc.
+}
+
+export interface NWSBreakdown {
+  liquidity: number;        // 0–20
+  investments: number;      // 0–25
+  assetDepth: number;       // 0–20
+  diversification: number;  // 0–15
+  identityConfidence: number; // 0–10
+  accountHealth: number;    // 0–10
+}
+
+// ── Helpers ──
+
+/** Clamp a value between min and max */
+const clamp = (val: number, min: number, max: number) =>
+  Math.max(min, Math.min(max, val));
+
+/** Safe parse number from any value */
+const toNum = (val: any): number => {
+  if (val === null || val === undefined) return 0;
+  const n = Number(val);
+  return isNaN(n) ? 0 : n;
+};
+
+/** Get score grade from total score */
+const getGrade = (score: number): NWSResult['grade'] => {
+  if (score >= 90) return 'A+';
+  if (score >= 80) return 'A';
+  if (score >= 70) return 'B+';
+  if (score >= 60) return 'B';
+  if (score >= 50) return 'C+';
+  if (score >= 40) return 'C';
+  if (score >= 25) return 'D';
+  return 'F';
+};
+
+/** Get human-readable label from score */
+const getLabel = (score: number): string => {
+  if (score >= 90) return 'Exceptional';
+  if (score >= 80) return 'Excellent';
+  if (score >= 70) return 'Very Good';
+  if (score >= 60) return 'Good';
+  if (score >= 50) return 'Fair';
+  if (score >= 40) return 'Below Average';
+  if (score >= 25) return 'Needs Improvement';
+  return 'Insufficient Data';
+};
+
+// ── Score Calculations ──
+
+/**
+ * Liquidity Score (0–20 pts)
+ * Based on total checking + savings balances.
+ * 
+ * Scale: $0 → 0pts, $10K → 10pts, $50K → 15pts, $200K+ → 20pts
+ */
+function calcLiquidityScore(balanceData: any): number {
+  if (!balanceData?.accounts) return 0;
+
+  const liquidAccounts = balanceData.accounts.filter((a: any) =>
+    ['checking', 'savings', 'money market', 'hsa', 'cd'].includes(a.subtype?.toLowerCase())
+  );
+
+  const totalLiquid = liquidAccounts.reduce((sum: number, a: any) => {
+    return sum + toNum(a.balances?.current || a.balances?.available || 0);
+  }, 0);
+
+  // Logarithmic scale: diminishing returns past $50K
+  if (totalLiquid <= 0) return 0;
+  if (totalLiquid <= 1000) return 2;
+  if (totalLiquid <= 5000) return 5;
+  if (totalLiquid <= 10000) return 8;
+  if (totalLiquid <= 25000) return 11;
+  if (totalLiquid <= 50000) return 14;
+  if (totalLiquid <= 100000) return 17;
+  return 20;
+}
+
+/**
+ * Investment Score (0–25 pts)
+ * Based on total investment holdings value.
+ * 
+ * Scale: $0 → 0pts, $50K → 10pts, $250K → 18pts, $1M+ → 25pts
+ */
+function calcInvestmentScore(investmentsData: any): number {
+  if (!investmentsData) return 0;
+
+  // Try holdings first, then accounts
+  let totalValue = 0;
+
+  if (investmentsData.holdings && Array.isArray(investmentsData.holdings)) {
+    totalValue = investmentsData.holdings.reduce((sum: number, h: any) => {
+      return sum + toNum(h.institution_value || h.cost_basis || 0);
+    }, 0);
+  }
+
+  // Fallback: sum investment account balances
+  if (totalValue === 0 && investmentsData.accounts) {
+    totalValue = investmentsData.accounts
+      .filter((a: any) => ['investment', 'brokerage', '401k', 'ira', 'roth'].includes(a.subtype?.toLowerCase()))
+      .reduce((sum: number, a: any) => sum + toNum(a.balances?.current || 0), 0);
+  }
+
+  if (totalValue <= 0) return 0;
+  if (totalValue <= 5000) return 3;
+  if (totalValue <= 25000) return 7;
+  if (totalValue <= 50000) return 10;
+  if (totalValue <= 100000) return 14;
+  if (totalValue <= 250000) return 18;
+  if (totalValue <= 500000) return 21;
+  if (totalValue <= 1000000) return 23;
+  return 25;
+}
+
+/**
+ * Asset Depth (0–20 pts)
+ * Based on total across ALL account types (liquid + investments + credit limits).
+ */
+function calcAssetDepthScore(balanceData: any, investmentsData: any): number {
+  let totalAssets = 0;
+
+  // Sum all balance accounts
+  if (balanceData?.accounts) {
+    totalAssets += balanceData.accounts.reduce((sum: number, a: any) => {
+      const current = toNum(a.balances?.current || 0);
+      // For credit cards, available credit shows capacity (not debt)
+      if (a.type === 'credit') {
+        return sum + toNum(a.balances?.limit || 0);
+      }
+      return sum + Math.max(0, current);
+    }, 0);
+  }
+
+  // Add investment value
+  if (investmentsData?.holdings) {
+    totalAssets += investmentsData.holdings.reduce((sum: number, h: any) =>
+      sum + toNum(h.institution_value || 0), 0);
+  }
+
+  if (totalAssets <= 0) return 0;
+  if (totalAssets <= 5000) return 3;
+  if (totalAssets <= 25000) return 7;
+  if (totalAssets <= 100000) return 11;
+  if (totalAssets <= 250000) return 14;
+  if (totalAssets <= 500000) return 17;
+  return 20;
+}
+
+/**
+ * Diversification (0–15 pts)
+ * Based on variety of account types and number of institutions.
+ * 
+ * More types = more diversified portfolio.
+ */
+function calcDiversificationScore(balanceData: any, investmentsData: any): number {
+  const accountTypes = new Set<string>();
+  const institutions = new Set<string>();
+  let totalAccounts = 0;
+
+  if (balanceData?.accounts) {
+    balanceData.accounts.forEach((a: any) => {
+      if (a.subtype) accountTypes.add(a.subtype.toLowerCase());
+      if (a.type) accountTypes.add(a.type.toLowerCase());
+      if (a.institution_id) institutions.add(a.institution_id);
+      totalAccounts++;
+    });
+  }
+
+  if (investmentsData?.accounts) {
+    investmentsData.accounts.forEach((a: any) => {
+      if (a.subtype) accountTypes.add(a.subtype.toLowerCase());
+      if (a.type) accountTypes.add(a.type.toLowerCase());
+      totalAccounts++;
+    });
+  }
+
+  // Score based on variety
+  let score = 0;
+
+  // Account type diversity (0–8 pts)
+  score += clamp(accountTypes.size * 2, 0, 8);
+
+  // Multiple institutions (0–4 pts)
+  score += clamp(institutions.size * 2, 0, 4);
+
+  // Total account count bonus (0–3 pts)
+  if (totalAccounts >= 5) score += 3;
+  else if (totalAccounts >= 3) score += 2;
+  else if (totalAccounts >= 1) score += 1;
+
+  return clamp(score, 0, 15);
+}
+
+/**
+ * Identity Confidence (0–10 pts)
+ * Based on Plaid identity match verification scores.
+ */
+function calcIdentityScore(identityMatchData: any): number {
+  if (!identityMatchData) return 0;
+
+  // Identity match returns scores for name, email, phone, address
+  const scores: number[] = [];
+
+  if (identityMatchData.legal_name?.score !== undefined) {
+    scores.push(toNum(identityMatchData.legal_name.score));
+  }
+  if (identityMatchData.email_address?.score !== undefined) {
+    scores.push(toNum(identityMatchData.email_address.score));
+  }
+  if (identityMatchData.phone_number?.score !== undefined) {
+    scores.push(toNum(identityMatchData.phone_number.score));
+  }
+  if (identityMatchData.address?.score !== undefined) {
+    scores.push(toNum(identityMatchData.address.score));
+  }
+
+  if (scores.length === 0) return 3; // Some credit for having linked bank at all
+
+  // Average of match scores (Plaid returns 0–100 per field)
+  const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length;
+  return clamp(Math.round(avgScore / 10), 0, 10);
+}
+
+/**
+ * Account Health (0–10 pts)
+ * Ratio of available balance to current balance.
+ * Higher available = healthier financial position.
+ */
+function calcAccountHealthScore(balanceData: any): number {
+  if (!balanceData?.accounts) return 0;
+
+  const checkingSavings = balanceData.accounts.filter((a: any) =>
+    ['checking', 'savings'].includes(a.subtype?.toLowerCase())
+  );
+
+  if (checkingSavings.length === 0) return 0;
+
+  let totalCurrent = 0;
+  let totalAvailable = 0;
+
+  checkingSavings.forEach((a: any) => {
+    totalCurrent += toNum(a.balances?.current || 0);
+    totalAvailable += toNum(a.balances?.available || a.balances?.current || 0);
+  });
+
+  if (totalCurrent <= 0) return 2; // Accounts exist but empty
+
+  // Ratio: available/current — ideally >= 0.8
+  const ratio = totalAvailable / totalCurrent;
+
+  if (ratio >= 0.95) return 10;
+  if (ratio >= 0.85) return 8;
+  if (ratio >= 0.70) return 6;
+  if (ratio >= 0.50) return 4;
+  return 2;
+}
+
+// ── Main Calculator ──
+
+/**
+ * Calculate Network Worth Score from Plaid financial data.
+ * Returns score 0–100 with breakdown.
+ */
+export function calculateNWS(input: NWSInput): NWSResult {
+  const { balanceData, investmentsData, identityMatchData } = input;
+
+  const breakdown: NWSBreakdown = {
+    liquidity: calcLiquidityScore(balanceData),
+    investments: calcInvestmentScore(investmentsData),
+    assetDepth: calcAssetDepthScore(balanceData, investmentsData),
+    diversification: calcDiversificationScore(balanceData, investmentsData),
+    identityConfidence: calcIdentityScore(identityMatchData),
+    accountHealth: calcAccountHealthScore(balanceData),
+  };
+
+  const score = clamp(
+    breakdown.liquidity +
+    breakdown.investments +
+    breakdown.assetDepth +
+    breakdown.diversification +
+    breakdown.identityConfidence +
+    breakdown.accountHealth,
+    0,
+    100
+  );
+
+  return {
+    score,
+    breakdown,
+    grade: getGrade(score),
+    label: getLabel(score),
+  };
+}
+
+/**
+ * Calculate NWS from raw Supabase user_financial_data row.
+ * Convenience wrapper that extracts the right fields.
+ */
+export function calculateNWSFromDB(financialRow: any): NWSResult {
+  if (!financialRow) {
+    return {
+      score: 0,
+      breakdown: { liquidity: 0, investments: 0, assetDepth: 0, diversification: 0, identityConfidence: 0, accountHealth: 0 },
+      grade: 'F',
+      label: 'No Financial Data',
+    };
+  }
+
+  return calculateNWS({
+    balanceData: financialRow.balance_data || null,
+    investmentsData: financialRow.investments_data || null,
+    identityMatchData: financialRow.identity_match_data || null,
+  });
+}

--- a/supabase/migrations/20260223100000_add_nws_score_column.sql
+++ b/supabase/migrations/20260223100000_add_nws_score_column.sql
@@ -1,0 +1,9 @@
+-- Add Network Worth Score (NWS) column to user_financial_data
+-- Computed from Plaid balance, investments, and identity match data
+-- Score range: 0-100
+
+ALTER TABLE user_financial_data
+ADD COLUMN IF NOT EXISTS nws_score INTEGER DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS nws_breakdown JSONB DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS nws_grade TEXT DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS nws_calculated_at TIMESTAMPTZ DEFAULT NULL;


### PR DESCRIPTION
**Problem:** Steps 5, 8, 11, 13 were not scrollable while Step 1 worked fine.

**Root Cause:** Step 1 had `pb-52` on the root container div, ensuring content always overflows the viewport and enables page scroll. Steps 5/8/11/13 only had `pb-48` on the inner `<main>` element. Step 5 also had `flex flex-col` on the root which trapped content height in the flex layout.

**Fix:**
- Added `pb-52` to root container div of Steps 5, 8, 11, 13 (matching Step 1 pattern)
- Removed `flex flex-col` from Step 5 root div to prevent flex height trapping