### PR TITLE
fix: profile page — stop 401 polling + Tailwind UI revamp

### DIFF
--- a/src/pages/profile/logic.ts
+++ b/src/pages/profile/logic.ts
@@ -1,23 +1,21 @@
+/**
+ * Profile Page — Logic / ViewModel
+ * Session, onboarding status, NDA check (once, no polling).
+ * UI stays in ui.tsx.
+ */
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useToast } from '@chakra-ui/react';
 import axios from 'axios';
 import config from '../../resources/config/config';
 
 export function useProfileLogic() {
-  const toast = useToast();
   const navigate = useNavigate();
 
   const [session, setSession] = useState<any>(null);
-  const [ndaStatus, setNdaStatus] = useState<string>('Not Applied');
-  const [ndaMetadata, setNdaMetadata] = useState<any>(null);
-  const [showNdaModal, setShowNdaModal] = useState(false);
-  const [showNdaDocModal, setShowNdaDocModal] = useState(false);
   const [ndaApproved, setNdaApproved] = useState(false);
-  const [isMetadataLoading, setIsMetadataLoading] = useState(false);
-  const metadataFetchedRef = useRef<boolean>(false);
+  const ndaCheckedRef = useRef(false);
 
-  // Onboarding status state
+  /* onboarding status */
   const [onboardingStatus, setOnboardingStatus] = useState<{
     hasProfile: boolean;
     isCompleted: boolean;
@@ -30,41 +28,38 @@ export function useProfileLogic() {
     loading: true,
   });
 
+  /* session setup */
   useEffect(() => {
-    config.supabaseClient?.auth.getSession().then(({ data: { session } }: any) => {
-      setSession(session);
-    });
-    const {
-      data: { subscription },
-    } = config.supabaseClient?.auth.onAuthStateChange((_event: any, session: any) => {
-      setSession(session);
-    }) ?? { data: { subscription: null } };
-    return () => {
-      if (subscription && typeof subscription.unsubscribe === 'function') {
-        subscription.unsubscribe();
-      }
-    };
+    config.supabaseClient?.auth
+      .getSession()
+      .then(({ data: { session } }: any) => setSession(session));
+
+    const { data: { subscription } } =
+      config.supabaseClient?.auth.onAuthStateChange((_event: any, s: any) => {
+        setSession(s);
+      }) ?? { data: { subscription: null } };
+
+    return () => subscription?.unsubscribe?.();
   }, []);
 
-  // Check user's onboarding status
+  /* check onboarding status (once when session loads) */
   useEffect(() => {
-    async function checkUserStatus() {
-      if (!session?.user?.id || !config.supabaseClient) {
-        setOnboardingStatus((prev) => ({ ...prev, loading: false }));
-        return;
-      }
+    if (!session?.user?.id || !config.supabaseClient) {
+      setOnboardingStatus((prev) => ({ ...prev, loading: false }));
+      return;
+    }
 
+    const checkUserStatus = async () => {
       try {
-        // Check if investor_profile exists
-        const { data: profile, error: profileError } = await config.supabaseClient
-          .from('investor_profiles')
-          .select('id, user_confirmed')
-          .eq('user_id', session.user.id)
-          .maybeSingle();
+        const { data: profile, error: profileError } =
+          await config.supabaseClient!
+            .from('investor_profiles')
+            .select('id, user_confirmed')
+            .eq('user_id', session.user.id)
+            .maybeSingle();
 
-        // Check onboarding_data status
-        const { data: onboarding } = await config.supabaseClient
-          .from('onboarding_data')
+        const { data: onboarding } = await config.supabaseClient!
+            .from('onboarding_data')
           .select('is_completed, current_step')
           .eq('user_id', session.user.id)
           .maybeSingle();
@@ -79,161 +74,72 @@ export function useProfileLogic() {
         console.error('Error checking user status:', error);
         setOnboardingStatus((prev) => ({ ...prev, loading: false }));
       }
-    }
+    };
 
-    if (session?.user?.id) {
-      checkUserStatus();
-    }
+    checkUserStatus();
   }, [session?.user?.id]);
 
-  const fetchNdaMetadata = useCallback(async () => {
-    if (
-      isMetadataLoading ||
-      (ndaMetadata && Object.keys(ndaMetadata).length > 0) ||
-      metadataFetchedRef.current
-    ) {
-      return;
-    }
-
-    setIsMetadataLoading(true);
-    try {
-      const ndaResponse = await axios.post(
-        'https://gsqmwxqgqrgzhlhmbscg.supabase.co/rest/v1/rpc/get_nda_metadata',
-        {},
-        {
-          headers: {
-            apikey: config.SUPABASE_ANON_KEY,
-            Authorization: `Bearer ${session.access_token}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      if (ndaResponse.data.status === 'success') {
-        const metadata = ndaResponse.data.metadata;
-        setNdaMetadata(metadata);
-
-        if (metadata && Object.keys(metadata).length > 0) {
-          metadataFetchedRef.current = true;
-        }
-
-        if (metadata && ndaStatus === 'Pending: Waiting for NDA Process') {
-          setShowNdaDocModal(true);
-        }
-      }
-    } catch (error) {
-      metadataFetchedRef.current = false;
-    } finally {
-      setIsMetadataLoading(false);
-    }
-  }, [session, ndaMetadata, isMetadataLoading, ndaStatus]);
-
-  const checkNdaStatus = useCallback(async () => {
-    if (!session) return;
-    try {
-      const response = await axios.post(
-        'https://gsqmwxqgqrgzhlhmbscg.supabase.co/rest/v1/rpc/check_access_status',
-        {},
-        {
-          headers: {
-            apikey: config.SUPABASE_ANON_KEY,
-            Authorization: `Bearer ${session.access_token}`,
-            'Content-Type': 'application/json',
-          },
-        }
-      );
-
-      const newStatus = response.data;
-      setNdaStatus(newStatus);
-
-      if (newStatus === 'Approved') {
-        setNdaApproved(true);
-      }
-
-      if (newStatus === 'Pending: Waiting for NDA Process' && !metadataFetchedRef.current) {
-        fetchNdaMetadata();
-      }
-    } catch (error) {
-      metadataFetchedRef.current = false;
-      console.warn('Failed to check NDA access status', error);
-    }
-  }, [session, fetchNdaMetadata]);
-
+  /* check NDA status ONCE (no polling) */
   useEffect(() => {
-    if (session) {
-      checkNdaStatus();
-      const intervalId = setInterval(() => {
-        checkNdaStatus();
-      }, 5000);
-      return () => clearInterval(intervalId);
-    }
-  }, [session, checkNdaStatus]);
+    if (!session?.access_token || ndaCheckedRef.current) return;
+    ndaCheckedRef.current = true;
 
-  useEffect(() => {
-    if (ndaStatus !== 'Pending: Waiting for NDA Process') {
-      metadataFetchedRef.current = false;
-    }
-  }, [ndaStatus]);
+    const checkNda = async () => {
+      try {
+        const { data } = await axios.post(
+          'https://gsqmwxqgqrgzhlhmbscg.supabase.co/rest/v1/rpc/check_access_status',
+          {},
+          {
+            headers: {
+              apikey: config.SUPABASE_ANON_KEY,
+              Authorization: `Bearer ${session.access_token}`,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+        if (data === 'Approved') setNdaApproved(true);
+      } catch (err: any) {
+        /* 401 = expired/invalid token — silently ignore, don't retry */
+        if (err?.response?.status === 401) return;
+        console.warn('NDA check failed:', err?.message);
+      }
+    };
 
-  // Get primary CTA text and action
+    checkNda();
+  }, [session?.access_token]);
+
+  /* primary CTA content based on onboarding status */
   const getPrimaryCTAContent = () => {
     if (onboardingStatus.loading) {
-      return { text: 'Loading...', action: () => {} };
+      return { text: 'loading...', action: () => {} };
     }
     if (onboardingStatus.hasProfile || onboardingStatus.isCompleted) {
       return {
-        text: 'View Your Profile',
+        text: 'view your profile',
         action: () => navigate('/hushh-user-profile'),
       };
     }
     if (onboardingStatus.currentStep > 1) {
       return {
-        text: `Continue Onboarding (Step ${onboardingStatus.currentStep})`,
-        action: () => navigate(`/onboarding/step-${onboardingStatus.currentStep}`),
+        text: `continue onboarding (step ${onboardingStatus.currentStep})`,
+        action: () =>
+          navigate(`/onboarding/step-${onboardingStatus.currentStep}`),
       };
     }
     return {
-      text: 'Complete Your Hushh Profile',
+      text: 'complete your hushh profile',
       action: () => navigate('/onboarding/financial-link'),
     };
   };
 
   const primaryCTA = getPrimaryCTAContent();
-
   const handleDiscoverFundA = () => navigate('/discover-fund-a');
-
-  const handleNdaModalClose = () => setShowNdaModal(false);
-
-  const handleNdaSubmit = (result: string) => {
-    setNdaStatus(result);
-    setShowNdaModal(false);
-
-    if (result === 'Pending: Waiting for NDA Process') {
-      fetchNdaMetadata();
-    }
-  };
-
-  const handleNdaDocModalClose = () => setShowNdaDocModal(false);
-
-  const handleNdaAccept = () => {
-    setNdaApproved(true);
-    setShowNdaDocModal(false);
-    setNdaStatus('Approved');
-    localStorage.setItem('communityFilter', 'nda');
-  };
 
   return {
     session,
-    ndaMetadata,
-    showNdaModal,
-    showNdaDocModal,
     ndaApproved,
     onboardingStatus,
     primaryCTA,
     handleDiscoverFundA,
-    handleNdaModalClose,
-    handleNdaSubmit,
-    handleNdaDocModalClose,
-    handleNdaAccept,
   };
 }

--- a/src/pages/profile/ui.tsx
+++ b/src/pages/profile/ui.tsx
@@ -1,355 +1,106 @@
+/**
+ * Profile Page — UI / Presentation
+ * Tailwind design matching home, fund-a, community pages.
+ * All logic in logic.ts via useProfileLogic().
+ */
 import React from 'react';
-import {
-  Box,
-  VStack,
-  Image,
-  Text,
-  Button,
-  Flex,
-  Icon,
-} from '@chakra-ui/react';
-import { FaLock } from 'react-icons/fa';
-import { motion } from 'framer-motion';
-import { keyframes } from '@emotion/react';
+import HushhTechBackHeader from '../../components/hushh-tech-back-header/HushhTechBackHeader';
+import HushhTechFooter from '../../components/hushh-tech-footer/HushhTechFooter';
+import HushhTechCta, { HushhTechCtaVariant } from '../../components/hushh-tech-cta/HushhTechCta';
 import HushhLogo from '../../components/images/Hushhogo.png';
-import NDARequestModal from '../../components/NDARequestModal';
-import NDADocumentModal from '../../components/NDADocumentModal';
+import { HushhFooterTab } from '../../components/hushh-tech-footer/HushhTechFooter';
 import { useProfileLogic } from './logic';
 
-// Motion components
-const MotionBox = motion(Box);
-const MotionButton = motion(Button);
-
-// Apple-like easing curve
-const appleEase: [number, number, number, number] = [0.25, 0.46, 0.45, 0.94];
-
-// Subtle pulse animation for loading states
-const pulseKeyframes = keyframes`
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
-`;
-
-// Animation variants
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: {
-      staggerChildren: 0.12,
-      delayChildren: 0.08,
-      duration: 0.5,
-      ease: appleEase,
-    },
-  },
-};
-
-const itemVariants = {
-  hidden: { opacity: 0, y: 24 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    transition: {
-      duration: 0.6,
-      ease: appleEase,
-    },
-  },
-};
-
-const logoVariants = {
-  hidden: { opacity: 0, scale: 0.92 },
-  visible: {
-    opacity: 1,
-    scale: 1,
-    transition: {
-      duration: 0.7,
-      ease: appleEase,
-    },
-  },
-};
-
-const cardVariants = {
-  hidden: { opacity: 0, y: 32, scale: 0.98 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    scale: 1,
-    transition: {
-      duration: 0.65,
-      delay: 0.2,
-      ease: appleEase,
-    },
-  },
-};
+/* ── section label (reusable) ── */
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <p className="text-[10px] tracking-[0.18em] uppercase text-neutral-400 font-medium">
+    {children}
+  </p>
+);
 
 const ProfilePage: React.FC = () => {
   const {
-    session,
-    ndaMetadata,
-    showNdaModal,
-    showNdaDocModal,
     onboardingStatus,
     primaryCTA,
     handleDiscoverFundA,
-    handleNdaModalClose,
-    handleNdaSubmit,
-    handleNdaDocModalClose,
-    handleNdaAccept,
   } = useProfileLogic();
 
   return (
-    <Box
-      bg="#FFFFFF"
-      minH="100vh"
-      display="flex"
-      flexDirection="column"
-      justifyContent="center"
-      alignItems="center"
-      px={{ base: 5, sm: 6, md: 8 }}
-      py={{ base: 10, md: 16 }}
-      position="relative"
-      overflow="hidden"
-      style={{
-        fontFamily:
-          '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", Inter, system-ui, sans-serif',
-      }}
-    >
-      {/* Subtle background gradient */}
-      <Box
-        position="absolute"
-        top="0"
-        left="0"
-        right="0"
-        bottom="0"
-        bg="linear-gradient(180deg, #FFFFFF 0%, #F8FAFC 50%, #F0F4F8 100%)"
-        pointerEvents="none"
-        zIndex={0}
-      />
+    <div className="flex flex-col min-h-screen bg-white">
+      {/* header */}
+      <HushhTechBackHeader />
 
-      {/* Content Container */}
-      <MotionBox
-        maxW="440px"
-        w="100%"
-        initial="hidden"
-        animate="visible"
-        variants={containerVariants}
-        position="relative"
-        zIndex={1}
-      >
-        {/* Logo Section */}
-        <MotionBox display="flex" justifyContent="center" mb={10} variants={logoVariants}>
-          <Box position="relative" display="flex" alignItems="center" justifyContent="center">
-            {/* Subtle glow behind logo */}
-            <Box
-              position="absolute"
-              w="160px"
-              h="160px"
-              bg="radial-gradient(circle, rgba(0, 169, 224, 0.08) 0%, transparent 70%)"
-              borderRadius="full"
-              filter="blur(20px)"
-              zIndex={-1}
-            />
-            <Image
-              src={HushhLogo}
-              alt="Hushh Logo"
-              h={{ base: '100px', md: '120px' }}
-              objectFit="contain"
-              filter="drop-shadow(0 4px 24px rgba(0, 169, 224, 0.12))"
-            />
-          </Box>
-        </MotionBox>
+      {/* scrollable content */}
+      <main className="flex-1 flex flex-col items-center justify-center px-5 py-10 sm:px-6 md:px-8">
+        <div className="w-full max-w-[440px] flex flex-col items-center gap-8">
 
-        {/* Header Section */}
-        <MotionBox textAlign="center" mb={10} variants={itemVariants}>
-          {/* Headline */}
-          <Text
-            as="h1"
-            fontSize={{ base: '34px', md: '40px' }}
-            fontWeight="600"
-            color="#1D1D1F"
-            lineHeight="1.08"
-            letterSpacing="-0.025em"
-            mb={4}
-          >
-            Investing in the Future.
-          </Text>
+          {/* pill badge */}
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-neutral-200 bg-neutral-50 px-4 py-1">
+            <span className="material-symbols-rounded text-[16px] text-neutral-500">person</span>
+            <span className="text-[11px] tracking-[0.14em] uppercase text-neutral-500 font-medium">
+              profile
+            </span>
+          </span>
 
-          {/* Subheadline */}
-          <Text
-            fontSize={{ base: '17px', md: '19px' }}
-            color="#515154"
-            lineHeight="1.55"
-            maxW="360px"
-            mx="auto"
-            fontWeight="400"
-          >
-            The AI-Powered Berkshire Hathaway. We combine AI and human expertise to invest in
-            exceptional businesses for long-term value creation.
-          </Text>
-        </MotionBox>
+          {/* logo */}
+          <img
+            src={HushhLogo}
+            alt="hushh logo"
+            className="h-[100px] md:h-[120px] object-contain"
+          />
 
-        {/* Main Action Card */}
-        <MotionBox
-          bg="rgba(255, 255, 255, 0.95)"
-          backdropFilter="blur(20px)"
-          borderRadius="28px"
-          p={{ base: 6, md: 8 }}
-          boxShadow="0 4px 40px rgba(0, 0, 0, 0.06), 0 1px 3px rgba(0, 0, 0, 0.04)"
-          border="1px solid rgba(0, 0, 0, 0.04)"
-          variants={cardVariants}
-        >
-          <VStack spacing={4}>
-            {/* Primary CTA Button */}
-            <MotionButton
+          {/* headline */}
+          <div className="text-center space-y-3">
+            <h1
+              className="text-[32px] md:text-[38px] leading-[1.08] tracking-tight text-neutral-900"
+              style={{ fontFamily: "'Playfair Display', serif" }}
+            >
+              investing in the future.
+            </h1>
+            <p className="text-[15px] md:text-[17px] leading-relaxed text-neutral-500 max-w-[360px] mx-auto">
+              the ai-powered berkshire hathaway. we combine ai and human expertise to invest in exceptional businesses for long-term value creation.
+            </p>
+          </div>
+
+          {/* action buttons */}
+          <div className="w-full space-y-3 mt-2">
+            <HushhTechCta
               onClick={primaryCTA.action}
-              w="100%"
-              h="56px"
-              borderRadius="full"
-              bg="#2b8cee"
-              color="white"
-              fontSize="17px"
-              fontWeight="600"
-              letterSpacing="-0.01em"
-              isLoading={onboardingStatus.loading}
-              loadingText="Loading..."
-              position="relative"
-              overflow="hidden"
-              _hover={{
-                bg: '#2480d9',
-                transform: 'translateY(-1px)',
-                boxShadow: '0 12px 32px rgba(43, 140, 238, 0.4)',
-              }}
-              _active={{
-                bg: '#1e74c9',
-                transform: 'scale(0.98)',
-              }}
-              _disabled={{
-                opacity: 0.7,
-                cursor: 'not-allowed',
-              }}
-              transition="all 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
-              boxShadow="0 8px 24px rgba(43, 140, 238, 0.35)"
-              whileHover={{ scale: 1.02 }}
-              whileTap={{ scale: 0.98 }}
+              variant={HushhTechCtaVariant.BLACK}
+              disabled={onboardingStatus.loading}
             >
-              {/* Subtle shine effect */}
-              <Box
-                position="absolute"
-                top="0"
-                left="-100%"
-                w="100%"
-                h="100%"
-                bg="linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent)"
-                animation={
-                  onboardingStatus.loading
-                    ? `${pulseKeyframes} 2s ease-in-out infinite`
-                    : 'none'
-                }
-              />
-              {primaryCTA.text}
-            </MotionButton>
-
-            {/* Secondary CTA Button */}
-            <MotionButton
+              {onboardingStatus.loading ? 'loading...' : primaryCTA.text}
+            </HushhTechCta>
+            <HushhTechCta
               onClick={handleDiscoverFundA}
-              w="100%"
-              h="56px"
-              borderRadius="full"
-              bg="white"
-              border="2px solid #2b8cee"
-              color="#1D1D1F"
-              fontSize="17px"
-              fontWeight="600"
-              letterSpacing="-0.01em"
-              _hover={{
-                bg: 'rgba(43, 140, 238, 0.05)',
-                borderColor: '#2480d9',
-                transform: 'translateY(-1px)',
-                boxShadow: '0 4px 16px rgba(43, 140, 238, 0.15)',
-              }}
-              _active={{
-                bg: 'rgba(43, 140, 238, 0.1)',
-                transform: 'scale(0.98)',
-              }}
-              transition="all 0.25s cubic-bezier(0.25, 0.46, 0.45, 0.94)"
-              whileHover={{ scale: 1.01 }}
-              whileTap={{ scale: 0.98 }}
+              variant={HushhTechCtaVariant.WHITE}
             >
-              Discover Fund A
-            </MotionButton>
-          </VStack>
-        </MotionBox>
+              discover fund a
+            </HushhTechCta>
+          </div>
 
-        {/* Footer Tagline */}
-        <MotionBox
-          textAlign="center"
-          mt={8}
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.7, duration: 0.5, ease: appleEase } as any}
-        >
-          <Text fontSize="13px" fontWeight="500" color="#8E8E93" letterSpacing="0.02em">
-            Secure. Private. AI-Powered.
-          </Text>
-        </MotionBox>
+          {/* trust indicators */}
+          <div className="flex items-center justify-center gap-6 mt-4">
+            <div className="flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
+              <SectionLabel>sec registered</SectionLabel>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="material-symbols-rounded text-[14px] text-neutral-400">lock</span>
+              <SectionLabel>bank level security</SectionLabel>
+            </div>
+          </div>
 
-        {/* Trust indicators - subtle */}
-        <MotionBox
-          display="flex"
-          justifyContent="center"
-          gap={6}
-          mt={6}
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ delay: 0.9, duration: 0.5 } as any}
-        >
-          <Box display="flex" alignItems="center" gap={2}>
-            <Box
-              w="8px"
-              h="8px"
-              borderRadius="full"
-              bg="#34C759"
-              boxShadow="0 0 8px rgba(52, 199, 89, 0.4)"
-              animation="pulse 2s ease-in-out infinite"
-              sx={{
-                '@keyframes pulse': {
-                  '0%, 100%': { opacity: 1, transform: 'scale(1)' },
-                  '50%': { opacity: 0.7, transform: 'scale(1.1)' },
-                },
-              }}
-            />
-            <Text fontSize="13px" color="#6E6E73" fontWeight="500">
-              SEC REGISTERED
-            </Text>
-          </Box>
-          <Box display="flex" alignItems="center" gap={2}>
-            <Icon as={FaLock} w="12px" h="12px" color="#6E6E73" />
-            <Text fontSize="13px" color="#6E6E73" fontWeight="500">
-              BANK LEVEL SECURITY
-            </Text>
-          </Box>
-        </MotionBox>
-      </MotionBox>
+          {/* tagline */}
+          <p className="text-[12px] text-neutral-400 tracking-wide text-center mt-2">
+            secure. private. ai-powered.
+          </p>
+        </div>
+      </main>
 
-      {/* NDA Modals - kept for compatibility but hidden */}
-      {false && showNdaModal && session && (
-        <NDARequestModal
-          isOpen={showNdaModal}
-          onClose={handleNdaModalClose}
-          session={session}
-          onSubmit={handleNdaSubmit}
-        />
-      )}
-
-      {false && showNdaDocModal && ndaMetadata && session && (
-        <NDADocumentModal
-          isOpen={showNdaDocModal}
-          onClose={handleNdaDocModalClose}
-          session={session}
-          ndaMetadata={ndaMetadata}
-          onAccept={handleNdaAccept}
-        />
-      )}
-    </Box>
+      {/* footer */}
+      <HushhTechFooter activeTab={HushhFooterTab.PROFILE} />
+    </div>
   );
 };
 


### PR DESCRIPTION
Fixes the 401 error spam on /profile page and revamps UI to match design system.

**logic.ts:**
- Removed 5-second NDA polling loop (was causing 401 errors every 5s)
- NDA status checked once on mount only
- 401 errors handled gracefully (no retry)
- Removed unused NDA modal state

**ui.tsx:**
- Converted from Chakra UI + Framer Motion to Tailwind
- Uses HushhTechBackHeader + HushhTechFooter (PROFILE active)
- HushhTechCta buttons (black + white variants)
- Pill badge, Playfair Display heading, trust indicators
- Build verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned profile page with a streamlined, centered layout for improved clarity.

* **Bug Fixes**
  * Simplified NDA verification process; now runs once per session.

* **Refactor**
  * Streamlined onboarding and session flows.
  * Updated navigation text to be more concise and consistent.
  * Removed unnecessary animations and visual complexity from the profile interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->