### PR TITLE
fix: add no-cache headers for SPA routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,24 @@
       ]
     },
     {
+      "source": "/hushh-user-profile",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/login",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/signup",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
       "source": "/assets/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
Prevents 404 on stale JS bundles by adding no-cache headers for /hushh-user-profile, /login, /signup routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized caching behavior for user profile, login, and signup pages to ensure users receive the latest content on these sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->