### PR TITLE
fix: profile footer navigation + reduce header whitespace

### DIFF
--- a/src/pages/profile/ui.tsx
+++ b/src/pages/profile/ui.tsx
@@ -9,6 +9,7 @@ import HushhTechFooter from '../../components/hushh-tech-footer/HushhTechFooter'
 import HushhTechCta, { HushhTechCtaVariant } from '../../components/hushh-tech-cta/HushhTechCta';
 import HushhLogo from '../../components/images/Hushhogo.png';
 import { HushhFooterTab } from '../../components/hushh-tech-footer/HushhTechFooter';
+import { useNavigate } from 'react-router-dom';
 import { useProfileLogic } from './logic';
 
 /* ── section label (reusable) ── */
@@ -19,19 +20,28 @@ const SectionLabel = ({ children }: { children: React.ReactNode }) => (
 );
 
 const ProfilePage: React.FC = () => {
+  const navigate = useNavigate();
   const {
     onboardingStatus,
     primaryCTA,
     handleDiscoverFundA,
   } = useProfileLogic();
 
+  /* footer tab navigation */
+  const handleTabChange = (tab: HushhFooterTab) => {
+    if (tab === HushhFooterTab.HOME) navigate('/');
+    else if (tab === HushhFooterTab.FUND_A) navigate('/discover-fund-a');
+    else if (tab === HushhFooterTab.COMMUNITY) navigate('/community');
+    else if (tab === HushhFooterTab.PROFILE) navigate('/profile');
+  };
+
   return (
     <div className="flex flex-col min-h-screen bg-white">
       {/* header */}
-      <HushhTechHeader />
+      <HushhTechHeader className="!py-2" />
 
       {/* scrollable content */}
-      <main className="flex-1 flex flex-col items-center justify-center px-5 py-4 sm:px-6 md:px-8">
+      <main className="flex-1 flex flex-col items-center justify-center px-5 py-2 sm:px-6 md:px-8">
         <div className="w-full max-w-[440px] flex flex-col items-center gap-8">
 
           {/* pill badge */}
@@ -99,7 +109,11 @@ const ProfilePage: React.FC = () => {
       </main>
 
       {/* footer */}
-      <HushhTechFooter activeTab={HushhFooterTab.PROFILE} />
+      <HushhTechFooter
+        activeTab={HushhFooterTab.PROFILE}
+        onTabChange={handleTabChange}
+        onLogoClick={() => navigate('/')}
+      />
     </div>
   );
 };


### PR DESCRIPTION
- Added onTabChange handler to footer (tabs were not navigating)
- Added onLogoClick to navigate home
- Reduced header padding with python3 -m venv
- Reduced main padding to py-2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile page now supports direct navigation between Home, Fund A, Community, and Profile sections.
  * Logo click navigates to home.
  * Improved layout spacing for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->