### PR TITLE
fix: rename NWS to Net Worth Score in profile page

### DIFF
--- a/src/components/profile/NWSScoreBadge.tsx
+++ b/src/components/profile/NWSScoreBadge.tsx
@@ -53,7 +53,7 @@ const NWSScoreBadge = ({ result, loading = false, size = 'md', showBreakdown = f
     return (
       <div className="flex flex-col items-center gap-1 opacity-50">
         <div className="w-16 h-16 rounded-full border-4 border-dashed border-gray-200 flex items-center justify-center">
-          <span className="text-[11px] text-gray-400 font-medium">NWS</span>
+          <span className="text-[11px] text-gray-400 font-medium">Net Worth Score</span>
         </div>
         <p className="text-[11px] text-gray-400">No data</p>
       </div>
@@ -102,7 +102,7 @@ const NWSScoreBadge = ({ result, loading = false, size = 'md', showBreakdown = f
 
       {/* Label */}
       <div className="text-center">
-        <p className="text-[13px] font-semibold text-black">NWS</p>
+        <p className="text-[13px] font-semibold text-black">Net Worth Score</p>
         <p className="text-[11px]" style={{ color }}>{label}</p>
       </div>
 

--- a/src/pages/hushh-user-profile/ui.tsx
+++ b/src/pages/hushh-user-profile/ui.tsx
@@ -76,7 +76,7 @@ const HushhUserProfilePage: React.FC = () => {
             className="text-lg italic text-gray-400 font-serif"
             style={playfair}
           >
-            NWS
+            Net Worth Score
           </span>
           {nwsResult ? (
             <NWSScoreBadge result={nwsResult} loading={nwsLoading} size="sm" />


### PR DESCRIPTION
Renamed all user-facing 'NWS' labels to 'Net Worth Score' in the profile page and NWSScoreBadge component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Net Worth Score labels from "NWS" to "Net Worth Score" across the user profile interface, including the score badge and profile section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->