### PR TITLE
fix: CTA buttons wrap content on desktop with internal padding

### DIFF
--- a/src/components/hushh-tech-cta/HushhTechCta.tsx
+++ b/src/components/hushh-tech-cta/HushhTechCta.tsx
@@ -41,7 +41,7 @@ const VARIANT_CLASSES: Record<HushhTechCtaVariant, string> = {
 
 /** Base classes shared by both variants */
 const BASE_CLASSES = [
-  "w-full h-14 md:h-11 rounded-xl",
+  "w-full md:w-auto h-14 md:h-11 px-4 md:px-8 rounded-xl",
   "font-semibold text-sm tracking-wide whitespace-nowrap capitalize",
   "flex items-center justify-center gap-2",
   "disabled:opacity-50 disabled:cursor-not-allowed",

--- a/src/pages/home/ui.tsx
+++ b/src/pages/home/ui.tsx
@@ -68,12 +68,11 @@ export default function HomePage() {
             </p>
 
             {/* Desktop CTAs — shown inline on md+ */}
-            <div className="hidden md:flex gap-3 mt-8 max-w-md">
+            <div className="hidden md:flex gap-3 mt-8">
               <HushhTechCta
                 onClick={primaryCTA.action}
                 disabled={primaryCTA.loading}
                 variant={HushhTechCtaVariant.BLACK}
-                className="flex-1"
               >
                 {primaryCTA.text}
                 <span className="material-symbols-outlined thin-icon text-lg">arrow_forward</span>
@@ -81,7 +80,6 @@ export default function HomePage() {
               <HushhTechCta
                 onClick={() => onNavigate("/discover-fund-a")}
                 variant={HushhTechCtaVariant.WHITE}
-                className="flex-1"
               >
                 Discover Fund A
               </HushhTechCta>
@@ -312,7 +310,7 @@ export default function HomePage() {
         </section>
 
         {/* ── Bottom CTAs ── */}
-        <section className="flex flex-col sm:flex-row gap-3 py-6 sm:max-w-lg sm:mx-auto sm:w-full md:max-w-xl">
+        <section className="flex flex-col sm:flex-row sm:justify-center gap-3 py-6">
           <HushhTechCta
             onClick={() => onNavigate("/discover-fund-a")}
             variant={HushhTechCtaVariant.BLACK}


### PR DESCRIPTION
CTA buttons now wrap content (w-auto) on desktop instead of stretching full width. Added px-8 internal padding on md+. Removed flex-1 from home page hero CTAs. Bottom CTAs centered.