### PR TITLE
fix: hamburger button black instead of indigo

### DIFF
--- a/src/components/hushh-tech-header/HushhTechHeader.tsx
+++ b/src/components/hushh-tech-header/HushhTechHeader.tsx
@@ -51,7 +51,7 @@ const HushhTechHeader: React.FC<HushhTechHeaderProps> = ({
         {/* Hamburger menu button */}
         <button
           onClick={() => setIsDrawerOpen(true)}
-          className="w-10 h-10 rounded-full bg-indigo-500 flex items-center justify-center hover:bg-indigo-600 transition-colors"
+          className="w-10 h-10 rounded-full bg-black flex items-center justify-center hover:bg-black/80 transition-colors"
           aria-label="Open menu"
           tabIndex={0}
         >


### PR DESCRIPTION
Changed HushhTechHeader hamburger from bg-indigo-500 to bg-black. Matches step 1-8 black design language.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated hamburger button styling with a new color scheme, changing from indigo to black tones for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->