### PR TITLE
fix: NDA CTA stays full width on desktop

### DIFF
--- a/src/pages/sign-nda/index.tsx
+++ b/src/pages/sign-nda/index.tsx
@@ -386,11 +386,12 @@ const SignNDAPage: React.FC = () => {
         </section>
 
         {/* ── CTA — Sign & Continue ── */}
-        <section className="space-y-3 mb-8 md:max-w-sm md:mx-auto">
+        <section className="space-y-3 mb-8">
           <HushhTechCta
             variant={HushhTechCtaVariant.BLACK}
             onClick={handleSignNDA}
             disabled={!agreedToTerms || !signerName.trim() || isSubmitting}
+            className="md:w-full"
           >
             {isSubmitting ? 'signing...' : 'sign & continue'}
           </HushhTechCta>


### PR DESCRIPTION
Added md:w-full override to NDA page CTA button so it stays full width despite the global CTA component now using w-auto on desktop.