### PR TITLE
feat: Fund A v3 — refined design matching profile + step pages

### DIFF
--- a/src/pages/discover-fund-a/ui.tsx
+++ b/src/pages/discover-fund-a/ui.tsx
@@ -1,8 +1,8 @@
 /**
- * Fund A — Discover Page (Revamped 2.0)
- * Matches onboarding step 1-8 design language.
- * Uses HushhTechBackHeader + HushhTechCta reusable components.
- * All content pulled from logic.ts — zero data here.
+ * Fund A — Discover Page (Revamped 3.0)
+ * Pixel-perfect alignment with hushh-user-profile + step 1-8 design.
+ * Uses same wrapper, header, CTA, FieldRow, SectionLabel patterns.
+ * All content from logic.ts — zero data here.
  */
 import React from "react";
 import { useNavigate } from "react-router-dom";
@@ -15,30 +15,81 @@ import HushhTechFooter, {
   HushhFooterTab,
 } from "../../components/hushh-tech-footer/HushhTechFooter";
 
-/* ── tiny reusable card ── */
-const InfoCard = ({
-  title,
-  description,
+/* ── settings-style row (same as profile page) ── */
+const FieldRow = ({
+  label,
+  children,
 }: {
-  title: string;
-  description: string;
+  label: string;
+  children: React.ReactNode;
 }) => (
-  <div className="bg-gray-50 border border-gray-100 rounded-xl p-6 transition-all hover:shadow-sm">
-    <h3 className="text-sm font-semibold text-black lowercase tracking-wide mb-2">
-      {title}
-    </h3>
-    <p className="text-xs text-gray-500 font-light leading-relaxed lowercase">
-      {description}
-    </p>
+  <div className="group flex items-center justify-between border-b border-gray-200 py-4 hover:bg-gray-50/50 transition-colors -mx-6 px-6">
+    <span className="text-sm text-gray-500 font-light lowercase">{label}</span>
+    <div className="flex items-center gap-2 text-right">{children}</div>
   </div>
 );
 
-/* ── section label ── */
+/* ── section label (same as profile page) ── */
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-  <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-4 mt-8 font-medium">
+  <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 font-medium mt-10 mb-2">
     {children}
   </p>
 );
+
+/* ── card with icon (same as step-2 cards) ── */
+const FeatureCard = ({
+  icon,
+  title,
+  description,
+}: {
+  icon: string;
+  title: string;
+  description: string;
+}) => (
+  <div className="flex items-start gap-4 border border-gray-200 rounded-2xl p-5 hover:border-gray-300 hover:bg-gray-50/50 transition-all">
+    <div className="w-11 h-11 rounded-full border border-gray-200 flex items-center justify-center shrink-0 bg-white">
+      <span className="material-symbols-outlined text-gray-700 !text-[1.15rem]">
+        {icon}
+      </span>
+    </div>
+    <div className="flex-1 min-w-0">
+      <h3 className="text-[13px] font-semibold text-black lowercase leading-snug mb-1">
+        {title}
+      </h3>
+      <p className="text-[11px] text-gray-400 font-light leading-relaxed lowercase">
+        {description}
+      </p>
+    </div>
+  </div>
+);
+
+/* ── icon map for cards ── */
+const PHILOSOPHY_ICONS: Record<string, string> = {
+  "Options Intelligence": "psychology",
+  "AI-Enhanced Research": "neurology",
+  "Risk-First Architecture": "shield",
+  "Concentrated Conviction": "target",
+};
+
+const EDGE_ICONS: Record<string, string> = {
+  "Volatility Harvesting": "trending_up",
+  "Asymmetric Returns": "rocket_launch",
+  "Income Generation": "payments",
+  "Downside Protection": "security",
+};
+
+const ASSET_ICONS: Record<string, string> = {
+  "U.S. Large-Cap Equities": "account_balance",
+  "Strategic Options Overlay": "tune",
+  "Cash & Equivalents": "savings",
+};
+
+const RISK_ICONS: Record<string, string> = {
+  "Position Limits": "pie_chart",
+  "Hedging Framework": "shield",
+  "Drawdown Protocols": "trending_down",
+  "Liquidity Management": "water_drop",
+};
 
 const FundA = () => {
   const navigate = useNavigate();
@@ -75,245 +126,255 @@ const FundA = () => {
 
   return (
     <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-black selection:text-white">
-      {/* ═══ Header — back + hamburger ═══ */}
+      {/* ═══ Header ═══ */}
       <HushhTechBackHeader
-        onBackClick={() => window.history.back()}
+        onBackClick={() => navigate("/")}
         rightType="hamburger"
       />
 
-      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-24">
+      {/* ═══ Main ═══ */}
+      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-32">
         {/* ── Hero ── */}
-        <section className="py-8">
-          <div className="inline-block px-3 py-1 mb-4 border border-gray-200 rounded-full">
-            <span className="text-[10px] tracking-widest uppercase font-medium text-gray-500 flex items-center gap-1">
-              <span className="w-1.5 h-1.5 bg-black rounded-full" />
-              investment opportunity
+        <section className="pt-6 pb-8">
+          {/* pill badge */}
+          <div className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 rounded-full mb-6">
+            <span className="w-1.5 h-1.5 bg-black rounded-full" />
+            <span className="text-[10px] tracking-[0.15em] uppercase font-medium text-gray-500">
+              flagship fund
             </span>
           </div>
 
           <h1
-            className="text-[2rem] leading-[1.15] font-medium text-black tracking-tight lowercase"
+            className="text-[28px] leading-[1.15] font-medium text-black tracking-tight lowercase mb-1"
             style={{ fontFamily: "'Playfair Display', serif" }}
           >
             {heroTitle}
           </h1>
-
           <h2
-            className="text-[2.25rem] leading-[1.1] font-medium tracking-tight lowercase mt-1"
-            style={{ fontFamily: "'Playfair Display', serif", color: "#1a1a1a" }}
+            className="text-[32px] leading-[1.1] font-medium text-black tracking-tight lowercase"
+            style={{ fontFamily: "'Playfair Display', serif" }}
           >
             {heroSubtitle}
           </h2>
 
-          <p className="text-gray-500 text-sm font-light mt-4 leading-relaxed lowercase">
+          <p className="text-[13px] text-gray-400 font-light mt-4 leading-relaxed lowercase max-w-xs">
             {heroDescription}
           </p>
         </section>
 
-        {/* ── Target IRR Card ── */}
-        <section className="mb-10">
-          <div className="bg-black rounded-2xl p-6 text-white text-center">
-            <p className="text-xs uppercase tracking-widest text-gray-400 mb-2 font-medium">
-              {targetIRRLabel}
-            </p>
-            <p
-              className="text-5xl font-medium mb-1"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
-              {targetIRRValue}
-            </p>
-            <p className="text-sm text-gray-300 lowercase mb-3">
-              {targetIRRPeriod}
-            </p>
-            <p className="text-[10px] text-gray-500 italic max-w-[240px] mx-auto">
-              {targetIRRDisclaimer}
-            </p>
+        {/* ── Target IRR (premium black card — like step-1 share class) ── */}
+        <section className="mb-8">
+          <div className="bg-black rounded-2xl p-6 text-center relative overflow-hidden">
+            {/* subtle glow */}
+            <div className="absolute -top-8 -right-8 w-32 h-32 bg-white/5 rounded-full blur-2xl" />
+            <div className="relative z-10">
+              <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 mb-3 font-medium">
+                {targetIRRLabel}
+              </p>
+              <p
+                className="text-[48px] leading-none font-medium text-white mb-2"
+                style={{ fontFamily: "'Playfair Display', serif" }}
+              >
+                {targetIRRValue}
+              </p>
+              <p className="text-[13px] text-gray-400 lowercase mb-4">
+                {targetIRRPeriod}
+              </p>
+              <p className="text-[9px] text-gray-600 italic max-w-[220px] mx-auto leading-relaxed">
+                {targetIRRDisclaimer}
+              </p>
+            </div>
           </div>
         </section>
 
         {/* ── Investment Philosophy ── */}
-        <section className="mb-10">
-          <SectionLabel>{philosophySectionTitle}</SectionLabel>
-          <div className="space-y-3">
-            {philosophyCards.map((card) => (
-              <InfoCard
-                key={card.title}
-                title={card.title}
-                description={card.description}
-              />
-            ))}
-          </div>
-        </section>
+        <SectionLabel>{philosophySectionTitle}</SectionLabel>
+        <div className="space-y-3 mb-2">
+          {philosophyCards.map((card) => (
+            <FeatureCard
+              key={card.title}
+              icon={PHILOSOPHY_ICONS[card.title] || "lightbulb"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
 
         {/* ── Sell the Wall Framework ── */}
-        <section className="mb-10">
-          <SectionLabel>
-            {edgeSectionTitle}{" "}
-            <a
-              href={sellTheWallHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-black underline hover:no-underline"
-            >
-              "sell the wall"
-            </a>{" "}
-            options framework
-          </SectionLabel>
-          <div className="space-y-3">
-            {edgeCards.map((card) => (
-              <InfoCard
-                key={card.title}
-                title={card.title}
-                description={card.description}
-              />
-            ))}
-          </div>
-        </section>
+        <SectionLabel>
+          our edge —{" "}
+          <a
+            href={sellTheWallHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-black underline decoration-gray-300 hover:decoration-black transition-colors"
+          >
+            sell the wall
+          </a>{" "}
+          framework
+        </SectionLabel>
+        <div className="space-y-3 mb-2">
+          {edgeCards.map((card) => (
+            <FeatureCard
+              key={card.title}
+              icon={EDGE_ICONS[card.title] || "auto_awesome"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
 
         {/* ── Asset Focus ── */}
-        <section className="mb-10">
-          <SectionLabel>{assetFocusSectionTitle}</SectionLabel>
-          <p className="text-xs text-gray-500 font-light leading-relaxed lowercase mb-4">
-            {assetFocusDescription}
-          </p>
-          <div className="space-y-3">
-            {assetPillars.map((pillar) => (
-              <InfoCard
-                key={pillar.title}
-                title={pillar.title}
-                description={pillar.description}
-              />
-            ))}
-          </div>
-        </section>
+        <SectionLabel>{assetFocusSectionTitle}</SectionLabel>
+        <p className="text-[11px] text-gray-400 font-light leading-relaxed lowercase mb-4">
+          {assetFocusDescription}
+        </p>
+        <div className="space-y-3 mb-2">
+          {assetPillars.map((pillar) => (
+            <FeatureCard
+              key={pillar.title}
+              icon={ASSET_ICONS[pillar.title] || "category"}
+              title={pillar.title}
+              description={pillar.description}
+            />
+          ))}
+        </div>
 
-        {/* ── Targeted Alpha Stack ── */}
-        <section className="mb-10">
-          <SectionLabel>{alphaStackSectionTitle}</SectionLabel>
-          <p className="text-[10px] text-gray-400 italic lowercase mb-4">
-            {alphaStackSubtitle}
-          </p>
-
-          <div className="border border-gray-200 rounded-xl overflow-hidden">
-            {alphaStackRows.map((row, index) => (
+        {/* ── Targeted Alpha Stack (FieldRow style) ── */}
+        <SectionLabel>{alphaStackSectionTitle}</SectionLabel>
+        <p className="text-[10px] text-gray-400 italic lowercase mb-1">
+          {alphaStackSubtitle}
+        </p>
+        <div className="mb-2">
+          {alphaStackRows.map((row) =>
+            row.isTotalRow ? (
               <div
                 key={row.label}
-                className={`flex justify-between items-center px-5 py-4 ${
-                  index < alphaStackRows.length - 1
-                    ? "border-b border-gray-100"
-                    : ""
-                } ${row.isTotalRow ? "bg-black text-white" : ""}`}
+                className="flex items-center justify-between bg-black text-white rounded-2xl px-6 py-4 mt-3"
               >
-                <span
-                  className={`text-sm font-medium lowercase ${
-                    row.isTotalRow ? "text-white" : "text-gray-900"
-                  }`}
-                >
+                <span className="text-sm font-semibold lowercase">
                   {row.label}
                 </span>
                 <span
-                  className={`text-sm font-semibold ${
-                    row.isTotalRow ? "text-white" : "text-black"
-                  }`}
+                  className="text-xl font-medium"
+                  style={{ fontFamily: "'Playfair Display', serif" }}
                 >
                   {row.value}
                 </span>
               </div>
-            ))}
-          </div>
-        </section>
+            ) : (
+              <FieldRow key={row.label} label={row.label}>
+                <span className="text-sm font-semibold text-black">
+                  {row.value}
+                </span>
+              </FieldRow>
+            )
+          )}
+        </div>
 
         {/* ── Risk Management ── */}
-        <section className="mb-10">
-          <SectionLabel>{riskSectionTitle}</SectionLabel>
-          <div className="space-y-3">
-            {riskCards.map((card) => (
-              <InfoCard
-                key={card.title}
-                title={card.title}
-                description={card.description}
-              />
-            ))}
-          </div>
-        </section>
+        <SectionLabel>{riskSectionTitle}</SectionLabel>
+        <div className="space-y-3 mb-2">
+          {riskCards.map((card) => (
+            <FeatureCard
+              key={card.title}
+              icon={RISK_ICONS[card.title] || "security"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
 
-        {/* ── Key Terms ── */}
-        <section className="mb-10">
-          <SectionLabel>{keyTermsSectionTitle}</SectionLabel>
-          <p className="text-[10px] text-gray-400 italic lowercase mb-4">
-            {keyTermsSubtitle}
-          </p>
+        {/* ── Key Terms (FieldRow style) ── */}
+        <SectionLabel>{keyTermsSectionTitle}</SectionLabel>
+        <p className="text-[10px] text-gray-400 italic lowercase mb-1">
+          {keyTermsSubtitle}
+        </p>
 
-          <div className="space-y-4">
-            {keyTerms.slice(0, 2).map((term) => (
-              <div key={term.title} className="py-2">
-                <h3 className="text-sm font-semibold text-black lowercase mb-1">
-                  {term.title}
-                </h3>
-                <p className="text-xs text-gray-500 font-light leading-relaxed lowercase">
-                  {term.content}
-                </p>
-              </div>
-            ))}
-          </div>
+        {/* First terms as FieldRows */}
+        <div className="mb-4">
+          {keyTerms.slice(0, 2).map((term) => (
+            <FieldRow key={term.title} label={term.title}>
+              <span className="text-[12px] font-medium text-black max-w-[180px] text-right lowercase leading-snug">
+                {term.content}
+              </span>
+            </FieldRow>
+          ))}
+        </div>
 
-          {/* Share Classes Table */}
-          <div className="mt-6 border border-gray-200 rounded-xl overflow-hidden">
-            <div className="bg-black text-white px-4 py-3">
-              <p className="text-[10px] uppercase tracking-widest font-medium text-gray-400">
-                share classes
-              </p>
-            </div>
-            {shareClasses.map((sc, index) => (
-              <div
-                key={sc.shareClass}
-                className={`px-4 py-3 ${
-                  index < shareClasses.length - 1
-                    ? "border-b border-gray-100"
-                    : ""
-                }`}
-              >
-                <div className="flex justify-between items-center mb-1">
-                  <span className="text-sm font-semibold text-black lowercase">
+        {/* Share Classes (compact cards) */}
+        <SectionLabel>share classes</SectionLabel>
+        <div className="space-y-3 mb-4">
+          {shareClasses.map((sc) => (
+            <div
+              key={sc.shareClass}
+              className="border border-gray-200 rounded-2xl p-5 hover:border-gray-300 transition-colors"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-full bg-black flex items-center justify-center">
+                    <span className="material-symbols-outlined text-white !text-[0.9rem]">
+                      account_balance_wallet
+                    </span>
+                  </div>
+                  <span className="text-[13px] font-semibold text-black lowercase">
                     {sc.shareClass}
                   </span>
-                  <span className="text-xs text-gray-500 font-medium">
-                    min {sc.minInvestment}
-                  </span>
                 </div>
-                <div className="flex gap-4 text-[10px] text-gray-400">
-                  <span>mgmt: {sc.managementFee}</span>
-                  <span>perf: {sc.performanceFee}</span>
-                  <span>hurdle: {sc.hurdleRate}</span>
+                <span className="text-[11px] font-medium text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full">
+                  min {sc.minInvestment}
+                </span>
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                <div className="text-center">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
+                    mgmt
+                  </p>
+                  <p className="text-[12px] font-semibold text-black">
+                    {sc.managementFee}
+                  </p>
+                </div>
+                <div className="text-center">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
+                    perf
+                  </p>
+                  <p className="text-[12px] font-semibold text-black">
+                    {sc.performanceFee}
+                  </p>
+                </div>
+                <div className="text-center">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
+                    hurdle
+                  </p>
+                  <p className="text-[12px] font-semibold text-black">
+                    {sc.hurdleRate}
+                  </p>
                 </div>
               </div>
-            ))}
-          </div>
+            </div>
+          ))}
+        </div>
 
-          {/* Remaining terms */}
-          <div className="space-y-4 mt-6">
-            {keyTerms.slice(2).map((term) => (
-              <div key={term.title} className="py-2">
-                <h3 className="text-sm font-semibold text-black lowercase mb-1">
-                  {term.title}
-                </h3>
-                <p className="text-xs text-gray-500 font-light leading-relaxed lowercase">
-                  {term.content}
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
+        {/* Remaining terms */}
+        <div className="mb-6">
+          {keyTerms.slice(2).map((term) => (
+            <FieldRow key={term.title} label={term.title}>
+              <span className="text-[12px] font-medium text-black max-w-[180px] text-right lowercase leading-snug">
+                {term.content}
+              </span>
+            </FieldRow>
+          ))}
+        </div>
 
         {/* ── Join / CTA ── */}
-        <section className="mb-12 border-t border-gray-200 pt-8">
+        <section className="border-t border-gray-200 pt-8 mb-8">
           <h2
-            className="text-2xl font-medium text-black tracking-tight lowercase mb-3"
+            className="text-[22px] font-medium text-black tracking-tight lowercase mb-2"
             style={{ fontFamily: "'Playfair Display', serif" }}
           >
             {joinSectionTitle}
           </h2>
-          <p className="text-sm text-gray-500 font-light leading-relaxed lowercase mb-8">
+          <p className="text-[13px] text-gray-400 font-light leading-relaxed lowercase mb-8 max-w-xs">
             {joinSectionDescription}
           </p>
 
@@ -323,18 +384,25 @@ const FundA = () => {
               onClick={handleCompleteProfile}
             >
               {joinButtonLabel}
-              <span className="material-symbols-outlined text-lg">
+              <span className="material-symbols-outlined !text-[1.1rem]">
                 arrow_forward
               </span>
             </HushhTechCta>
             <HushhTechCta
               variant={HushhTechCtaVariant.WHITE}
-              onClick={() => window.history.back()}
+              onClick={() => navigate("/")}
             >
-              go back
+              back to home
             </HushhTechCta>
           </div>
         </section>
+
+        {/* ── Disclaimer ── */}
+        <p className="text-[9px] text-gray-400 text-center leading-relaxed italic max-w-xs mx-auto mb-4">
+          investing involves risk, including possible loss of principal. past
+          performance does not guarantee future results. hushh technologies is an
+          sec registered investment advisor.
+        </p>
       </main>
 
       {/* ═══ Footer Nav ═══ */}


### PR DESCRIPTION
- FieldRow component (same as profile page — border-b, hover:bg-gray-50/50)
- FeatureCard component (same as step-2 cards — icon circle + text)
- Material symbol icons for each section (philosophy, edge, asset, risk)
- Alpha stack as FieldRows with black total row (rounded-2xl)
- Share classes as compact cards (black icon circle, grid stats, pill badge)
- Key terms as FieldRow settings-style
- Premium black IRR card with subtle glow
- SectionLabel matching profile page exactly
- Disclaimer footer
- Build verified ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned the fund details page with a modern card-based interface for improved visual organization
  * Enhanced hero section with updated typography and visual hierarchy
  * Updated Target IRR card with premium styling for better prominence
  * Restructured information sections (philosophy, edges, assets, risk) with modernized component layout
  * Added global disclaimer at the bottom of the fund details page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->