### PR TITLE
fix: hide stock ticker on onboarding pages for cleaner UX

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -65,6 +65,9 @@ export default function Navbar() {
   const isMobile = useBreakpointValue({ base: true, lg: false });
   const isDesktop = isMobile === false;
 
+  // Hide ticker strip on onboarding pages to keep UX clean
+  const isOnboarding = location.pathname.startsWith('/onboarding');
+
   // Fetch real-time stock quotes (refreshes every 2 minutes for 27 stocks)
   const { quotes, loading: quotesLoading, lastUpdated } = useStockQuotes(120000);
 
@@ -314,7 +317,8 @@ export default function Navbar() {
           </div>
         </nav>
 
-        {/* Chip-based Ticker Strip - BELOW Navigation */}
+        {/* Chip-based Ticker Strip - BELOW Navigation (hidden on onboarding pages) */}
+        {!isOnboarding && (
         <section className="relative w-full bg-[#F8F9FA] py-2.5 border-b border-gray-200">
           {/* Ticker Marquee with Fade Mask */}
           <div className="ticker-mask relative flex w-full overflow-hidden">
@@ -348,10 +352,11 @@ export default function Navbar() {
             </div>
           )}
         </section>
+        )}
       </header>
 
-      {/* Spacer for fixed header (ticker ~48px + nav ~64px = 112px) */}
-      <div className="h-28" />
+      {/* Spacer for fixed header — shorter on onboarding (no ticker) */}
+      <div className={isOnboarding ? "h-16" : "h-28"} />
 
       {/* iOS Native Side Menu */}
       {isOpen && (


### PR DESCRIPTION
## Problem
The moving stock ticker strip at the top was showing on onboarding pages, cluttering the UI and hurting UX on mobile.

## Fix
- Added isOnboarding route check in Navbar.tsx
- Wrapped ticker section in conditional rendering
- Adjusted spacer height when ticker is hidden (h-16 vs h-28)
- Zero impact on other pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The ticker strip is now hidden on onboarding pages to provide a cleaner user experience during account setup.
  * Header spacing has been adjusted accordingly when the ticker is hidden on onboarding screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->