### PR TITLE
fix: remove hardcoded 100 hushh coins, ensure 300,000 everywhere

### DIFF
--- a/src/pages/your-profile/index.tsx
+++ b/src/pages/your-profile/index.tsx
@@ -298,7 +298,7 @@ const ProfilePage = () => {
                     country: "test country",
                     email: userEmail || "test@example.com",
                     zipcode: "12345",
-                    user_coins: 100,
+                    user_coins: 300000,
                     dob: "1990-01-15",
                     phone_number: "+1234567890",
                     investor_type: "Individual Investor",


### PR DESCRIPTION
## Fix
- Updated mock `user_coins` from 100 to 300,000 in your-profile test data
- All code paths already use 300,000 correctly (meet-ceo logic, coupon, stripe)

## ⚠️ DB ACTION NEEDED
Run this on **Supabase Dashboard SQL Editor** to fix existing users:
```sql
ALTER TABLE ceo_meeting_payments ALTER COLUMN hushh_coins_awarded SET DEFAULT 300000;
UPDATE ceo_meeting_payments SET hushh_coins_awarded = 300000 WHERE hushh_coins_awarded = 100;
```
This is from migration `20260223200000_update_hushh_coins_default.sql`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test data values in the profile section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->