### PR TITLE
fix: Step 8 city/state not populating after GPS detection

### DIFF
--- a/src/hooks/useLocationDropdowns.ts
+++ b/src/hooks/useLocationDropdowns.ts
@@ -55,6 +55,11 @@ export function useLocationDropdowns(
   const [statesError, setStatesError] = useState(false);
   const [citiesError, setCitiesError] = useState(false);
 
+  // Bumped each time applyDetectedLocation is called so that the
+  // pending-resolution effects re-run even when the dropdown arrays
+  // haven't changed (fixes: same country → state/city not populating).
+  const [detectionVersion, setDetectionVersion] = useState(0);
+
   // Pending refs — store GPS values until dropdown options arrive
   const pendingState = useRef<string | null>(null);
   const pendingCity = useRef<string | null>(null);
@@ -122,7 +127,7 @@ export function useLocationDropdowns(
     return () => { cancelled = true; };
   }, [country, state, states]);
 
-  // Apply pending state when states list loads
+  // Apply pending state when states list loads OR detection version bumps
   useEffect(() => {
     if (states.length === 0 || !pendingState.current) return;
 
@@ -133,9 +138,9 @@ export function useLocationDropdowns(
 
     if (match) setStateRaw(match.isoCode);
     pendingState.current = null;
-  }, [states]);
+  }, [states, detectionVersion]);
 
-  // Apply pending city when cities list loads
+  // Apply pending city when cities list loads OR detection version bumps
   useEffect(() => {
     if (cities.length === 0 || !pendingCity.current) return;
 
@@ -146,7 +151,7 @@ export function useLocationDropdowns(
 
     if (match) setCityRaw(match.name);
     pendingCity.current = null;
-  }, [cities]);
+  }, [cities, detectionVersion]);
 
   // Apply GPS/detected location — queues values for when dropdowns load
   const applyDetectedLocation = useCallback((
@@ -155,10 +160,14 @@ export function useLocationDropdowns(
     stateName?: string,
     cityName?: string
   ) => {
-    if (countryCode) setCountryRaw(countryCode);
     if (stateCode) pendingState.current = stateCode;
     else if (stateName) pendingState.current = stateName;
     if (cityName) pendingCity.current = cityName;
+    if (countryCode) setCountryRaw(countryCode);
+
+    // Bump version so pending-resolution effects re-evaluate
+    // even when states/cities arrays haven't changed.
+    setDetectionVersion(v => v + 1);
   }, []);
 
   // Retry functions — re-trigger the useEffect by toggling country/state


### PR DESCRIPTION
## 🐛 Production Bug Fix

**Reported by:** Multiple users complaining that city and state fields remain blank after GPS location detection on Step 8.

### Root Cause
Race condition in `useLocationDropdowns.ts` — when the same country was already set (e.g. 'US' from init → 'US' from GPS), `setCountryRaw(sameValue)` didn't trigger a React re-render, so the pending state/city resolution effects never re-ran. City and state stayed blank.

### Fix
Added a `detectionVersion` counter that bumps on every `applyDetectedLocation()` call, forcing the pending-resolution effects to re-evaluate even when the states/cities dropdown arrays haven't changed.

### Files Changed (1)
- `src/hooks/useLocationDropdowns.ts` — 14 insertions, 5 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved location detection behavior to ensure state and city dropdown selections update reliably when applying detected locations. Enhanced the pending location resolution mechanism to guarantee dropdowns refresh appropriately, even when dropdown option arrays haven't changed since the last detection event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->