### PR TITLE
fix: prevent stale chunk 404s on SPA routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,12 @@
       ]
     },
     {
+      "source": "/onboarding/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
Adds no-cache headers for /onboarding/* routes to prevent browsers from serving cached old index.html after deployments.