### PR TITLE
revamp: delete account page & modal — align with Step 1-8 design philosophy

### DIFF
--- a/src/components/DeleteAccountModal.tsx
+++ b/src/components/DeleteAccountModal.tsx
@@ -10,7 +10,8 @@ interface DeleteAccountModalProps {
 }
 
 /**
- * iOS-native style Delete Account dialog.
+ * Delete Account Modal — Glassmorphism design matching Step 4 location modal.
+ * Playfair Display headings, black/white buttons, frosted overlay.
  * Backend logic is preserved — only UI is redesigned.
  */
 const DeleteAccountModal = ({
@@ -128,124 +129,115 @@ const DeleteAccountModal = ({
   if (!isOpen) return null;
 
   // =====================================================
-  // iOS Native Alert UI
+  // Glassmorphism Modal — Matches Step 4 location modal
   // =====================================================
   return (
-    <div
-      className="fixed inset-0 z-[2000] flex items-center justify-center px-6"
-      style={{ background: "rgba(0, 0, 0, 0.4)" }}
-      onClick={handleClose}
-    >
+    <>
+      {/* ── Frosted glass overlay ── */}
       <div
-        className="w-full max-w-[320px] bg-white rounded-[14px] overflow-hidden shadow-2xl"
-        style={{
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif',
-        }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* Content Area */}
-        <div className="px-5 pt-5 pb-4">
-          {/* Warning Icon + Title */}
-          <div className="flex items-center justify-center mb-2">
-            <span
-              className="material-symbols-outlined text-[#FF3B30] mr-2 text-[22px]"
-              style={{ fontVariationSettings: "'FILL' 1, 'wght' 600" }}
+        className="fixed inset-0 z-40 bg-white/60 backdrop-blur-sm"
+        onClick={handleClose}
+      />
+
+      {/* ── Modal card — bottom-sheet on mobile, centered on desktop ── */}
+      <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-4 pb-6 sm:pb-0">
+        <div
+          className="relative w-full max-w-sm bg-white rounded-3xl shadow-[0_20px_40px_-10px_rgba(0,0,0,0.08),0_0_1px_rgba(0,0,0,0.04)] p-8 flex flex-col items-center text-center border border-gray-100/50"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* ── Warning icon in circle ── */}
+          <div className="mb-8">
+            <div className="w-20 h-20 rounded-full border border-gray-200 bg-white flex items-center justify-center shadow-sm">
+              <span
+                className="material-symbols-outlined text-black text-[2rem]"
+                style={{ fontVariationSettings: "'wght' 200" }}
+              >
+                delete_forever
+              </span>
+            </div>
+          </div>
+
+          {/* ── Heading & description ── */}
+          <div className="space-y-4 mb-8 px-2">
+            <h2
+              className="text-[1.75rem] leading-[1.2] text-black lowercase tracking-tight"
+              style={{ fontFamily: "'Playfair Display', serif" }}
             >
-              warning
-            </span>
-            <h3 className="text-[17px] font-semibold text-black leading-tight">
-              {t("deleteAccount.title")}
-            </h3>
-          </div>
-
-          {/* Warning message */}
-          <p className="text-[13px] text-[#8E8E93] text-center leading-[1.5] mb-4">
-            {t("deleteAccount.warningMessage")}
-          </p>
-
-          {/* What will be deleted — iOS grouped card */}
-          <div className="bg-[#F2F2F7] rounded-[10px] px-4 py-3 mb-4">
-            <p className="text-[13px] font-medium text-black mb-2">
-              {t("deleteAccount.willDelete")}
+              are you sure?
+            </h2>
+            <p className="text-gray-500 text-[0.85rem] leading-relaxed font-normal lowercase max-w-[90%] mx-auto">
+              this action is permanent and cannot be undone. all your data,
+              investment info, and services will be removed.
             </p>
-            <ul className="space-y-1.5">
-              {[
-                t("deleteAccount.deleteItem1"),
-                t("deleteAccount.deleteItem2"),
-                t("deleteAccount.deleteItem3"),
-                t("deleteAccount.deleteItem4"),
-                "All your Hushh AI chats and conversations",
-                "All uploaded media files (images, documents)",
-                "Your AI chat history and preferences",
-              ].map((item, i) => (
-                <li
-                  key={i}
-                  className="text-[13px] text-[#8E8E93] leading-[1.4] flex items-start"
-                >
-                  <span className="text-[#8E8E93] mr-1.5 mt-0.5 shrink-0">•</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
           </div>
 
-          {/* Confirmation input */}
-          <p className="text-[13px] font-medium text-black mb-2">
-            {t("deleteAccount.confirmPrompt")}
-          </p>
-          <input
-            type="text"
-            value={confirmText}
-            onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
-            placeholder="DELETE"
-            className="w-full h-[44px] rounded-[10px] bg-[#F2F2F7] border border-[#E5E5EA] px-4 text-[15px] text-black font-mono tracking-[2px] placeholder:text-[#C7C7CC] focus:outline-none focus:border-[#007AFF] focus:ring-1 focus:ring-[#007AFF] transition-colors"
-            autoComplete="off"
-            autoCorrect="off"
-            spellCheck={false}
-          />
-        </div>
+          {/* ── Confirmation input ── */}
+          <div className="w-full mb-8">
+            <p className="text-xs text-gray-500 lowercase font-semibold mb-3 tracking-wide">
+              type DELETE to confirm
+            </p>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value.toUpperCase())}
+              placeholder="DELETE"
+              className="w-full h-[52px] border border-gray-200 bg-white px-4 text-sm text-black font-mono tracking-[2px] placeholder:text-gray-300 focus:outline-none focus:border-black focus:ring-1 focus:ring-black transition-colors"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              aria-label="Type DELETE to confirm account deletion"
+            />
+          </div>
 
-        {/* iOS-style stacked action buttons with hairline separators */}
-        <div className="border-t border-[#C6C6C8]">
-          {/* Cancel Button — iOS style: bold, blue */}
-          <button
-            onClick={handleClose}
-            disabled={isDeleting}
-            className="w-full h-[44px] text-[17px] font-semibold text-[#007AFF] active:bg-[#E5E5EA] transition-colors disabled:opacity-50"
-          >
-            {t("deleteAccount.cancel")}
-          </button>
+          {/* ── Action buttons ── */}
+          <div className="w-full space-y-4">
+            {/* Delete — primary black */}
+            <button
+              onClick={handleDeleteAccount}
+              disabled={!isDeleteEnabled || isDeleting}
+              className="w-full h-12 bg-black text-white font-medium text-[0.8rem] flex items-center justify-center gap-2 shadow-lg hover:shadow-xl transition-all active:scale-[0.99] border border-black hover:bg-black/90 disabled:opacity-30 disabled:cursor-not-allowed disabled:shadow-none lowercase"
+            >
+              {isDeleting ? (
+                <>
+                  <div className="animate-spin h-4 w-4 border-2 border-white/30 border-t-white rounded-full" />
+                  <span>deleting...</span>
+                </>
+              ) : (
+                <>
+                  <span
+                    className="material-symbols-outlined text-lg"
+                    style={{ fontVariationSettings: "'wght' 400" }}
+                  >
+                    delete_forever
+                  </span>
+                  <span>delete my account</span>
+                </>
+              )}
+            </button>
 
-          {/* Hairline separator */}
-          <div className="h-[0.5px] bg-[#C6C6C8]" />
+            {/* Keep — outlined white */}
+            <button
+              onClick={handleClose}
+              disabled={isDeleting}
+              className="w-full h-12 border border-black bg-white text-black font-medium text-[0.8rem] hover:bg-gray-50 transition-colors active:scale-[0.99] disabled:opacity-50 lowercase"
+            >
+              keep my account
+            </button>
 
-          {/* Delete Button — iOS style: destructive red, regular weight */}
-          <button
-            onClick={handleDeleteAccount}
-            disabled={!isDeleteEnabled || isDeleting}
-            className="w-full h-[44px] text-[17px] font-normal text-[#FF3B30] active:bg-[#E5E5EA] transition-colors disabled:text-[#FF3B30]/30 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-          >
-            {isDeleting ? (
-              <>
-                <span className="material-symbols-outlined text-[18px] animate-spin">progress_activity</span>
-                <span>{t("deleteAccount.deleting")}</span>
-              </>
-            ) : (
-              <>
-                <span
-                  className="material-symbols-outlined text-[18px]"
-                  style={{ fontVariationSettings: "'FILL' 1, 'wght' 400" }}
-                >
-                  delete
-                </span>
-                <span>{t("deleteAccount.confirmDelete")}</span>
-              </>
-            )}
-          </button>
+            {/* Cancel — text link */}
+            <div className="pt-2">
+              <button
+                onClick={handleClose}
+                disabled={isDeleting}
+                className="text-xs font-medium text-gray-400 hover:text-black transition-colors lowercase disabled:opacity-50"
+              >
+                cancel
+              </button>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/pages/delete-account/ui.tsx
+++ b/src/pages/delete-account/ui.tsx
@@ -1,6 +1,8 @@
 /**
- * Delete Account Page — Aligned with onboarding step 1-8 design language.
- * Uses Playfair Display headings, lowercase, HushhTechCta, same spacing.
+ * Delete Account Page — Follows Step 1–8 design philosophy exactly.
+ * Playfair Display headings, all lowercase, black/white/gray palette,
+ * icon-circle rows, HushhTechBackHeader, HushhTechCta, glassmorphism modal.
+ * Logic stays in logic.ts — zero logic changes.
  */
 import React from "react";
 import { useNavigate } from "react-router-dom";
@@ -11,6 +13,41 @@ import HushhTechCta, {
 } from "../../components/hushh-tech-cta/HushhTechCta";
 import DeleteAccountModal from "../../components/DeleteAccountModal";
 import { Helmet } from "react-helmet";
+
+/* ── Data items for deletion list ── */
+const DELETION_ITEMS = [
+  { icon: "person", label: "account credentials & profile" },
+  { icon: "analytics", label: "investor profile & preferences" },
+  { icon: "checklist", label: "onboarding data & responses" },
+  { icon: "verified_user", label: "kyc verification data" },
+  { icon: "chat", label: "chat history with ai assistant" },
+  { icon: "folder", label: "uploaded documents & files" },
+  { icon: "shield", label: "privacy settings & data vault" },
+];
+
+/* ── Retention policy items ── */
+const RETENTION_ITEMS = [
+  {
+    icon: "bolt",
+    title: "immediate",
+    desc: "all personal data is deleted upon confirmation",
+  },
+  {
+    icon: "schedule",
+    title: "30 days",
+    desc: "encrypted backups are purged within 30 days",
+  },
+  {
+    icon: "gavel",
+    title: "7 years",
+    desc: "transaction records retained per financial regulations",
+  },
+  {
+    icon: "analytics",
+    title: "anonymized",
+    desc: "aggregated analytics that cannot identify you may be kept",
+  },
+];
 
 const DeleteAccountPage: React.FC = () => {
   const navigate = useNavigate();
@@ -35,80 +72,82 @@ const DeleteAccountPage: React.FC = () => {
         />
       </Helmet>
 
-      <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-black selection:text-white">
-        {/* ═══ Header ═══ */}
-        <HushhTechBackHeader
-          onBackClick={() => navigate(-1)}
-          rightType="hamburger"
-        />
+      <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-black selection:text-white relative overflow-hidden">
+        {/* ═══ Background layer (blurs when modal is open) ═══ */}
+        <div
+          className={`flex-1 flex flex-col transition-all duration-300 ${
+            isOpen
+              ? "scale-[0.98] blur-[2px] opacity-40 pointer-events-none select-none"
+              : ""
+          }`}
+        >
+          {/* ═══ Header ═══ */}
+          <HushhTechBackHeader
+            onBackClick={() => navigate(-1)}
+            rightType="hamburger"
+          />
 
-        <main className="px-6 flex-grow max-w-md mx-auto w-full pb-16">
-          {/* ── Title Section ── */}
-          <section className="py-8">
-            <h1
-              className="text-[2.25rem] leading-[1.1] font-medium text-black tracking-tight lowercase"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
-              delete your <br />
-              <span className="text-gray-400">account</span>
-            </h1>
-            <p className="text-gray-500 text-sm font-light mt-3 lowercase leading-relaxed">
-              permanently remove your account and all associated data
-            </p>
-          </section>
-
-          {/* ── Action Card ── */}
-          <section className="mb-10 border border-red-200 bg-red-50/30 rounded-none p-6">
-            {isLoading ? (
-              <div className="flex items-center justify-center py-8">
-                <div className="w-6 h-6 border-2 border-gray-300 border-t-black rounded-full animate-spin" />
-                <span className="ml-3 text-sm text-gray-500 lowercase">
-                  checking session...
+          <main className="px-6 flex-grow max-w-md mx-auto w-full pb-16">
+            {/* ── Title Section ── */}
+            <section className="py-8">
+              <h3 className="text-[11px] tracking-wide text-gray-500 lowercase mb-4 font-semibold">
+                account settings
+              </h3>
+              <h1
+                className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight lowercase"
+                style={{ fontFamily: "'Playfair Display', serif" }}
+              >
+                delete your
+                <br />
+                <span className="text-gray-400 italic font-normal">
+                  account
                 </span>
-              </div>
-            ) : isLoggedIn ? (
-              <div className="space-y-4">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center shrink-0">
+              </h1>
+              <p className="text-sm text-gray-500 mt-4 leading-relaxed lowercase font-medium">
+                permanently remove your account and all associated data from our
+                systems.
+              </p>
+            </section>
+
+            {/* ── Session Status Row ── */}
+            <section className="mb-2">
+              {isLoading ? (
+                <div className="flex items-center gap-4 py-5 border-b border-gray-200">
+                  <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                    <div className="animate-spin h-5 w-5 border-2 border-gray-300 border-t-black rounded-full" />
+                  </div>
+                  <p className="text-sm font-medium text-gray-700 lowercase">
+                    checking session...
+                  </p>
+                </div>
+              ) : isLoggedIn ? (
+                <div className="flex items-center gap-4 py-5 border-b border-gray-200">
+                  <div className="w-10 h-10 rounded-full bg-green-50 border border-green-200 flex items-center justify-center shrink-0">
                     <span
-                      className="material-symbols-outlined text-red-600 text-lg"
-                      style={{ fontVariationSettings: "'wght' 400" }}
+                      className="material-symbols-outlined text-green-600 text-lg"
+                      style={{
+                        fontVariationSettings: "'FILL' 1, 'wght' 600",
+                      }}
                     >
-                      warning
+                      check
                     </span>
                   </div>
                   <div>
                     <p className="text-sm font-semibold text-gray-900 lowercase">
-                      ready to delete?
+                      logged in
                     </p>
                     {userEmail && (
-                      <p className="text-xs text-gray-500 lowercase">
-                        logged in as {userEmail}
+                      <p className="text-xs text-gray-500 lowercase font-medium">
+                        {userEmail}
                       </p>
                     )}
                   </div>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed lowercase">
-                  this action is permanent and cannot be undone. all your data,
-                  investment info, and services will be removed.
-                </p>
-                <button
-                  type="button"
-                  onClick={onOpen}
-                  className="w-full h-[52px] bg-red-600 text-white text-sm font-medium lowercase flex items-center justify-center gap-2 active:scale-[0.98] transition-transform hover:bg-red-700"
-                >
-                  <span className="material-symbols-outlined text-lg">
-                    delete_forever
-                  </span>
-                  delete my account
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                <div className="flex items-center gap-3">
+              ) : (
+                <div className="flex items-center gap-4 py-5 border-b border-gray-200">
                   <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
                     <span
-                      className="material-symbols-outlined text-gray-600 text-lg"
+                      className="material-symbols-outlined text-gray-700 text-lg"
                       style={{ fontVariationSettings: "'wght' 400" }}
                     >
                       lock
@@ -118,166 +157,194 @@ const DeleteAccountPage: React.FC = () => {
                     <p className="text-sm font-semibold text-gray-900 lowercase">
                       login required
                     </p>
-                    <p className="text-xs text-gray-500 lowercase">
+                    <p className="text-xs text-gray-500 lowercase font-medium">
                       please login to delete your account
                     </p>
                   </div>
                 </div>
+              )}
+            </section>
+
+            {/* ── What Gets Deleted ── */}
+            <section className="mb-8">
+              <h2
+                className="text-xl font-normal text-black tracking-tight lowercase mb-1 pt-6"
+                style={{ fontFamily: "'Playfair Display', serif" }}
+              >
+                data that will be deleted
+              </h2>
+              <p className="text-xs text-gray-500 lowercase font-medium mb-5">
+                the following data will be permanently removed
+              </p>
+
+              <div className="space-y-0">
+                {DELETION_ITEMS.map((item, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center gap-4 py-4 border-b border-gray-200"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                      <span
+                        className="material-symbols-outlined text-gray-700 text-lg"
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        {item.icon}
+                      </span>
+                    </div>
+                    <span className="text-sm text-gray-900 lowercase font-medium">
+                      {item.label}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* ── Retention Policy ── */}
+            <section className="mb-8">
+              <h2
+                className="text-xl font-normal text-black tracking-tight lowercase mb-1"
+                style={{ fontFamily: "'Playfair Display', serif" }}
+              >
+                retention policy
+              </h2>
+              <p className="text-xs text-gray-500 lowercase font-medium mb-5">
+                some data may be retained as required by law
+              </p>
+
+              <div className="space-y-0">
+                {RETENTION_ITEMS.map((item, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center gap-4 py-4 border-b border-gray-200"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                      <span
+                        className="material-symbols-outlined text-gray-700 text-lg"
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        {item.icon}
+                      </span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-semibold text-gray-900 lowercase mb-0.5">
+                        {item.title}
+                      </p>
+                      <p className="text-xs text-gray-500 lowercase font-medium">
+                        {item.desc}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* ── Need Help ── */}
+            <section className="mb-8">
+              <h2
+                className="text-xl font-normal text-black tracking-tight lowercase mb-1"
+                style={{ fontFamily: "'Playfair Display', serif" }}
+              >
+                need help?
+              </h2>
+              <p className="text-xs text-gray-500 lowercase font-medium mb-5">
+                if you're unable to access your account, contact us directly
+              </p>
+
+              <a
+                href="mailto:support@hushh.ai"
+                className="flex items-center gap-4 py-4 border-b border-gray-200 group"
+              >
+                <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 group-hover:bg-gray-200 transition-colors">
+                  <span
+                    className="material-symbols-outlined text-gray-700 text-lg"
+                    style={{ fontVariationSettings: "'wght' 400" }}
+                  >
+                    mail
+                  </span>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900 lowercase">
+                    support@hushh.ai
+                  </p>
+                  <p className="text-xs text-gray-500 lowercase font-medium">
+                    general support
+                  </p>
+                </div>
+              </a>
+
+              <a
+                href="mailto:privacy@hushh.ai"
+                className="flex items-center gap-4 py-4 border-b border-gray-200 group"
+              >
+                <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 group-hover:bg-gray-200 transition-colors">
+                  <span
+                    className="material-symbols-outlined text-gray-700 text-lg"
+                    style={{ fontVariationSettings: "'wght' 400" }}
+                  >
+                    shield
+                  </span>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-gray-900 lowercase">
+                    privacy@hushh.ai
+                  </p>
+                  <p className="text-xs text-gray-500 lowercase font-medium">
+                    privacy & data requests
+                  </p>
+                </div>
+              </a>
+            </section>
+
+            {/* ── CTAs ── */}
+            <section className="pb-12 space-y-3 mt-4">
+              {isLoggedIn ? (
+                <HushhTechCta
+                  variant={HushhTechCtaVariant.BLACK}
+                  onClick={onOpen}
+                >
+                  delete my account
+                </HushhTechCta>
+              ) : (
                 <HushhTechCta
                   variant={HushhTechCtaVariant.BLACK}
                   onClick={handleLoginRedirect}
                 >
                   login to continue
                 </HushhTechCta>
+              )}
+
+              <HushhTechCta
+                variant={HushhTechCtaVariant.WHITE}
+                onClick={() => navigate("/")}
+              >
+                go to home
+              </HushhTechCta>
+            </section>
+
+            {/* ── Trust Badges ── */}
+            <section className="flex flex-col items-center justify-center text-center gap-2 pb-8">
+              <div className="flex items-center gap-1">
+                <span className="material-symbols-outlined text-[12px] text-gray-600">
+                  lock
+                </span>
+                <span className="text-[10px] text-gray-600 tracking-wide uppercase font-medium">
+                  256 bit encryption
+                </span>
               </div>
-            )}
-          </section>
+              <p className="text-[10px] text-gray-400 lowercase">
+                hushh technologies inc.
+              </p>
+            </section>
+          </main>
+        </div>
 
-          {/* ── What Gets Deleted ── */}
-          <section className="mb-10">
-            <h2
-              className="text-xl font-medium text-black tracking-tight lowercase mb-5"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
-              data that will be deleted
-            </h2>
-            <div className="space-y-0">
-              {[
-                { icon: "person", label: "account credentials & profile" },
-                { icon: "analytics", label: "investor profile & preferences" },
-                { icon: "checklist", label: "onboarding data & responses" },
-                { icon: "verified_user", label: "kyc verification data" },
-                { icon: "chat", label: "chat history with ai assistant" },
-                { icon: "folder", label: "uploaded documents & files" },
-                { icon: "shield", label: "privacy settings & data vault" },
-              ].map((item, idx) => (
-                <div
-                  key={idx}
-                  className="flex items-center gap-4 py-3.5 border-b border-gray-100"
-                >
-                  <span
-                    className="material-symbols-outlined text-gray-400 text-lg"
-                    style={{ fontVariationSettings: "'wght' 300" }}
-                  >
-                    {item.icon}
-                  </span>
-                  <span className="text-sm text-gray-700 lowercase font-light">
-                    {item.label}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          {/* ── Retention Policy ── */}
-          <section className="mb-10">
-            <h2
-              className="text-xl font-medium text-black tracking-tight lowercase mb-5"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
-              retention policy
-            </h2>
-            <div className="space-y-4">
-              {[
-                {
-                  title: "immediate",
-                  desc: "all personal data is deleted upon confirmation",
-                },
-                {
-                  title: "30 days",
-                  desc: "encrypted backups are purged within 30 days",
-                },
-                {
-                  title: "7 years",
-                  desc: "transaction records retained per financial regulations",
-                },
-                {
-                  title: "anonymized",
-                  desc: "aggregated analytics that cannot identify you may be kept",
-                },
-              ].map((item, idx) => (
-                <div key={idx} className="flex items-start gap-4">
-                  <span className="text-[10px] uppercase tracking-widest text-gray-400 font-semibold w-20 shrink-0 pt-0.5">
-                    {item.title}
-                  </span>
-                  <p className="text-sm text-gray-600 lowercase font-light leading-relaxed">
-                    {item.desc}
-                  </p>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          {/* ── Need Help ── */}
-          <section className="mb-10 border-t border-gray-100 pt-8">
-            <h2
-              className="text-xl font-medium text-black tracking-tight lowercase mb-4"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
-              need help?
-            </h2>
-            <p className="text-sm text-gray-500 lowercase font-light leading-relaxed mb-4">
-              if you're unable to access your account, contact us directly:
-            </p>
-            <div className="space-y-2">
-              <a
-                href="mailto:support@hushh.ai"
-                className="flex items-center gap-3 py-3 border-b border-gray-100 group"
-              >
-                <span className="material-symbols-outlined text-gray-400 text-lg">
-                  mail
-                </span>
-                <span className="text-sm text-gray-700 lowercase font-light group-hover:text-black transition-colors">
-                  support@hushh.ai
-                </span>
-              </a>
-              <a
-                href="mailto:privacy@hushh.ai"
-                className="flex items-center gap-3 py-3 border-b border-gray-100 group"
-              >
-                <span className="material-symbols-outlined text-gray-400 text-lg">
-                  shield
-                </span>
-                <span className="text-sm text-gray-700 lowercase font-light group-hover:text-black transition-colors">
-                  privacy@hushh.ai
-                </span>
-              </a>
-            </div>
-          </section>
-
-          {/* ── CTAs ── */}
-          <section className="pb-12 space-y-3">
-            <HushhTechCta
-              variant={HushhTechCtaVariant.WHITE}
-              onClick={() => navigate("/")}
-            >
-              go to home
-            </HushhTechCta>
-          </section>
-
-          {/* ── Trust Badges ── */}
-          <section className="flex flex-col items-center justify-center text-center gap-2 pb-8">
-            <div className="flex items-center gap-1">
-              <span className="material-symbols-outlined text-[12px] text-gray-400">
-                lock
-              </span>
-              <span className="text-[10px] text-gray-400 tracking-wide uppercase font-medium">
-                256 bit encryption
-              </span>
-            </div>
-            <p className="text-[10px] text-gray-400 lowercase">
-              hushh technologies inc.
-            </p>
-          </section>
-        </main>
+        {/* ═══ Delete Account Modal — Glassmorphism (matches Step 4 location modal) ═══ */}
+        <DeleteAccountModal
+          isOpen={isOpen}
+          onClose={onClose}
+          onAccountDeleted={handleAccountDeleted}
+        />
       </div>
-
-      {/* Delete Account Modal */}
-      <DeleteAccountModal
-        isOpen={isOpen}
-        onClose={onClose}
-        onAccountDeleted={handleAccountDeleted}
-      />
     </>
   );
 };


### PR DESCRIPTION
## Changes

**Delete Account Page (ui.tsx):**
- Playfair Display headings, all lowercase, italic gray-400 accent
- Session status as icon-circle row with green check/lock icon
- All items use w-10 h-10 rounded-full bg-gray-100 icon circles with border-b dividers
- HushhTechCta for primary/secondary buttons
- Background blurs when modal is open
- Trust badge at bottom

**Delete Account Modal (DeleteAccountModal.tsx):**
- iOS-native style replaced with glassmorphism modal (Step 4 pattern)
- bg-white/60 backdrop-blur-sm frosted overlay
- rounded-3xl card, bottom-sheet mobile, centered desktop
- Playfair Display heading, black/white buttons
- All backend logic UNTOUCHED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Delete Account modal with frosted glass styling and improved mobile experience (bottom-sheet layout on smaller screens).
  * Enhanced Delete Account page with expanded sections including data deletion information, retention policy details, and help/contact resources.
  * Updated button styling and interaction flow for clearer account deletion confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->