### PR TITLE
fix: make home page fully responsive for tablet & desktop

### DIFF
--- a/src/components/hushh-tech-cta/HushhTechCta.tsx
+++ b/src/components/hushh-tech-cta/HushhTechCta.tsx
@@ -41,8 +41,8 @@ const VARIANT_CLASSES: Record<HushhTechCtaVariant, string> = {
 
 /** Base classes shared by both variants */
 const BASE_CLASSES = [
-  "w-full h-14",
-  "font-semibold text-sm tracking-wide",
+  "w-full h-14 md:h-11 rounded-xl",
+  "font-semibold text-sm tracking-wide whitespace-nowrap",
   "flex items-center justify-center gap-2",
   "disabled:opacity-50 disabled:cursor-not-allowed",
 ].join(" ");

--- a/src/components/hushh-tech-footer/HushhTechFooter.tsx
+++ b/src/components/hushh-tech-footer/HushhTechFooter.tsx
@@ -140,8 +140,8 @@ const HushhTechFooter: React.FC<HushhTechFooterProps> = ({
     <div
       className={`fixed bottom-0 left-0 right-0 z-50 px-4 pb-6 pt-4 pointer-events-none ${className}`}
     >
-      <div className="relative max-w-md mx-auto pointer-events-auto">
-        <div className="h-[72px] bg-[#050505] rounded-[2rem] flex items-center justify-between px-8 relative shadow-2xl">
+      <div className="relative max-w-md sm:max-w-lg md:max-w-xl mx-auto pointer-events-auto">
+        <div className="h-[72px] bg-[#050505] rounded-[2rem] flex items-center justify-between px-8 md:px-12 relative shadow-2xl">
           {/* Center Hushh logo — ALWAYS goes to /community (blogs) */}
           <div className="absolute left-1/2 -top-6 -translate-x-1/2 z-10">
             <button

--- a/src/components/hushh-tech-header/HushhTechHeader.tsx
+++ b/src/components/hushh-tech-header/HushhTechHeader.tsx
@@ -27,7 +27,7 @@ const HushhTechHeader: React.FC<HushhTechHeaderProps> = ({
   return (
     <>
       <header
-        className={`${positionClasses} bg-white px-6 py-4 flex justify-between items-center transition-all duration-300 ${className}`}
+        className={`${positionClasses} bg-white px-5 sm:px-6 md:px-8 lg:px-12 py-4 md:py-5 flex justify-between items-center transition-all duration-300 max-w-md sm:max-w-lg md:max-w-3xl lg:max-w-5xl xl:max-w-6xl mx-auto w-full ${className}`}
       >
         {/* Logo + Brand */}
         <div className="flex items-center gap-3">

--- a/src/pages/home/ui.tsx
+++ b/src/pages/home/ui.tsx
@@ -1,8 +1,12 @@
 /**
  * Home Page — UI / Presentation
- * Follows the same design language as onboarding steps 1-8,
- * profile page, login/signup — Playfair Display headings,
- * font-medium weight, max-w-md centered layout.
+ * Fully responsive: mobile-first, scales beautifully on tablet & desktop.
+ *
+ * Breakpoints:
+ *   - Mobile: < 768px (default)
+ *   - Tablet: md (768px+)
+ *   - Desktop: lg (1024px+)
+ *   - Large Desktop: xl (1280px+)
  *
  * Apple iOS Core App Colors:
  * - System Blue (#0066CC) for interactive elements
@@ -15,8 +19,7 @@
  */
 import { useHomeLogic } from "./logic";
 import HushhTechHeader from "../../components/hushh-tech-header/HushhTechHeader";
-import HushhTechFooter, {
-} from "../../components/hushh-tech-footer/HushhTechFooter";
+import HushhTechFooter from "../../components/hushh-tech-footer/HushhTechFooter";
 import HushhTechCta, {
   HushhTechCtaVariant,
 } from "../../components/hushh-tech-cta/HushhTechCta";
@@ -38,32 +41,92 @@ export default function HomePage() {
         className="sticky top-0 z-50 border-b border-transparent"
       />
 
-      {/* ═══ Main Content — max-w-md centered like all other pages ═══ */}
-      <main className="flex-1 px-6 pb-32 flex flex-col gap-12 pt-4 max-w-md mx-auto w-full">
+      {/* ═══ Main Content — responsive container ═══ */}
+      <main className="flex-1 px-5 sm:px-6 md:px-8 lg:px-12 pb-32 flex flex-col gap-10 md:gap-14 lg:gap-16 pt-4 md:pt-8 max-w-md sm:max-w-lg md:max-w-3xl lg:max-w-5xl xl:max-w-6xl mx-auto w-full">
 
         {/* ── Hero ── */}
-        <section className="py-4">
-          <div className="inline-block px-3 py-1 mb-5 border border-hushh-blue/20 rounded-full bg-hushh-blue/5">
-            <span className="text-[10px] tracking-widest uppercase font-medium text-hushh-blue flex items-center gap-1">
-              <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
-              AI-Powered Investing
-            </span>
+        <section className="py-4 md:py-8 lg:py-12 md:flex md:items-center md:justify-between md:gap-12">
+          <div className="md:flex-1 md:max-w-xl">
+            <div className="inline-block px-3 py-1 mb-5 border border-hushh-blue/20 rounded-full bg-hushh-blue/5">
+              <span className="text-[10px] md:text-xs tracking-widest uppercase font-medium text-hushh-blue flex items-center gap-1">
+                <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
+                AI-Powered Investing
+              </span>
+            </div>
+            <h1
+              className="text-[2.75rem] md:text-5xl lg:text-6xl xl:text-7xl leading-[1.1] font-normal text-black tracking-tight font-serif"
+              style={playfair}
+            >
+              Investing in <br className="md:hidden" />
+              <span className="hidden md:inline"> </span>
+              the{" "}
+              <span className="text-gray-400 italic font-light">Future.</span>
+            </h1>
+            <p className="text-gray-500 text-sm md:text-base lg:text-lg font-light mt-3 md:mt-5 leading-relaxed max-w-sm md:max-w-md">
+              The world's first AI-powered Berkshire Hathaway. Merging rigorous
+              data science with human wisdom.
+            </p>
+
+            {/* Desktop CTAs — shown inline on md+ */}
+            <div className="hidden md:flex gap-3 mt-8 max-w-md">
+              <HushhTechCta
+                onClick={primaryCTA.action}
+                disabled={primaryCTA.loading}
+                variant={HushhTechCtaVariant.BLACK}
+                className="flex-1"
+              >
+                {primaryCTA.text}
+                <span className="material-symbols-outlined thin-icon text-lg">arrow_forward</span>
+              </HushhTechCta>
+              <HushhTechCta
+                onClick={() => onNavigate("/discover-fund-a")}
+                variant={HushhTechCtaVariant.WHITE}
+                className="flex-1"
+              >
+                Discover Fund A
+              </HushhTechCta>
+            </div>
           </div>
-          <h1
-            className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight font-serif"
-            style={playfair}
-          >
-            Investing in <br /> the{" "}
-            <span className="text-gray-400 italic font-light">Future.</span>
-          </h1>
-          <p className="text-gray-500 text-sm font-light mt-3 leading-relaxed max-w-sm">
-            The world's first AI-powered Berkshire Hathaway. Merging rigorous
-            data science with human wisdom.
-          </p>
+
+          {/* Right side — feature cards on desktop (side by side with hero) */}
+          <div className="hidden lg:flex flex-col gap-4 w-80 xl:w-96 shrink-0">
+            <div className="bg-ios-gray-bg p-6 rounded-2xl border border-gray-200/60 flex flex-col justify-between min-h-[160px] hover:border-hushh-blue/30 transition-colors">
+              <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-hushh-blue">
+                neurology
+              </span>
+              <div>
+                <h3
+                  className="text-lg font-medium mb-1 font-serif"
+                  style={playfair}
+                >
+                  AI-Powered
+                </h3>
+                <p className="text-xs text-gray-500 font-light leading-relaxed">
+                  Institutional analytics processing millions of signals.
+                </p>
+              </div>
+            </div>
+            <div className="bg-ios-gray-bg p-6 rounded-2xl border border-gray-200/60 flex flex-col justify-between min-h-[160px] hover:border-hushh-blue/30 transition-colors">
+              <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-ios-dark">
+                supervised_user_circle
+              </span>
+              <div>
+                <h3
+                  className="text-lg font-medium mb-1 font-serif"
+                  style={playfair}
+                >
+                  Human-Led
+                </h3>
+                <p className="text-xs text-gray-500 font-light leading-relaxed">
+                  Seasoned oversight ensuring long-term strategic vision.
+                </p>
+              </div>
+            </div>
+          </div>
         </section>
 
-        {/* ── Feature Cards (AI-Powered / Human-Led) ── */}
-        <section className="grid grid-cols-2 gap-4">
+        {/* ── Feature Cards — visible on mobile & tablet, hidden on lg+ (shown in hero) ── */}
+        <section className="grid grid-cols-2 gap-4 lg:hidden">
           <div className="bg-ios-gray-bg p-5 rounded-2xl border border-gray-200/60 flex flex-col justify-between min-h-[180px] hover:border-hushh-blue/30 transition-colors">
             <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-hushh-blue">
               neurology
@@ -98,8 +161,8 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* ── Primary CTAs ── */}
-        <section className="flex flex-col gap-3">
+        {/* ── Primary CTAs — mobile only ── */}
+        <section className="flex flex-col gap-3 md:hidden">
           <HushhTechCta
             onClick={primaryCTA.action}
             disabled={primaryCTA.loading}
@@ -117,21 +180,21 @@ export default function HomePage() {
         </section>
 
         {/* ── Trust strip ── */}
-        <section className="border-t border-b border-gray-100 py-5 flex justify-center items-center gap-6">
+        <section className="border-t border-b border-gray-100 py-5 md:py-6 flex justify-center items-center gap-6 md:gap-10">
           <div className="flex items-center gap-2">
-            <span className="material-symbols-outlined thin-icon text-lg text-ios-green">
+            <span className="material-symbols-outlined thin-icon text-lg md:text-xl text-ios-green">
               verified_user
             </span>
-            <span className="text-[10px] font-medium tracking-widest uppercase text-gray-400">
+            <span className="text-[10px] md:text-xs font-medium tracking-widest uppercase text-gray-400">
               SEC Registered
             </span>
           </div>
           <div className="w-1 h-1 bg-gray-300 rounded-full" />
           <div className="flex items-center gap-2">
-            <span className="material-symbols-outlined thin-icon text-lg text-hushh-blue">
+            <span className="material-symbols-outlined thin-icon text-lg md:text-xl text-hushh-blue">
               lock
             </span>
-            <span className="text-[10px] font-medium tracking-widest uppercase text-gray-400">
+            <span className="text-[10px] md:text-xs font-medium tracking-widest uppercase text-gray-400">
               Bank Level Security
             </span>
           </div>
@@ -139,14 +202,16 @@ export default function HomePage() {
 
         {/* ── The Hushh Advantage ── */}
         <section>
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-2 font-medium">Why Hushh</p>
+          <p className="text-[10px] md:text-xs uppercase tracking-[0.2em] text-gray-400 mb-2 font-medium">
+            Why Hushh
+          </p>
           <h2
-            className="text-2xl font-medium mb-8 tracking-tight font-serif"
+            className="text-2xl md:text-3xl lg:text-4xl font-medium mb-8 md:mb-10 tracking-tight font-serif"
             style={playfair}
           >
             The Hushh Advantage
           </h2>
-          <div className="grid grid-cols-2 gap-x-4 gap-y-10">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-x-4 gap-y-10 md:gap-x-6 lg:gap-x-8">
             {[
               { icon: "analytics", color: "text-hushh-blue", bg: "bg-hushh-blue/10", title: "Data Driven", desc: "Decisions based on facts, not emotions." },
               { icon: "savings", color: "text-ios-green", bg: "bg-ios-green/10", title: "Low Fees", desc: "More of your returns stay in your pocket." },
@@ -154,12 +219,12 @@ export default function HomePage() {
               { icon: "autorenew", color: "text-hushh-blue", bg: "bg-hushh-blue/10", title: "Automated", desc: "Set it and forget it peace of mind." },
             ].map((item) => (
               <div key={item.icon} className="flex flex-col items-center text-center gap-3">
-                <div className={`w-12 h-12 rounded-full border border-gray-200/60 flex items-center justify-center ${item.bg}`}>
+                <div className={`w-12 h-12 md:w-14 md:h-14 rounded-full border border-gray-200/60 flex items-center justify-center ${item.bg}`}>
                   <span className={`material-symbols-outlined thin-icon ${item.color}`}>{item.icon}</span>
                 </div>
                 <div>
-                  <h4 className="font-medium text-sm mb-1">{item.title}</h4>
-                  <p className="text-[11px] text-gray-500 font-light max-w-[120px] mx-auto">
+                  <h4 className="font-medium text-sm md:text-base mb-1">{item.title}</h4>
+                  <p className="text-[11px] md:text-xs text-gray-500 font-light max-w-[120px] md:max-w-[160px] mx-auto">
                     {item.desc}
                   </p>
                 </div>
@@ -168,41 +233,42 @@ export default function HomePage() {
           </div>
         </section>
 
-        {/* ── Fund A Card ── */}
-        <section className="relative mt-4">
-          <div className="bg-ios-dark text-white p-8 rounded-2xl relative overflow-hidden shadow-2xl">
-            {/* Glow effects — Apple blue accent */}
+        {/* ── Fund A Card + Feature Grid — side by side on lg+ ── */}
+        <section className="lg:grid lg:grid-cols-2 lg:gap-8 xl:gap-12 space-y-10 lg:space-y-0 relative mt-4 lg:mt-0">
+          {/* Fund A Card */}
+          <div className="bg-ios-dark text-white p-8 md:p-10 rounded-2xl relative overflow-hidden shadow-2xl lg:flex lg:flex-col lg:justify-center">
+            {/* Glow effects */}
             <div className="absolute -top-10 -right-10 w-40 h-40 bg-hushh-blue/15 rounded-full blur-3xl" />
             <div className="absolute bottom-0 left-0 w-full h-1/2 bg-gradient-to-t from-hushh-blue/5 to-transparent" />
 
             <div className="relative z-10 flex flex-col gap-6">
               <div className="flex justify-between items-start">
                 <div>
-                  <span className="text-[10px] font-medium tracking-widest uppercase text-white/50 mb-1 block">
+                  <span className="text-[10px] md:text-xs font-medium tracking-widest uppercase text-white/50 mb-1 block">
                     Flagship Product
                   </span>
                   <h2
-                    className="text-3xl font-medium font-serif"
+                    className="text-3xl md:text-4xl font-medium font-serif"
                     style={playfair}
                   >
                     Fund A
                   </h2>
                 </div>
-                <span className="bg-hushh-blue/20 backdrop-blur-md px-3 py-1 rounded-full text-[10px] font-medium uppercase tracking-wider border border-hushh-blue/30 text-hushh-blue">
+                <span className="bg-hushh-blue/20 backdrop-blur-md px-3 py-1 rounded-full text-[10px] md:text-xs font-medium uppercase tracking-wider border border-hushh-blue/30 text-hushh-blue">
                   High Growth
                 </span>
               </div>
 
               <div className="space-y-4 my-2">
                 <div>
-                  <span className="text-xs text-white/50 block mb-1">Target Net IRR</span>
-                  <span className="text-4xl font-mono font-light tracking-tighter text-ios-green">
+                  <span className="text-xs md:text-sm text-white/50 block mb-1">Target Net IRR</span>
+                  <span className="text-4xl md:text-5xl font-mono font-light tracking-tighter text-ios-green">
                     18-23%
                   </span>
                 </div>
                 <div>
-                  <span className="text-xs text-white/50 block mb-1">Inception Year</span>
-                  <span className="font-mono text-xl">2024</span>
+                  <span className="text-xs md:text-sm text-white/50 block mb-1">Inception Year</span>
+                  <span className="font-mono text-xl md:text-2xl">2024</span>
                 </div>
               </div>
 
@@ -214,7 +280,7 @@ export default function HomePage() {
                 aria-label="View performance details"
                 onKeyDown={(e) => { if (e.key === 'Enter') onNavigate("/discover-fund-a"); }}
               >
-                <span className="text-xs font-medium tracking-wide uppercase text-hushh-blue">
+                <span className="text-xs md:text-sm font-medium tracking-wide uppercase text-hushh-blue">
                   Performance Details
                 </span>
                 <span className="material-symbols-outlined thin-icon text-sm text-hushh-blue group-hover:translate-x-1 transition-transform">
@@ -223,10 +289,8 @@ export default function HomePage() {
               </div>
             </div>
           </div>
-        </section>
 
-        {/* ── Feature Grid ── */}
-        <section>
+          {/* Feature Grid */}
           <div className="grid grid-cols-2 gap-4">
             {[
               { icon: "rocket_launch", color: "text-hushh-blue", title: "High Growth", desc: "Accelerated returns strategy" },
@@ -234,12 +298,12 @@ export default function HomePage() {
               { icon: "trending_up", color: "text-ios-green", title: "Liquid", desc: "Quarterly redemption windows" },
               { icon: "security", color: "text-hushh-blue", title: "Secure", desc: "Regulated custodian assets" },
             ].map((item) => (
-              <div key={item.icon} className="bg-ios-gray-bg border border-gray-200/60 p-4 rounded-2xl hover:border-hushh-blue/30 transition-colors">
-                <span className={`material-symbols-outlined thin-icon ${item.color} mb-2`}>
+              <div key={item.icon} className="bg-ios-gray-bg border border-gray-200/60 p-4 md:p-5 lg:p-6 rounded-2xl hover:border-hushh-blue/30 transition-colors flex flex-col justify-center">
+                <span className={`material-symbols-outlined thin-icon ${item.color} mb-2 md:mb-3 text-2xl md:text-3xl`}>
                   {item.icon}
                 </span>
-                <h5 className="font-medium text-sm">{item.title}</h5>
-                <p className="text-[10px] text-gray-500 font-light">
+                <h5 className="font-medium text-sm md:text-base">{item.title}</h5>
+                <p className="text-[10px] md:text-xs text-gray-500 font-light mt-1">
                   {item.desc}
                 </p>
               </div>
@@ -248,7 +312,7 @@ export default function HomePage() {
         </section>
 
         {/* ── Bottom CTAs ── */}
-        <section className="flex flex-col gap-3 py-6">
+        <section className="flex flex-col sm:flex-row gap-3 py-6 sm:max-w-lg sm:mx-auto sm:w-full md:max-w-xl">
           <HushhTechCta
             onClick={() => onNavigate("/discover-fund-a")}
             variant={HushhTechCtaVariant.BLACK}
@@ -267,7 +331,7 @@ export default function HomePage() {
         {/* ── Disclaimer ── */}
         <footer className="mb-8">
           <p
-            className="text-[10px] text-gray-400 text-center leading-relaxed italic max-w-xs mx-auto font-serif"
+            className="text-[10px] md:text-xs text-gray-400 text-center leading-relaxed italic max-w-xs md:max-w-md mx-auto font-serif"
             style={playfair}
           >
             Investing involves risk, including possible loss of principal. Past
@@ -278,8 +342,7 @@ export default function HomePage() {
       </main>
 
       {/* ═══ Footer Nav ═══ */}
-      <HushhTechFooter
-      />
+      <HushhTechFooter />
     </div>
   );
 }


### PR DESCRIPTION
## Changes
- **Home page**: Responsive container scales from mobile (max-w-md) → tablet (max-w-3xl) → desktop (max-w-5xl/6xl)
- **Hero section**: Side-by-side layout on desktop (hero text + feature cards)
- **Grids**: 2-col on mobile → 4-col on tablet+ for advantage section; Fund A card + feature grid side-by-side on lg+
- **CTAs**: Mobile-stacked, desktop-inline; slimmer height on desktop (h-14 → md:h-11), whitespace-nowrap to prevent text wrapping
- **Header**: Responsive padding & matching responsive max-width
- **Footer**: Wider nav bar on tablet+ (sm:max-w-lg md:max-w-xl)
- **Typography**: All text sizes scale up on larger breakpoints

## Files Changed
- src/pages/home/ui.tsx
- src/components/hushh-tech-header/HushhTechHeader.tsx
- src/components/hushh-tech-footer/HushhTechFooter.tsx
- src/components/hushh-tech-cta/HushhTechCta.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Enhanced responsive design across header, footer, and call-to-action components for improved layout behavior at different screen sizes
  * Redesigned home page with mobile-first approach, responsive typography scaling, and reorganized feature cards optimized for mobile, tablet, and desktop viewing
  * Updated button styling with rounded corners and improved text handling for better visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->