### PR TITLE
feat: Fund A page revamp — step 1-8 design language

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -103,9 +103,10 @@ const ContentWrapper = ({ children }: { children: ReactNode }) => {
   const isHushhUserProfile = location.pathname.startsWith('/hushh-user-profile');
   const isSignNda = location.pathname.startsWith('/sign-nda');
   const isInvestorProfile = location.pathname.startsWith('/investor-profile');
+  const isDiscoverFundA = location.pathname === '/discover-fund-a';
 
   return (
-    <div className={`${isHomePage || isAuthCallback || isUserRegistration || isOnboarding || isKycFlow || isA2APlayground || isInvestorGuide || isHushhAI || isHushhAgent || isKai || isStudio || isHushhUserProfile || isSignNda || isInvestorProfile ? '' : 'mt-20'}`}>
+    <div className={`${isHomePage || isAuthCallback || isUserRegistration || isOnboarding || isKycFlow || isA2APlayground || isInvestorGuide || isHushhAI || isHushhAgent || isKai || isStudio || isHushhUserProfile || isSignNda || isInvestorProfile || isDiscoverFundA ? '' : 'mt-20'}`}>
       {children}
     </div>
   );
@@ -121,12 +122,13 @@ const useLayoutVisibility = () => {
   const isStudio = location.pathname.startsWith('/studio');
   const isOnboarding = location.pathname.startsWith('/onboarding');
   const isProfile = location.pathname === '/profile';
+  const isFundA = location.pathname === '/discover-fund-a';
 
-  // Home + Onboarding + Profile use HushhTechHeader/Footer — hide old global nav/footer
+  // Home + Onboarding + Profile + Fund A use HushhTechHeader/Footer — hide old global nav/footer
   return {
-    showNavbar: !isHushhAI && !isHushhAgent && !isKai && !isStudio && !isHomePage && !isOnboarding && !isProfile,
-    showFooter: !isHushhAI && !isHushhAgent && !isKai && !isStudio && !isOnboarding && !isHomePage && !isProfile,
-    showMobileNav: !isHushhAI && !isHushhAgent && !isKai && !isStudio && !isOnboarding && !isHomePage && !isProfile,
+    showNavbar: !isHushhAI && !isHushhAgent && !isKai && !isStudio && !isHomePage && !isOnboarding && !isProfile && !isFundA,
+    showFooter: !isHushhAI && !isHushhAgent && !isKai && !isStudio && !isOnboarding && !isHomePage && !isProfile && !isFundA,
+    showMobileNav: !isHushhAI && !isHushhAgent && !isKai && !isStudio && !isOnboarding && !isHomePage && !isProfile && !isFundA,
   };
 };
 

--- a/src/pages/discover-fund-a/ui.tsx
+++ b/src/pages/discover-fund-a/ui.tsx
@@ -1,21 +1,40 @@
-import React from 'react'
-import {
-  Box,
-  Container,
-  Heading,
-  Text,
-  Flex,
-  SimpleGrid,
-  Grid,
-  GridItem,
-  Table,
-  Tbody,
-  Tr,
-  Td,
-  VStack,
-  Button,
-} from '@chakra-ui/react'
-import { useDiscoverFundALogic } from './logic'
+/**
+ * Fund A — Discover Page (Revamped 2.0)
+ * Matches onboarding step 1-8 design language.
+ * Uses HushhTechBackHeader + HushhTechCta reusable components.
+ * All content pulled from logic.ts — zero data here.
+ */
+import React from "react";
+import { useDiscoverFundALogic } from "./logic";
+import HushhTechBackHeader from "../../components/hushh-tech-back-header/HushhTechBackHeader";
+import HushhTechCta, {
+  HushhTechCtaVariant,
+} from "../../components/hushh-tech-cta/HushhTechCta";
+
+/* ── tiny reusable card ── */
+const InfoCard = ({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) => (
+  <div className="bg-gray-50 border border-gray-100 rounded-xl p-6 transition-all hover:shadow-sm">
+    <h3 className="text-sm font-semibold text-black lowercase tracking-wide mb-2">
+      {title}
+    </h3>
+    <p className="text-xs text-gray-500 font-light leading-relaxed lowercase">
+      {description}
+    </p>
+  </div>
+);
+
+/* ── section label ── */
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-4 mt-8 font-medium">
+    {children}
+  </p>
+);
 
 const FundA = () => {
   const {
@@ -47,615 +66,273 @@ const FundA = () => {
     joinSectionDescription,
     joinButtonLabel,
     handleCompleteProfile,
-  } = useDiscoverFundALogic()
+  } = useDiscoverFundALogic();
 
   return (
-    <Box bg="white">
-      {/* Hero Section */}
-      <Box pt={{ base: 16, md: 8 }} px={4} textAlign="center">
-        <Container maxW="container.lg" mt={{ md: 16, base: 8 }}>
-          <Heading
-            as="h1"
-            fontSize={{ base: '3xl', md: '6xl' }}
-            fontWeight="400"
-            mb={{ md: 2, base: 1 }}
-            lineHeight="1.2"
-            color="#1D1D1F"
+    <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-black selection:text-white">
+      {/* ═══ Header — back + hamburger ═══ */}
+      <HushhTechBackHeader
+        onBackClick={() => window.history.back()}
+        rightType="hamburger"
+      />
+
+      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-24">
+        {/* ── Hero ── */}
+        <section className="py-8">
+          <div className="inline-block px-3 py-1 mb-4 border border-gray-200 rounded-full">
+            <span className="text-[10px] tracking-widest uppercase font-medium text-gray-500 flex items-center gap-1">
+              <span className="w-1.5 h-1.5 bg-black rounded-full" />
+              investment opportunity
+            </span>
+          </div>
+
+          <h1
+            className="text-[2rem] leading-[1.15] font-medium text-black tracking-tight lowercase"
+            style={{ fontFamily: "'Playfair Display', serif" }}
           >
             {heroTitle}
-          </Heading>
+          </h1>
 
-          <Heading
-            as="h2"
-            fontSize={{ base: '4xl', md: '7xl' }}
-            fontWeight="500"
-            mb={{ md: 10, base: 6 }}
-            lineHeight="1.1"
-            bgGradient="linear(to-r, #00A9E0, #4BC0C8)"
-            bgClip="text"
+          <h2
+            className="text-[2.25rem] leading-[1.1] font-medium tracking-tight lowercase mt-1"
+            style={{ fontFamily: "'Playfair Display', serif", color: "#1a1a1a" }}
           >
             {heroSubtitle}
-          </Heading>
+          </h2>
 
-          <Text
-            fontSize={{ base: 'lg', md: '2xl' }}
-            color="#6E6E73"
-            maxW="4xl"
-            mx="auto"
-            mb={16}
-            fontWeight="light"
-            lineHeight="tall"
-          >
+          <p className="text-gray-500 text-sm font-light mt-4 leading-relaxed lowercase">
             {heroDescription}
-          </Text>
+          </p>
+        </section>
 
-          {/* Stats Card */}
-          <Box
-            maxW="md"
-            mx="auto"
-            bgGradient="linear(to-r, #00A9E0, #4BC0C8)"
-            borderRadius="xl"
-            p={8}
-            color="white"
-            mb={16}
-          >
-            <Text fontSize="xl" fontWeight="500" mb={4}>
+        {/* ── Target IRR Card ── */}
+        <section className="mb-10">
+          <div className="bg-black rounded-2xl p-6 text-white text-center">
+            <p className="text-xs uppercase tracking-widest text-gray-400 mb-2 font-medium">
               {targetIRRLabel}
-            </Text>
-
-            <Heading as="h3" fontSize="7xl" fontWeight="500" mb={2}>
+            </p>
+            <p
+              className="text-5xl font-medium mb-1"
+              style={{ fontFamily: "'Playfair Display', serif" }}
+            >
               {targetIRRValue}
-            </Heading>
-
-            <Text fontSize="lg" mb={4}>
+            </p>
+            <p className="text-sm text-gray-300 lowercase mb-3">
               {targetIRRPeriod}
-            </Text>
-
-            <Text fontSize="xs" fontStyle="italic" maxW="xs" mx="auto">
+            </p>
+            <p className="text-[10px] text-gray-500 italic max-w-[240px] mx-auto">
               {targetIRRDisclaimer}
-            </Text>
-          </Box>
-        </Container>
-      </Box>
+            </p>
+          </div>
+        </section>
 
-      {/* Investment Philosophy Section */}
-      <Box
-        py={{ base: 12, md: 16 }}
-        px={0}
-        background="rgb(249 250 251 / var(--tw-bg-opacity, 1))"
-      >
-        <Container maxW="container.lg">
-          <Heading
-            as="h2"
-            fontSize={{ base: '2xl', md: '5xl' }}
-            fontWeight="300"
-            mb={{ md: 16, base: 10 }}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
-          >
-            {philosophySectionTitle}
-          </Heading>
-
-          <SimpleGrid columns={{ base: 1, md: 1 }} spacing={6} maxW="container.lg" mx="auto">
+        {/* ── Investment Philosophy ── */}
+        <section className="mb-10">
+          <SectionLabel>{philosophySectionTitle}</SectionLabel>
+          <div className="space-y-3">
             {philosophyCards.map((card) => (
-              <Box
+              <InfoCard
                 key={card.title}
-                bg="white"
-                p={8}
-                borderRadius="xl"
-                border="1px"
-                borderColor="gray.100"
-                transition="all 0.3s"
-                _hover={{ boxShadow: 'sm' }}
-              >
-                <Flex alignItems="flex-start" gap={6}>
-                  <Box flex="1">
-                    <Heading
-                      as="h3"
-                      fontSize={{ base: 'xl', md: '2xl' }}
-                      fontWeight="500"
-                      color="#1D1D1F"
-                      mb={4}
-                    >
-                      {card.title}
-                    </Heading>
-                    <Text
-                      color="#6E6E73"
-                      fontWeight="light"
-                      lineHeight="tall"
-                      fontSize={{ base: 'md', md: 'lg' }}
-                    >
-                      {card.description}
-                    </Text>
-                  </Box>
-                </Flex>
-              </Box>
+                title={card.title}
+                description={card.description}
+              />
             ))}
-          </SimpleGrid>
-        </Container>
-      </Box>
+          </div>
+        </section>
 
-      {/* Sell the Wall Options Framework Section */}
-      <Box py={{ base: 12, md: 20 }} px={0} bg="white">
-        <Container maxW="container.lg">
-          <Heading
-            as="h2"
-            fontSize={{ base: '2xl', md: '5xl' }}
-            fontWeight="300"
-            mb={{ md: 16, base: 10 }}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
-          >
-            {edgeSectionTitle}{' '}
-            <Text
-              as="a"
+        {/* ── Sell the Wall Framework ── */}
+        <section className="mb-10">
+          <SectionLabel>
+            {edgeSectionTitle}{" "}
+            <a
               href={sellTheWallHref}
               target="_blank"
               rel="noopener noreferrer"
-              display="inline"
-              color="#00A9E0"
-              textDecoration="underline"
-              cursor="pointer"
-              transition="all 0.2s"
-              _hover={{
-                color: '#4BC0C8',
-                textDecoration: 'none',
-              }}
+              className="text-black underline hover:no-underline"
             >
-              "Sell the Wall"
-            </Text>{' '}
-            Options Framework
-          </Heading>
-
-          <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }} gap={8}>
+              "sell the wall"
+            </a>{" "}
+            options framework
+          </SectionLabel>
+          <div className="space-y-3">
             {edgeCards.map((card) => (
-              <GridItem key={card.title}>
-                <Box
-                  bg="white"
-                  p={8}
-                  borderRadius="xl"
-                  border="1px"
-                  borderColor="gray.100"
-                  h="full"
-                  transition="all 0.3s"
-                  _hover={{ boxShadow: 'sm' }}
-                >
-                  <Heading
-                    as="h3"
-                    fontSize={{ base: 'xl', md: '2xl' }}
-                    fontWeight="500"
-                    color="#1D1D1F"
-                    mb={4}
-                  >
-                    {card.title}
-                  </Heading>
-                  <Text
-                    color="#6E6E73"
-                    fontWeight="light"
-                    lineHeight="tall"
-                    fontSize={{ base: 'md', md: 'lg' }}
-                  >
-                    {card.description}
-                  </Text>
-                </Box>
-              </GridItem>
+              <InfoCard
+                key={card.title}
+                title={card.title}
+                description={card.description}
+              />
             ))}
-          </Grid>
-        </Container>
-      </Box>
+          </div>
+        </section>
 
-      {/* Asset Focus Section */}
-      <Box
-        py={{ base: 12, md: 20 }}
-        px={0}
-        bg="rgb(249 250 251 / var(--tw-bg-opacity, 1))"
-      >
-        <Container maxW="container.xl">
-          <Heading
-            as="h2"
-            fontSize={{ base: '2xl', md: '5xl' }}
-            fontWeight="300"
-            mb={6}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
-          >
-            {assetFocusSectionTitle}
-          </Heading>
-
-          <Text
-            fontSize={{ base: 'md', md: 'xl' }}
-            color="#6E6E73"
-            fontWeight="light"
-            lineHeight="tall"
-            textAlign="center"
-            maxW="4xl"
-            mx="auto"
-            mb={16}
-          >
+        {/* ── Asset Focus ── */}
+        <section className="mb-10">
+          <SectionLabel>{assetFocusSectionTitle}</SectionLabel>
+          <p className="text-xs text-gray-500 font-light leading-relaxed lowercase mb-4">
             {assetFocusDescription}
-          </Text>
-
-          <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={8}>
+          </p>
+          <div className="space-y-3">
             {assetPillars.map((pillar) => (
-              <GridItem key={pillar.title}>
-                <Box
-                  bg="white"
-                  p={8}
-                  borderRadius="xl"
-                  border="1px"
-                  borderColor="gray.100"
-                  h="full"
-                  transition="all 0.3s"
-                  _hover={{ boxShadow: 'sm' }}
-                >
-                  <Heading
-                    as="h3"
-                    fontSize={{ base: 'xl', md: '2xl' }}
-                    fontWeight="500"
-                    color="#1D1D1F"
-                    mb={4}
-                    textAlign="center"
-                  >
-                    {pillar.title}
-                  </Heading>
-                  <Text
-                    color="#6E6E73"
-                    fontWeight="light"
-                    lineHeight="tall"
-                    fontSize={{ base: 'md', md: 'lg' }}
-                    textAlign="center"
-                  >
-                    {pillar.description}
-                  </Text>
-                </Box>
-              </GridItem>
+              <InfoCard
+                key={pillar.title}
+                title={pillar.title}
+                description={pillar.description}
+              />
             ))}
-          </Grid>
-        </Container>
-      </Box>
+          </div>
+        </section>
 
-      {/* Targeted Alpha Stack Section */}
-      <Box py={{ base: 12, md: 20 }} px={0} bg="white">
-        <Container maxW="container.xl">
-          <Heading
-            as="h2"
-            fontSize={{ base: '2xl', md: '5xl' }}
-            fontWeight="300"
-            mb={2}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
-          >
-            {alphaStackSectionTitle}
-          </Heading>
-
-          <Text
-            fontSize={{ base: 'sm', md: 'md' }}
-            color="#6E6E73"
-            fontWeight="light"
-            fontStyle="italic"
-            textAlign="center"
-            mb={16}
-          >
+        {/* ── Targeted Alpha Stack ── */}
+        <section className="mb-10">
+          <SectionLabel>{alphaStackSectionTitle}</SectionLabel>
+          <p className="text-[10px] text-gray-400 italic lowercase mb-4">
             {alphaStackSubtitle}
-          </Text>
+          </p>
 
-          <Box
-            maxW="4xl"
-            mx="auto"
-            p={{ base: 0, md: 8 }}
-            borderRadius="xl"
-            border="1px"
-            borderColor="gray.100"
-          >
-            <Table variant="simple">
-              <Tbody>
-                {alphaStackRows.map((row, index) => (
-                  <Tr
-                    key={row.label}
-                    borderBottom={
-                      index < alphaStackRows.length - 1 ? '1px solid' : undefined
-                    }
-                    borderColor="gray.100"
-                  >
-                    <Td
-                      fontSize={
-                        row.isTotalRow
-                          ? { base: 'xl', md: '2xl' }
-                          : { base: 'md', md: 'lg' }
-                      }
-                      fontWeight="500"
-                      color="#1D1D1F"
-                      py={6}
-                    >
-                      {row.label}
-                    </Td>
-                    <Td
-                      fontSize={
-                        row.isTotalRow
-                          ? { base: 'xl', md: '2xl' }
-                          : { base: 'md', md: 'lg' }
-                      }
-                      fontWeight="500"
-                      color="#00A9E0"
-                      textAlign="right"
-                      py={6}
-                      whiteSpace="nowrap"
-                    >
-                      {row.value}
-                    </Td>
-                  </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </Box>
-        </Container>
-      </Box>
-
-      {/* Risk Management Section */}
-      <Box
-        py={{ base: 12, md: 20 }}
-        px={0}
-        bg="rgb(249 250 251 / var(--tw-bg-opacity, 1))"
-      >
-        <Container maxW="container.xl">
-          <Heading
-            as="h2"
-            fontSize={{ base: '2xl', md: '5xl' }}
-            fontWeight="300"
-            mb={16}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
-          >
-            {riskSectionTitle}
-          </Heading>
-
-          <Grid
-            mx="2em"
-            templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }}
-            gap={8}
-          >
-            {riskCards.map((card) => (
-              <GridItem key={card.title}>
-                <Box
-                  bg="white"
-                  p={8}
-                  borderRadius="xl"
-                  border="1px"
-                  borderColor="gray.100"
-                  h="full"
-                  transition="all 0.3s"
-                  _hover={{ boxShadow: 'sm' }}
+          <div className="border border-gray-200 rounded-xl overflow-hidden">
+            {alphaStackRows.map((row, index) => (
+              <div
+                key={row.label}
+                className={`flex justify-between items-center px-5 py-4 ${
+                  index < alphaStackRows.length - 1
+                    ? "border-b border-gray-100"
+                    : ""
+                } ${row.isTotalRow ? "bg-black text-white" : ""}`}
+              >
+                <span
+                  className={`text-sm font-medium lowercase ${
+                    row.isTotalRow ? "text-white" : "text-gray-900"
+                  }`}
                 >
-                  <Heading
-                    as="h3"
-                    fontSize={{ base: 'xl', md: '2xl' }}
-                    fontWeight="500"
-                    color="#1D1D1F"
-                    mb={4}
-                  >
-                    {card.title}
-                  </Heading>
-                  <Text
-                    color="#6E6E73"
-                    fontWeight="light"
-                    lineHeight="tall"
-                    fontSize={{ base: 'md', md: 'lg' }}
-                  >
-                    {card.description}
-                  </Text>
-                </Box>
-              </GridItem>
+                  {row.label}
+                </span>
+                <span
+                  className={`text-sm font-semibold ${
+                    row.isTotalRow ? "text-white" : "text-black"
+                  }`}
+                >
+                  {row.value}
+                </span>
+              </div>
             ))}
-          </Grid>
-        </Container>
-      </Box>
+          </div>
+        </section>
 
-      {/* Key Terms Section */}
-      <Box py={{ base: 12, md: 20 }} px={0} bg="white">
-        <Container maxW="container.xl">
-          <Heading
-            as="h2"
-            fontSize={{ base: '2xl', md: '5xl' }}
-            fontWeight="300"
-            mb={2}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
-          >
-            {keyTermsSectionTitle}
-          </Heading>
+        {/* ── Risk Management ── */}
+        <section className="mb-10">
+          <SectionLabel>{riskSectionTitle}</SectionLabel>
+          <div className="space-y-3">
+            {riskCards.map((card) => (
+              <InfoCard
+                key={card.title}
+                title={card.title}
+                description={card.description}
+              />
+            ))}
+          </div>
+        </section>
 
-          <Text
-            fontSize={{ base: 'sm', md: 'md' }}
-            color="#6E6E73"
-            fontWeight="light"
-            fontStyle="italic"
-            textAlign="center"
-            mb={16}
-          >
+        {/* ── Key Terms ── */}
+        <section className="mb-10">
+          <SectionLabel>{keyTermsSectionTitle}</SectionLabel>
+          <p className="text-[10px] text-gray-400 italic lowercase mb-4">
             {keyTermsSubtitle}
-          </Text>
+          </p>
 
-          <Box
-            maxW="4xl"
-            mx="auto"
-            p={{ base: 4, md: 8 }}
-            borderRadius="xl"
-            border="1px"
-            borderColor="gray.100"
-          >
-            <VStack spacing={8} align="stretch">
-              {keyTerms.slice(0, 2).map((term) => (
-                <Box key={term.title}>
-                  <Heading
-                    as="h3"
-                    fontSize={{ base: 'lg', md: 'xl' }}
-                    fontWeight="500"
-                    color="#1D1D1F"
-                    mb={2}
-                  >
-                    {term.title}
-                  </Heading>
-                  <Text
-                    color="#6E6E73"
-                    fontWeight="light"
-                    fontSize={{ base: 'md', md: 'lg' }}
-                  >
-                    {term.content}
-                  </Text>
-                </Box>
-              ))}
+          <div className="space-y-4">
+            {keyTerms.slice(0, 2).map((term) => (
+              <div key={term.title} className="py-2">
+                <h3 className="text-sm font-semibold text-black lowercase mb-1">
+                  {term.title}
+                </h3>
+                <p className="text-xs text-gray-500 font-light leading-relaxed lowercase">
+                  {term.content}
+                </p>
+              </div>
+            ))}
+          </div>
 
-              {/* Share Classes Table */}
-              <Box>
-                <Heading
-                  as="h3"
-                  fontSize={{ base: 'lg', md: 'xl' }}
-                  fontWeight="500"
-                  color="#1D1D1F"
-                  mb={4}
-                >
-                  Share Classes (Min. Investment / Fees - Mgmt/Perf./Hurdle)
-                </Heading>
+          {/* Share Classes Table */}
+          <div className="mt-6 border border-gray-200 rounded-xl overflow-hidden">
+            <div className="bg-black text-white px-4 py-3">
+              <p className="text-[10px] uppercase tracking-widest font-medium text-gray-400">
+                share classes
+              </p>
+            </div>
+            {shareClasses.map((sc, index) => (
+              <div
+                key={sc.shareClass}
+                className={`px-4 py-3 ${
+                  index < shareClasses.length - 1
+                    ? "border-b border-gray-100"
+                    : ""
+                }`}
+              >
+                <div className="flex justify-between items-center mb-1">
+                  <span className="text-sm font-semibold text-black lowercase">
+                    {sc.shareClass}
+                  </span>
+                  <span className="text-xs text-gray-500 font-medium">
+                    min {sc.minInvestment}
+                  </span>
+                </div>
+                <div className="flex gap-4 text-[10px] text-gray-400">
+                  <span>mgmt: {sc.managementFee}</span>
+                  <span>perf: {sc.performanceFee}</span>
+                  <span>hurdle: {sc.hurdleRate}</span>
+                </div>
+              </div>
+            ))}
+          </div>
 
-                <Box
-                  borderWidth="1px"
-                  borderColor="gray.200"
-                  borderRadius="md"
-                  overflow="hidden"
-                  bg="#111"
-                >
-                  <Table variant="unstyled" size="md">
-                    <thead>
-                      <Tr borderBottomWidth="1px" borderColor="gray.700">
-                        <Td fontWeight="500" color="white" py={4}>
-                          Share Class
-                        </Td>
-                        <Td fontWeight="500" color="white" py={4}>
-                          Min. Investment
-                        </Td>
-                        <Td fontWeight="500" color="white" py={4}>
-                          Management Fee
-                        </Td>
-                        <Td fontWeight="500" color="white" py={4}>
-                          Performance Fee
-                        </Td>
-                        <Td fontWeight="500" color="white" py={4}>
-                          Hurdle Rate
-                        </Td>
-                      </Tr>
-                    </thead>
-                    <Tbody>
-                      {shareClasses.map((sc, index) => (
-                        <Tr
-                          key={sc.shareClass}
-                          borderBottomWidth={
-                            index < shareClasses.length - 1 ? '1px' : undefined
-                          }
-                          borderColor="gray.700"
-                        >
-                          <Td color="white" py={4}>
-                            {sc.shareClass}
-                          </Td>
-                          <Td color="white" py={4}>
-                            {sc.minInvestment}
-                          </Td>
-                          <Td color="white" py={4}>
-                            {sc.managementFee}
-                          </Td>
-                          <Td color="white" py={4}>
-                            {sc.performanceFee}
-                          </Td>
-                          <Td color="white" py={4}>
-                            {sc.hurdleRate}
-                          </Td>
-                        </Tr>
-                      ))}
-                    </Tbody>
-                  </Table>
-                </Box>
-              </Box>
+          {/* Remaining terms */}
+          <div className="space-y-4 mt-6">
+            {keyTerms.slice(2).map((term) => (
+              <div key={term.title} className="py-2">
+                <h3 className="text-sm font-semibold text-black lowercase mb-1">
+                  {term.title}
+                </h3>
+                <p className="text-xs text-gray-500 font-light leading-relaxed lowercase">
+                  {term.content}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-              {keyTerms.slice(2).map((term) => (
-                <Box key={term.title}>
-                  <Heading
-                    as="h3"
-                    fontSize={{ base: 'lg', md: 'xl' }}
-                    fontWeight="500"
-                    color="#1D1D1F"
-                    mb={2}
-                  >
-                    {term.title}
-                  </Heading>
-                  <Text
-                    color="#6E6E73"
-                    fontWeight="light"
-                    fontSize={{ base: 'md', md: 'lg' }}
-                  >
-                    {term.content}
-                  </Text>
-                </Box>
-              ))}
-            </VStack>
-          </Box>
-        </Container>
-      </Box>
-
-      {/* Join Us Section */}
-      <Box py={{ base: 16, md: 24 }} px={0} bg="gray.50">
-        <Container maxW="container.xl">
-          <Heading
-            as="h2"
-            fontSize={{ base: '3xl', md: '5xl' }}
-            fontWeight="400"
-            mb={6}
-            lineHeight="1.2"
-            textAlign="center"
-            color="#1D1D1F"
+        {/* ── Join / CTA ── */}
+        <section className="mb-12 border-t border-gray-200 pt-8">
+          <h2
+            className="text-2xl font-medium text-black tracking-tight lowercase mb-3"
+            style={{ fontFamily: "'Playfair Display', serif" }}
           >
             {joinSectionTitle}
-          </Heading>
-
-          <Text
-            fontSize={{ base: 'lg', md: '2xl' }}
-            color="#6E6E73"
-            fontWeight="light"
-            lineHeight="tall"
-            textAlign="center"
-            maxW="4xl"
-            mx="auto"
-            mb={12}
-            whiteSpace="pre-line"
-          >
+          </h2>
+          <p className="text-sm text-gray-500 font-light leading-relaxed lowercase mb-8">
             {joinSectionDescription}
-          </Text>
+          </p>
 
-          <Flex justify="center" mb={8}>
-            <Button
-              size="lg"
-              px={12}
-              py={7}
-              borderRadius="full"
-              background="linear-gradient(to right, #00A9E0, #4BC0C8)"
-              color="white"
-              _hover={{
-                background: 'linear-gradient(to right, #00A9E0, #4BC0C8)',
-              }}
-              fontWeight="500"
+          <div className="space-y-3">
+            <HushhTechCta
+              variant={HushhTechCtaVariant.BLACK}
               onClick={handleCompleteProfile}
             >
               {joinButtonLabel}
-            </Button>
-          </Flex>
-        </Container>
-      </Box>
-    </Box>
-  )
-}
+              <span className="material-symbols-outlined text-lg">
+                arrow_forward
+              </span>
+            </HushhTechCta>
+            <HushhTechCta
+              variant={HushhTechCtaVariant.WHITE}
+              onClick={() => window.history.back()}
+            >
+              go back
+            </HushhTechCta>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
 
-export default FundA
+export default FundA;


### PR DESCRIPTION
- Complete rewrite of discover-fund-a/ui.tsx from Chakra UI → Tailwind CSS
- Matches step 1-8 design: HushhTechBackHeader (back+hamburger), Playfair Display headings, black CTA, lowercase, minimal
- Black IRR card, InfoCard components, alpha stack table, share classes table
- Hidden global Navbar/Footer on /discover-fund-a
- Removed top margin in ContentWrapper
- Build verified ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new Discover Fund A page accessible via dedicated route
  * Integrated Fund A page into app navigation with consistent header and footer display
  * Redesigned Fund A page with new visual layout and component structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->