### PR TITLE
fix: Step 8 city not pre-filling — fuzzy matching + Plaid fallback

### DIFF
--- a/src/hooks/useLocationDropdowns.ts
+++ b/src/hooks/useLocationDropdowns.ts
@@ -18,7 +18,7 @@ interface CityItem {
   name: string;
 }
 
-interface LocationDropdownState {
+export interface LocationDropdownState {
   countries: DropdownItem[];
   states: DropdownItem[];
   cities: CityItem[];
@@ -136,21 +136,35 @@ export function useLocationDropdowns(
       states.find(s => s.isoCode.toLowerCase() === raw || s.name.toLowerCase() === raw) ||
       states.find(s => s.name.toLowerCase().includes(raw) || raw.includes(s.name.toLowerCase()));
 
-    if (match) setStateRaw(match.isoCode);
-    pendingState.current = null;
+    if (match) {
+      setStateRaw(match.isoCode);
+      pendingState.current = null;
+    }
+    /* Keep pendingState if no match — retry when states reload */
   }, [states, detectionVersion]);
 
   // Apply pending city when cities list loads OR detection version bumps
   useEffect(() => {
     if (cities.length === 0 || !pendingCity.current) return;
 
-    const raw = pendingCity.current.toLowerCase();
+    const raw = pendingCity.current.toLowerCase().replace(/[-]/g, ' ');
+    /* Normalize city names: strip hyphens, trim, compare loosely */
+    const normalize = (s: string) => s.toLowerCase().replace(/[-]/g, ' ').trim();
     const match =
-      cities.find(c => c.name.toLowerCase() === raw) ||
-      cities.find(c => c.name.toLowerCase().includes(raw) || raw.includes(c.name.toLowerCase()));
+      cities.find(c => normalize(c.name) === raw) ||
+      cities.find(c => normalize(c.name).includes(raw) || raw.includes(normalize(c.name))) ||
+      cities.find(c => {
+        /* Token-based: match if first word matches */
+        const cTokens = normalize(c.name).split(/\s+/);
+        const rTokens = raw.split(/\s+/);
+        return cTokens[0] === rTokens[0] && cTokens[0].length > 2;
+      });
 
-    if (match) setCityRaw(match.name);
-    pendingCity.current = null;
+    if (match) {
+      setCityRaw(match.name);
+      pendingCity.current = null;
+    }
+    /* Keep pendingCity if no match — retry when cities reload */
   }, [cities, detectionVersion]);
 
   // Apply GPS/detected location — queues values for when dropdowns load

--- a/src/pages/onboarding/step-8/logic.ts
+++ b/src/pages/onboarding/step-8/logic.ts
@@ -126,7 +126,41 @@ export function useStep8Logic() {
         return;
       }
 
+      /* ── Try Plaid identity address as primary source ── */
+      let plaidCity: string | undefined;
+      try {
+        const { data: finData } = await config.supabaseClient
+          .from('user_financial_data')
+          .select('identity_data')
+          .eq('user_id', user.id)
+          .maybeSingle();
+
+        if (finData?.identity_data) {
+          const accounts = finData.identity_data.accounts || [];
+          const owners = accounts[0]?.owners || [];
+          const owner = owners[0];
+          if (owner?.addresses?.length) {
+            const primaryAddr = owner.addresses.find((a: any) => a.primary) || owner.addresses[0];
+            const addr = primaryAddr?.data || {};
+            if (addr.city) {
+              plaidCity = addr.city;
+              console.log('[Step8] City from Plaid identity:', plaidCity);
+            }
+            /* Pre-fill address fields from Plaid if available */
+            if (addr.street && !saved?.address_line_1) setAddressLine1(addr.street);
+            if (addr.postal_code && !saved?.zip_code) setZipCode(addr.postal_code);
+          }
+        }
+      } catch (err) {
+        console.warn('[Step8] Plaid identity fetch failed:', err);
+      }
+
       await detectAndApply(user.id);
+
+      /* If GPS didn't set city but Plaid has it, apply Plaid city */
+      if (plaidCity && !dropdowns.city) {
+        dropdowns.applyDetectedLocation(undefined, undefined, undefined, plaidCity);
+      }
 
       if (saved?.residence_country) {
         const code = locationService.mapCountryToIsoCode(saved.residence_country);


### PR DESCRIPTION
## Root Cause
City dropdown stayed empty because:
1. GPS city name (e.g. 'Pimpri-Chinchwad') didn't match static list name exactly
2. pendingCity was cleared even when no match found — preventing retry

## Fixes
**useLocationDropdowns:**
- Don't clear pendingCity/pendingState if no match (keeps retrying on reload)
- Normalize city names: strip hyphens for fuzzy matching
- Token-based matching: first-word match for compound city names
- Export LocationDropdownState interface

**Step 8 logic:**
- Fetch Plaid identity address data as fallback for city
- Pre-fill street + postal_code from Plaid identity if available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Address fields are now pre-filled during onboarding using financial account data when available.

* **Improvements**
  * Enhanced city name matching with normalization and intelligent matching for improved location accuracy.
  * Improved pending state handling for more reliable location selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->