### PR TITLE
fix: merge Step 8 (address) into Step 4 — remove duplicate KYC step

### DIFF
--- a/docs/STEP8_AUDIT_REPORT.md
+++ b/docs/STEP8_AUDIT_REPORT.md
@@ -1,0 +1,695 @@
+# Step 8 — Address Entry: Full Audit Report
+
+**Date:** 2026-04-03  
+**Auditor:** Code Audit  
+**Files Reviewed:**
+- `src/pages/onboarding/step-8/logic.ts` (ACTIVE — used by App.tsx)
+- `src/pages/onboarding/step-8/ui.tsx` (ACTIVE — used by App.tsx)
+- `src/pages/onboarding/Step8.tsx` (DEAD CODE — not imported anywhere)
+- `src/hooks/useLocationDropdowns.ts`
+- `src/services/location/locationService.ts`
+- `src/services/location/types.ts`
+- `src/data/locationData.ts`
+- `src/services/onboarding/upsertOnboardingData.ts`
+- `src/App.tsx` (routing)
+
+---
+
+## 1. What Step 8 Does
+
+Step 8 collects the user's residential address:
+- Address Line 1 (required)
+- Address Line 2 (optional)
+- Country dropdown (required)
+- State dropdown (required)
+- City dropdown (required)
+- ZIP / Postal Code (required)
+
+It also has a "Use My Current Location" button that auto-fills all fields via GPS/IP detection.
+
+---
+
+## 2. File Architecture
+
+```
+App.tsx routing:
+  /onboarding/step-8 → src/pages/onboarding/step-8/ui.tsx
+                         └── imports logic from → step-8/logic.ts
+                              └── uses → useLocationDropdowns (hook)
+                              └── uses → locationService (singleton)
+                              └── uses → upsertOnboardingData (DB helper)
+
+DEAD FILE (not imported):
+  src/pages/onboarding/Step8.tsx ← DUPLICATE, different implementation
+```
+
+---
+
+## 3. Current Location Detection Flow
+
+### 3.1 On Page Load (init useEffect in logic.ts)
+
+```
+1. auth.getUser() → get current user
+2. SELECT from onboarding_data → get saved address + residence_country
+
+PATH A — Return Visit (address_line_1 exists):
+  → Populate all fields from saved DB data
+  → STOP. No GPS detection.
+
+PATH B — First Visit (no address_line_1):
+  → Collect data from 3 sources in PRIORITY ORDER:
+
+  Source 1: Step 4 saved data
+    → residence_country → bestCountryCode
+    → city → bestCity
+
+  Source 2: Plaid Identity (bank-linked address)
+    → user_financial_data.identity_data
+    → accounts[0].owners[0].addresses[0]
+    → addr.street → addressLine1
+    → addr.postal_code → zipCode
+    → addr.city → bestCity (only if no Step 4 city)
+
+  Source 3: GPS Detection
+    → locationService.detectLocation()
+    → postalCode → zipCode (only if Plaid didn't set it)
+    → formattedAddress → parse into address lines (only if Plaid didn't set)
+    → countryCode → bestCountryCode (OVERRIDES Step 4!)
+    → stateCode → bestStateCode
+    → city → bestCity (only if no prior source)
+    → Also saves GPS data to DB in background
+
+  FINALLY:
+    → dropdowns.applyDetectedLocation(bestCountryCode, bestStateCode, bestStateName, bestCity)
+```
+
+### 3.2 GPS Detection (locationService.detectLocation())
+
+```
+Step 1: Check permission state
+  → navigator.permissions.query({ name: 'geolocation' })
+  → Returns: 'granted' | 'denied' | 'prompt' | 'unavailable'
+
+Step 2: If GPS available (not denied/unavailable)
+  → navigator.geolocation.getCurrentPosition()
+  → Low accuracy first (8s timeout, 60s cache)
+  → If accuracy > 2km → retry with high accuracy (15s timeout, no cache)
+  → If low accuracy fails → retry with high accuracy
+  → Result: { latitude, longitude }
+
+Step 3: Reverse Geocoding (coordinates → address)
+  → Try 3 providers sequentially:
+    1. Supabase Edge Function (hushh-location-geocode) → wraps Google Maps API
+    2. Nominatim (terrestris.de CORS-enabled instance)
+    3. BigDataCloud (free, no API key)
+  → First success returns LocationData
+
+Step 4: If GPS fails entirely → IP Fallback
+  → Try 2 IP providers:
+    1. ipwho.is (primary)
+    2. ipwhois.app (backup)
+  → Returns approximate city-level location
+```
+
+### 3.3 Dropdown Cascade (useLocationDropdowns)
+
+```
+Country (static) → States (async from Supabase Edge Function) → Cities (async)
+
+Data flow when applyDetectedLocation() is called:
+  1. pendingState.current = stateCode
+  2. pendingCity.current = cityName
+  3. setCountryRaw(countryCode) ← triggers states load
+  4. detectionVersion++ ← forces re-evaluation
+
+  → States load → pendingState matched → setStateRaw() → triggers cities load
+  → Cities load → pendingCity matched → setCityRaw()
+
+  Total cascade: ~3 async steps with useEffect dependencies
+```
+
+### 3.4 "Use My Current Location" Button
+
+```
+handleDetectClick()
+  → auth.getUser()
+  → detectAndApply(userId)
+    → locationService.detectLocation()
+    → Fill: zipCode, addressLine1, addressLine2
+    → dropdowns.applyDetectedLocation(country, state, stateName, city)
+    → saveLocationToOnboarding (background)
+    → Show detection status for 2.5s
+```
+
+### 3.5 Save (Continue click)
+
+```
+handleContinue()
+  → validateAll() → check all fields
+  → upsertOnboardingData(userId, {
+      address_line_1, address_line_2,
+      address_country: ISO code (e.g. "IN"),
+      state: ISO code (e.g. "MH"),
+      city: name (e.g. "Mumbai"),
+      zip_code,
+      current_step: 8
+    })
+  → navigate('/onboarding/step-9')
+```
+
+---
+
+## 4. BUGS & ISSUES FOUND
+
+### 🔴 CRITICAL
+
+| # | Issue | Location | Description |
+|---|-------|----------|-------------|
+| C1 | GPS overrides user's Step 4 country | `logic.ts` L108 | `if (result.data.countryCode) bestCountryCode = result.data.countryCode` — GPS blindly overwrites the country the user manually selected in Step 4. If user is traveling or on VPN, GPS gives wrong country. |
+| C2 | No auth failure handling | `logic.ts` L61 | `if (!user) return;` — silently returns. User sees blank form, no error, no redirect to login. |
+| C3 | `setCountryRaw` vs `setCountry` race | `useLocationDropdowns.ts` L138 | `applyDetectedLocation` uses `setCountryRaw()` which does NOT clear old states/cities. If country changes, stale dropdown data can flash briefly. |
+
+### 🟡 MEDIUM
+
+| # | Issue | Location | Description |
+|---|-------|----------|-------------|
+| M1 | Dead legacy file | `Step8.tsx` | `src/pages/onboarding/Step8.tsx` is a complete duplicate with DIFFERENT init logic. Not imported by App.tsx. Maintenance confusion risk. |
+| M2 | Plaid missing state data | `logic.ts` L87-96 | Plaid identity address has `region`/`state` field but code only takes `city`, `street`, `postal_code`. State is ignored, so city-state mismatch can happen. |
+| M3 | Double error display | `logic.ts` L141 | `validateAll()` sets per-field `errors` state AND `setError('Please fix the errors above')` sets a banner. User sees errors in 2 places — confusing. |
+| M4 | `states` dependency in cities useEffect | `useLocationDropdowns.ts` L93 | `[country, state, states]` — cities reload whenever states array changes, even if `state` value is same. Unnecessary API calls. |
+| M5 | Step numbering confusion | `logic.ts` L13-15 | Route = `/step-8`, DISPLAY_STEP = 7, current_step DB = 8. Three different numbers for same step. |
+| M6 | `isFooterVisible` unused in UI | `logic.ts` → `ui.tsx` | Hook returns `isFooterVisible` but `ui.tsx` never uses it. Dead variable. |
+| M7 | `saveLocationToOnboarding` dual schema | `locationService.ts` L359-393 | Tries V2 columns first, then legacy columns. If DB has partial columns from both schemas, data goes inconsistent. |
+
+### 🟢 LOW
+
+| # | Issue | Location | Description |
+|---|-------|----------|-------------|
+| L1 | setTimeout memory leak | `logic.ts` L98 | `setTimeout(() => setDetectionStatus(null), 2500)` — no cleanup on unmount. React warning if user navigates away fast. |
+| L2 | Plaid silent failure | `logic.ts` L80-95 | Plaid identity fetch catches all errors silently. Fine since it's optional, but if both Plaid AND GPS fail, user gets blank form with no explanation. |
+| L3 | `COUNTRY_NAME_TO_CODE` incomplete | `types.ts` L94-112 | Only 18 country mappings. `mapCountryToIsoCode("Germany")` returns "Germany" (not "DE") because it's not in the map. |
+| L4 | Nominatim CORS risk | `locationService.ts` L29 | Uses `nominatim.terrestris.de` (third-party Nominatim mirror). This is NOT an official service and could go down anytime. |
+| L5 | IP geolocation on VPN | `locationService.ts` | IP fallback gives VPN server location, not user's real location. No warning shown to user. |
+
+---
+
+## 5. Data Flow Diagram
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    PAGE LOAD                         │
+│                                                      │
+│  ┌──────────┐     ┌──────────────┐                  │
+│  │ Supabase │────►│ Saved Data?  │                  │
+│  │ Auth     │     │ address_line │                  │
+│  └──────────┘     └──────┬───────┘                  │
+│                     YES  │  NO                       │
+│                  ┌───────┘  └────────┐               │
+│                  ▼                   ▼               │
+│         PATH A: Restore      PATH B: Detect          │
+│         from DB              ┌───────────────┐       │
+│         → populate all       │ Source 1:      │       │
+│         → DONE               │ Step 4 DB     │       │
+│                              │ (country,city) │       │
+│                              └───────┬───────┘       │
+│                                      ▼               │
+│                              ┌───────────────┐       │
+│                              │ Source 2:      │       │
+│                              │ Plaid Identity │       │
+│                              │ (street,zip,   │       │
+│                              │  city)         │       │
+│                              └───────┬───────┘       │
+│                                      ▼               │
+│                              ┌───────────────┐       │
+│                              │ Source 3: GPS  │       │
+│                              │ or IP fallback │       │
+│                              │ (everything)   │       │
+│                              └───────┬───────┘       │
+│                                      ▼               │
+│                         applyDetectedLocation()      │
+│                              ┌───────────────┐       │
+│                              │ Dropdown       │       │
+│                              │ Cascade:       │       │
+│                              │ Country→State  │       │
+│                              │ →City          │       │
+│                              └───────────────┘       │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│               GPS DETECTION FLOW                     │
+│                                                      │
+│  Permission Check                                    │
+│  ├── 'granted'/'prompt' → Try GPS                   │
+│  │   ├── Low accuracy (8s) ──► coords               │
+│  │   │   └── accuracy > 2km? → High accuracy (15s)  │
+│  │   └── GPS failed? → High accuracy retry           │
+│  │                                                   │
+│  │   coords ──► Reverse Geocode                      │
+│  │   ├── 1. Supabase Edge Fn (Google Maps)          │
+│  │   ├── 2. Nominatim (terrestris.de)               │
+│  │   └── 3. BigDataCloud                            │
+│  │                                                   │
+│  ├── 'denied'/'unavailable' ──► IP Fallback         │
+│  │   ├── 1. ipwho.is                                │
+│  │   └── 2. ipwhois.app                             │
+│  │                                                   │
+│  └── All failed → { source: 'failed', data: null }  │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│            DROPDOWN CASCADE FLOW                     │
+│                                                      │
+│  applyDetectedLocation(country, state, _, city)      │
+│  │                                                   │
+│  ├── pendingState = state                            │
+│  ├── pendingCity = city                              │
+│  ├── setCountryRaw(country) ← NOTE: not setCountry! │
+│  └── detectionVersion++                              │
+│       │                                              │
+│       ▼                                              │
+│  useEffect [country] → fetch states from Edge Fn     │
+│       │                       (fallback: countriesnow)│
+│       ▼                                              │
+│  useEffect [states, detectionVersion]                │
+│  → match pendingState in states list                 │
+│  → setStateRaw(matched.isoCode)                     │
+│       │                                              │
+│       ▼                                              │
+│  useEffect [country, state, states] → fetch cities   │
+│       │                                              │
+│       ▼                                              │
+│  useEffect [cities, detectionVersion]                │
+│  → match pendingCity in cities list                  │
+│  → setCityRaw(matched.name)                          │
+│       │                                              │
+│       ▼                                              │
+│  ALL DROPDOWNS POPULATED ✓                           │
+│  (Total time: states fetch + cities fetch)           │
+└─────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Database Columns Used
+
+### Read (on page load):
+```sql
+-- From onboarding_data:
+address_line_1, address_line_2, address_country, state, city, zip_code, residence_country
+
+-- From user_financial_data:
+identity_data  -- JSON blob with Plaid identity
+```
+
+### Write (on Continue):
+```sql
+-- To onboarding_data:
+address_line_1, address_line_2, address_country, state, city, zip_code, current_step
+```
+
+### Write (GPS background save):
+```sql
+-- V2 schema:
+gps_latitude, gps_longitude, gps_city, gps_state, gps_country, 
+gps_zip_code, gps_full_address, gps_detected_at, updated_at
+
+-- Legacy fallback:
+gps_location_data (JSON), gps_detected_country, gps_detected_state,
+gps_detected_city, gps_detected_postal_code, gps_detected_phone_dial_code,
+gps_detected_timezone, updated_at
+```
+
+---
+
+## 7. External API Dependencies
+
+| API | Purpose | Auth | Reliability |
+|-----|---------|------|-------------|
+| Supabase `get-locations` | States & Cities dropdown data | anon key | High |
+| Supabase `hushh-location-geocode` | GPS reverse geocoding (Google Maps wrapper) | anon key | High |
+| countriesnow.space | Fallback for states/cities | None | Medium |
+| nominatim.terrestris.de | Fallback reverse geocoding | None | Low (3rd party mirror) |
+| api.bigdatacloud.net | Fallback reverse geocoding | None | Medium |
+| ipwho.is | IP geolocation primary | None | Medium |
+| ipwhois.app | IP geolocation backup | None | Medium |
+
+---
+
+## 8. Summary
+
+**Total issues found: 14**
+- 🔴 Critical: 3
+- 🟡 Medium: 7  
+- 🟢 Low: 5
+
+**Most impactful issues:**
+1. GPS silently overriding user's manually selected country from Step 4
+2. No error handling when auth fails (blank page)
+3. Dead legacy `Step8.tsx` file causing confusion
+4. Plaid state data not being utilized
+5. `setCountryRaw` vs `setCountry` causing potential stale dropdown data
+
+**No code changes made. This is audit only.**
+
+---
+
+## 9. BACKEND LOGIC FLOW — Deep Dive
+
+Step 8 ke backend me **3 systems** kaam karte hain:
+
+### 9.1 Supabase Edge Function: `get-locations` (Dropdown Data)
+
+**File:** `supabase/functions/get-locations/index.ts`  
+**URL:** `{SUPABASE_URL}/functions/v1/get-locations`  
+**Auth:** PUBLIC — no auth required (only `apikey` header from frontend)  
+**Library:** `country-state-city@3.2.1` (npm package running on Deno)
+
+**What it does:**
+```
+GET /get-locations?type=countries
+  → Country.getAllCountries() → returns [{isoCode, name}, ...]
+
+GET /get-locations?type=states&country=IN
+  → State.getStatesOfCountry("IN") → returns [{isoCode, name}, ...]
+
+GET /get-locations?type=cities&country=IN&state=MH
+  → City.getCitiesOfState("IN", "MH") → returns [{name}, ...]
+```
+
+**Logic:**
+1. Parse query params: `type`, `country`, `state`
+2. Switch on `type`:
+   - `countries` → return all countries (no params needed)
+   - `states` → requires `country` param, returns states for that country
+   - `cities` → requires `country` + `state`, returns cities
+3. Response cached for 24 hours (`Cache-Control: public, max-age=86400`)
+4. Error if missing required params (400) or server error (500)
+
+**Backend Issues:**
+- ⚠️ **No rate limiting** — PUBLIC endpoint, anyone can spam it
+- ⚠️ **No input validation** on country/state codes — passes raw string to library
+- ✅ Good: 24hr cache header reduces repeat calls
+- ✅ Good: CORS properly configured
+
+---
+
+### 9.2 Supabase Edge Function: `hushh-location-geocode` (GPS → Address)
+
+**File:** `supabase/functions/hushh-location-geocode/index.ts`  
+**URL:** `{SUPABASE_URL}/functions/v1/hushh-location-geocode`  
+**Auth:** Uses `apikey` + `Authorization: Bearer` (anon key)  
+**Method:** POST
+
+**What it does:**
+```
+POST /hushh-location-geocode
+Body: { latitude: 28.6139, longitude: 77.2090 }
+
+Response: {
+  success: true,
+  data: {
+    country: "India",
+    countryCode: "IN",
+    state: "Delhi",
+    stateCode: "DL",
+    city: "New Delhi",
+    postalCode: "110001",
+    phoneDialCode: "+91",
+    timezone: "Asia/Kolkata",
+    formattedAddress: "New Delhi, Delhi 110001, India",
+    latitude: 28.6139,
+    longitude: 77.2090
+  }
+}
+```
+
+**Logic:**
+1. Parse `{latitude, longitude}` from request body
+2. Validate: check not null, check isFinite
+3. **Primary: Google Geocoding API**
+   - Reads `GOOGLE_MAPS_API_KEY` from env
+   - Calls `https://maps.googleapis.com/maps/api/geocode/json?latlng={lat},{lng}&key={key}`
+   - Parses `address_components` array:
+     - `country` type → country + countryCode
+     - `administrative_area_level_1` → state + stateCode
+     - `locality` → city (fallback: `sublocality_level_1`)
+     - `postal_code` → postalCode
+   - Adds phoneDialCode from hardcoded mapping (50+ countries)
+   - Adds timezone from hardcoded mapping (13 countries only!)
+4. **Fallback: Nominatim (OpenStreetMap)**
+   - If `GOOGLE_MAPS_API_KEY` not set OR Google fails
+   - Calls `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=...&lon=...`
+   - NOTE: Uses OFFICIAL Nominatim (with User-Agent header) — different from frontend which uses terrestris.de mirror
+   - Parses address from `address` object
+   - State code extracted from ISO3166-2 subdivision codes
+   - City fallback chain: city → town → village → hamlet → suburb → county → state_district
+5. Return structured LocationData
+
+**Backend Issues:**
+- 🔴 **Timezone mapping only covers 13 countries** — Most countries get "UTC" as fallback. Indian user in Kolkata gets correct "Asia/Kolkata", but user in Nigeria gets "UTC"
+- 🔴 **Dial code mapping hardcoded on BOTH frontend AND backend** — `COUNTRY_DIAL_CODES` duplicated in locationService.ts AND hushh-location-geocode. Any update needs 2 file changes
+- ⚠️ **Google API key exposure risk** — If edge function logs the full URL, API key appears in Supabase function logs
+- ⚠️ **Nominatim rate limiting** — Official Nominatim has strict rate limits (1 req/second). No throttling implemented
+- ⚠️ **No caching** — Same coordinates geocoded repeatedly make fresh API calls
+- ✅ Good: Falls back gracefully from Google to Nominatim
+- ✅ Good: Input validation for lat/lng
+
+---
+
+### 9.3 Supabase Direct DB: `upsertOnboardingData` (Save Address)
+
+**File:** `src/services/onboarding/upsertOnboardingData.ts`  
+**Table:** `onboarding_data`  
+**Auth:** Uses Supabase client (user's JWT token for RLS)
+
+**What it does:**
+```
+upsertOnboardingData(userId, {
+  address_line_1: "123 Main St",
+  address_line_2: "Apt 4B",
+  address_country: "US",
+  state: "CA",
+  city: "San Francisco",
+  zip_code: "94102",
+  current_step: 8
+})
+```
+
+**Logic (Complex!):**
+1. **SELECT** — Check if row exists for this user
+   ```sql
+   SELECT id FROM onboarding_data WHERE user_id = '{userId}' LIMIT 1
+   ```
+
+2. **If row EXISTS → UPDATE**
+   ```sql
+   UPDATE onboarding_data 
+   SET address_line_1='123 Main St', ..., updated_at=NOW()
+   WHERE user_id = '{userId}'
+   ```
+
+3. **If row DOESN'T EXIST → INSERT**
+   ```sql
+   INSERT INTO onboarding_data (user_id, address_line_1, ...) 
+   VALUES ('{userId}', '123 Main St', ...)
+   ```
+
+4. **Error Handling — The Defensive Layer:**
+
+   **a) Missing Column Retry (PGRST204):**
+   - If PostgREST says "Could not find column 'X' in schema cache"
+   - Drops that column from payload and retries
+   - Up to 5 retries, dropping 1 column per attempt
+   - This handles schema migrations where DB hasn't been updated yet
+
+   **b) Recurring Frequency Constraint Retry:**
+   - If DB has a CHECK constraint on `recurring_frequency` column
+   - First try: new format values (`once_a_month`, `twice_a_month`, etc.)
+   - If constraint violation → retry with legacy format (`monthly`, `bimonthly`, etc.)
+   - Handles both old and new DB schemas
+
+   **c) Normalization:**
+   - Converts various frequency formats (UI labels, legacy values, new values)
+   - Handles empty strings, "null", "undefined" → converts to actual null
+
+**Backend Issues:**
+- 🔴 **SELECT then UPDATE/INSERT is NOT atomic** — Race condition if 2 requests come at same time. Two inserts could run simultaneously, one will fail on unique constraint
+- 🟡 **Up to 5 retries per save** — If schema is badly out of sync, user waits for 5 failed DB calls before getting error
+- 🟡 **Missing column retry is a HACK** — Proper fix is to keep DB schema and code in sync. This "auto-drop columns" approach silently loses data
+- 🟡 **Recurring frequency handling is unrelated** — This is for a different step but the same upsert function handles ALL steps. Address step doesn't use recurring_frequency but the normalization code runs anyway
+- ⚠️ **No optimistic locking** — If user has 2 tabs open, last save wins with no warning
+- ✅ Good: Handles schema mismatches gracefully (won't crash)
+- ✅ Good: Comprehensive error logging
+
+---
+
+### 9.4 Supabase Direct DB: `saveLocationToOnboarding` (GPS Background Save)
+
+**File:** `src/services/location/locationService.ts` (method on LocationService class)  
+**Table:** `onboarding_data`
+
+**What it does (runs in BACKGROUND, fire-and-forget):**
+```
+locationService.saveLocationToOnboarding(userId, gpsLocationData)
+// Called with .catch(() => {}) — errors silently swallowed
+```
+
+**Logic:**
+1. **Try V2 schema first:**
+   ```sql
+   UPDATE onboarding_data SET
+     gps_latitude = 28.6139,
+     gps_longitude = 77.2090,
+     gps_city = 'New Delhi',
+     gps_state = 'Delhi',
+     gps_country = 'India',
+     gps_zip_code = '110001',
+     gps_full_address = 'New Delhi, Delhi 110001, India',
+     gps_detected_at = '2026-04-03T...',
+     updated_at = '2026-04-03T...'
+   WHERE user_id = '{userId}'
+   ```
+
+2. **If V2 fails with PGRST204 (columns don't exist) → Try Legacy schema:**
+   ```sql
+   UPDATE onboarding_data SET
+     gps_location_data = {full JSON blob},
+     gps_detected_country = 'India',
+     gps_detected_state = 'Delhi',
+     gps_detected_city = 'New Delhi',
+     gps_detected_postal_code = '110001',
+     gps_detected_phone_dial_code = '+91',
+     gps_detected_timezone = 'Asia/Kolkata',
+     updated_at = '2026-04-03T...'
+   WHERE user_id = '{userId}'
+   ```
+
+**Backend Issues:**
+- 🔴 **Country stored as NAME, not ISO code** — `gps_country = 'India'` instead of 'IN'. But address save uses ISO code (`address_country = 'IN'`). Inconsistent data
+- 🟡 **Dual schema is confusing** — V2 uses `gps_*` columns, Legacy uses `gps_location_data` JSON blob + `gps_detected_*` columns. Hard to know which schema is active
+- 🟡 **Fire-and-forget** — Errors are `.catch(() => {})` swallowed. If GPS data fails to save, nobody knows
+- ⚠️ **Uses UPDATE only, no INSERT** — If `upsertOnboardingData` hasn't created the row yet (user hasn't clicked Continue), this UPDATE does nothing silently
+
+---
+
+## 10. Complete Backend API Call Sequence
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                    STEP 8 — BACKEND CALLS                        │
+│                                                                  │
+│  PAGE LOAD:                                                      │
+│  ┌─────────────────────────────────────────────────────────┐     │
+│  │ 1. auth.getUser()                                       │     │
+│  │    → Supabase Auth (JWT validation)                     │     │
+│  │                                                         │     │
+│  │ 2. SELECT onboarding_data                               │     │
+│  │    → Supabase PostgREST (direct DB)                     │     │
+│  │    Fields: address_line_1, address_line_2,              │     │
+│  │            address_country, state, city, zip_code,      │     │
+│  │            residence_country                            │     │
+│  │                                                         │     │
+│  │ 3. SELECT user_financial_data (Plaid identity)          │     │
+│  │    → Supabase PostgREST (direct DB)                     │     │
+│  │    Fields: identity_data (JSON blob)                    │     │
+│  │                                                         │     │
+│  │ 4. GPS Detection (browser API — NOT a backend call)     │     │
+│  │    → navigator.geolocation.getCurrentPosition()         │     │
+│  │                                                         │     │
+│  │ 5. Reverse Geocode (if GPS succeeds)                    │     │
+│  │    → POST /functions/v1/hushh-location-geocode          │     │
+│  │      Body: {latitude, longitude}                        │     │
+│  │      → Google Maps API (or Nominatim fallback)          │     │
+│  │    OR (if edge function fails):                         │     │
+│  │    → GET nominatim.terrestris.de/reverse?...            │     │
+│  │    OR:                                                  │     │
+│  │    → GET api.bigdatacloud.net/...                       │     │
+│  │                                                         │     │
+│  │ 5b. IP Fallback (if GPS fails)                          │     │
+│  │    → GET https://ipwho.is/                              │     │
+│  │    OR:                                                  │     │
+│  │    → GET https://ipwhois.app/json/                      │     │
+│  │                                                         │     │
+│  │ 6. Background GPS Save                                  │     │
+│  │    → UPDATE onboarding_data SET gps_* columns           │     │
+│  │      (fire-and-forget, errors swallowed)                │     │
+│  └─────────────────────────────────────────────────────────┘     │
+│                                                                  │
+│  DROPDOWN LOADING (cascading):                                   │
+│  ┌─────────────────────────────────────────────────────────┐     │
+│  │ 7. Countries → STATIC (no API call)                     │     │
+│  │                                                         │     │
+│  │ 8. States:                                              │     │
+│  │    → GET /functions/v1/get-locations?type=states&        │     │
+│  │          country=IN                                     │     │
+│  │      (uses country-state-city npm on Deno)              │     │
+│  │    Fallback:                                            │     │
+│  │    → POST countriesnow.space/api/v0.1/countries/states  │     │
+│  │                                                         │     │
+│  │ 9. Cities:                                              │     │
+│  │    → GET /functions/v1/get-locations?type=cities&        │     │
+│  │          country=IN&state=MH                            │     │
+│  │    Fallback:                                            │     │
+│  │    → POST countriesnow.space/api/v0.1/countries/        │     │
+│  │          state/cities                                   │     │
+│  └─────────────────────────────────────────────────────────┘     │
+│                                                                  │
+│  CONTINUE CLICK:                                                 │
+│  ┌─────────────────────────────────────────────────────────┐     │
+│  │ 10. auth.getUser()                                      │     │
+│  │     → Supabase Auth                                     │     │
+│  │                                                         │     │
+│  │ 11. upsertOnboardingData()                              │     │
+│  │     → SELECT onboarding_data (check if row exists)      │     │
+│  │     → UPDATE or INSERT onboarding_data                  │     │
+│  │       Fields: address_line_1, address_line_2,           │     │
+│  │               address_country, state, city,             │     │
+│  │               zip_code, current_step=8                  │     │
+│  │     → Up to 5 retries if schema mismatch                │     │
+│  └─────────────────────────────────────────────────────────┘     │
+│                                                                  │
+│  SKIP CLICK:                                                     │
+│  ┌─────────────────────────────────────────────────────────┐     │
+│  │ 12. auth.getUser()                                      │     │
+│  │ 13. upsertOnboardingData({ current_step: 8 })           │     │
+│  │     → Only saves step number, no address data           │     │
+│  └─────────────────────────────────────────────────────────┘     │
+└──────────────────────────────────────────────────────────────────┘
+
+TOTAL BACKEND CALLS ON PAGE LOAD (worst case):
+  1. auth.getUser()
+  2. SELECT onboarding_data  
+  3. SELECT user_financial_data
+  4. POST hushh-location-geocode (→ Google Maps API)
+  5. UPDATE onboarding_data (GPS background save)
+  6. GET get-locations?type=states
+  7. GET get-locations?type=cities
+  = 7 backend calls minimum
+
+TOTAL ON CONTINUE:
+  8. auth.getUser()
+  9. SELECT onboarding_data (check exists)
+  10. UPDATE onboarding_data (save address)
+  = 3 more calls
+
+GRAND TOTAL: ~10 backend calls for one step
+```
+
+---
+
+## 11. Backend Bug Summary
+
+| # | Issue | Severity | Location |
+|---|-------|----------|----------|
+| B1 | Timezone mapping only 13 countries | 🔴 Critical | `hushh-location-geocode` |
+| B2 | COUNTRY_DIAL_CODES duplicated in 2 files | 🟡 Medium | frontend + edge function |
+| B3 | upsertOnboardingData not atomic (SELECT→UPDATE race) | 🔴 Critical | `upsertOnboardingData.ts` |
+| B4 | Missing column auto-drop silently loses data | 🟡 Medium | `upsertOnboardingData.ts` |
+| B5 | GPS country stored as name, address as ISO code | 🔴 Critical | `locationService.ts` |
+| B6 | Dual V2/Legacy schema confusion | 🟡 Medium | `locationService.ts` |
+| B7 | GPS save fire-and-forget (errors swallowed) | 🟡 Medium | `logic.ts` |
+| B8 | GPS save uses UPDATE only — fails if row doesn't exist | 🟡 Medium | `locationService.ts` |
+| B9 | get-locations is PUBLIC with no rate limiting | 🟡 Medium | `get-locations/index.ts` |
+| B10 | Nominatim rate limit not respected in edge function | ⚠️ Low | `hushh-location-geocode` |
+| B11 | 10 backend calls for 1 step — could be reduced | ⚠️ Low | Architecture |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,7 +63,7 @@ import OnboardingStep3 from './pages/onboarding/step-3/ui';
 import OnboardingStep4 from './pages/onboarding/step-4/ui';
 import OnboardingStep5 from './pages/onboarding/step-5/ui';
 import OnboardingStep7 from './pages/onboarding/step-7/ui';
-import OnboardingStep8 from './pages/onboarding/step-8/ui';
+// Step 8 removed — merged into Step 4 (Location & Address KYC)
 import OnboardingStep9 from './pages/onboarding/step-9/ui';
 import OnboardingStep11 from './pages/onboarding/step-11/ui';
 import OnboardingStep13 from './pages/onboarding/step-13/ui';
@@ -303,7 +303,7 @@ function App() {
             } />
             <Route path="/onboarding/step-8" element={
               <ProtectedRoute>
-                <OnboardingStep8 />
+                <Navigate to="/onboarding/step-9" replace />
               </ProtectedRoute>
             } />
             <Route path="/onboarding/step-9" element={

--- a/src/pages/onboarding/step-4/logic.ts
+++ b/src/pages/onboarding/step-4/logic.ts
@@ -1,108 +1,236 @@
 /**
- * Step 4 — All Business Logic
- * Country/residence detection, GPS/IP location, Supabase upsert
+ * Step 4 — Location & Address (Merged KYC Step)
+ *
+ * Single step that:
+ * 1. Requests GPS permission
+ * 2. Reverse geocodes via Google (Supabase edge function)
+ * 3. Auto-fills citizenship, residence, and full address
+ * 4. All address fields are READ-ONLY (KYC)
+ * 5. Only citizenship is editable (user may be an expat)
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import config from '../../../resources/config/config';
 import { upsertOnboardingData } from '../../../services/onboarding/upsertOnboardingData';
 import { useFooterVisibility } from '../../../utils/useFooterVisibility';
-import { locationService, type LocationData, COUNTRY_CODE_TO_NAME } from '../../../services/location';
+import {
+  locationService,
+  type LocationData,
+  COUNTRY_CODE_TO_NAME,
+} from '../../../services/location';
 
+/* ═══ Constants ═══ */
 export const CURRENT_STEP = 4;
 export const TOTAL_STEPS = 12;
 export const PROGRESS_PCT = Math.round((CURRENT_STEP / TOTAL_STEPS) * 100);
 
+/** Sorted country list for citizenship dropdown */
 export const countries = [
-  'United States','Afghanistan','Albania','Algeria','Andorra','Angola','Argentina','Armenia','Australia',
-  'Austria','Azerbaijan','Bahamas','Bahrain','Bangladesh','Barbados','Belarus','Belgium','Belize','Benin',
-  'Bhutan','Bolivia','Bosnia and Herzegovina','Botswana','Brazil','Brunei','Bulgaria','Burkina Faso',
-  'Burundi','Cambodia','Cameroon','Canada','Cape Verde','Central African Republic','Chad','Chile','China',
-  'Colombia','Comoros','Congo','Costa Rica','Croatia','Cuba','Cyprus','Czech Republic','Denmark','Djibouti',
-  'Dominica','Dominican Republic','East Timor','Ecuador','Egypt','El Salvador','Equatorial Guinea','Eritrea',
-  'Estonia','Ethiopia','Fiji','Finland','France','Gabon','Gambia','Georgia','Germany','Ghana','Greece',
-  'Grenada','Guatemala','Guinea','Guinea-Bissau','Guyana','Haiti','Honduras','Hungary','Iceland','India',
-  'Indonesia','Iran','Iraq','Ireland','Israel','Italy','Jamaica','Japan','Jordan','Kazakhstan','Kenya',
-  'Kiribati','North Korea','South Korea','Kuwait','Kyrgyzstan','Laos','Latvia','Lebanon','Lesotho','Liberia',
-  'Libya','Liechtenstein','Lithuania','Luxembourg','Macedonia','Madagascar','Malawi','Malaysia','Maldives',
-  'Mali','Malta','Marshall Islands','Mauritania','Mauritius','Mexico','Micronesia','Moldova','Monaco',
-  'Mongolia','Montenegro','Morocco','Mozambique','Myanmar','Namibia','Nauru','Nepal','Netherlands',
-  'New Zealand','Nicaragua','Niger','Nigeria','Norway','Oman','Pakistan','Palau','Panama',
-  'Papua New Guinea','Paraguay','Peru','Philippines','Poland','Portugal','Qatar','Romania','Russia','Rwanda',
-  'Saint Kitts and Nevis','Saint Lucia','Saint Vincent and the Grenadines','Samoa','San Marino',
-  'Sao Tome and Principe','Saudi Arabia','Senegal','Serbia','Seychelles','Sierra Leone','Singapore',
-  'Slovakia','Slovenia','Solomon Islands','Somalia','South Africa','South Sudan','Spain','Sri Lanka','Sudan',
-  'Suriname','Swaziland','Sweden','Switzerland','Syria','Taiwan','Tajikistan','Tanzania','Thailand','Togo',
-  'Tonga','Trinidad and Tobago','Tunisia','Turkey','Turkmenistan','Tuvalu','Uganda','Ukraine',
-  'United Arab Emirates','United Kingdom','Uruguay','Uzbekistan','Vanuatu','Vatican City','Venezuela',
-  'Vietnam','Yemen','Zambia','Zimbabwe',
+  'United States','Afghanistan','Albania','Algeria','Andorra','Angola','Argentina','Armenia',
+  'Australia','Austria','Azerbaijan','Bahamas','Bahrain','Bangladesh','Barbados','Belarus',
+  'Belgium','Belize','Benin','Bhutan','Bolivia','Bosnia and Herzegovina','Botswana','Brazil',
+  'Brunei','Bulgaria','Burkina Faso','Burundi','Cambodia','Cameroon','Canada','Cape Verde',
+  'Central African Republic','Chad','Chile','China','Colombia','Comoros','Congo','Costa Rica',
+  'Croatia','Cuba','Cyprus','Czech Republic','Denmark','Djibouti','Dominica','Dominican Republic',
+  'East Timor','Ecuador','Egypt','El Salvador','Equatorial Guinea','Eritrea','Estonia','Ethiopia',
+  'Fiji','Finland','France','Gabon','Gambia','Georgia','Germany','Ghana','Greece','Grenada',
+  'Guatemala','Guinea','Guinea-Bissau','Guyana','Haiti','Honduras','Hungary','Iceland','India',
+  'Indonesia','Iran','Iraq','Ireland','Israel','Italy','Jamaica','Japan','Jordan','Kazakhstan',
+  'Kenya','Kiribati','North Korea','South Korea','Kuwait','Kyrgyzstan','Laos','Latvia','Lebanon',
+  'Lesotho','Liberia','Libya','Liechtenstein','Lithuania','Luxembourg','Macedonia','Madagascar',
+  'Malawi','Malaysia','Maldives','Mali','Malta','Marshall Islands','Mauritania','Mauritius',
+  'Mexico','Micronesia','Moldova','Monaco','Mongolia','Montenegro','Morocco','Mozambique',
+  'Myanmar','Namibia','Nauru','Nepal','Netherlands','New Zealand','Nicaragua','Niger','Nigeria',
+  'Norway','Oman','Pakistan','Palau','Panama','Papua New Guinea','Paraguay','Peru','Philippines',
+  'Poland','Portugal','Qatar','Romania','Russia','Rwanda','Saint Kitts and Nevis','Saint Lucia',
+  'Saint Vincent and the Grenadines','Samoa','San Marino','Sao Tome and Principe','Saudi Arabia',
+  'Senegal','Serbia','Seychelles','Sierra Leone','Singapore','Slovakia','Slovenia',
+  'Solomon Islands','Somalia','South Africa','South Sudan','Spain','Sri Lanka','Sudan',
+  'Suriname','Swaziland','Sweden','Switzerland','Syria','Taiwan','Tajikistan','Tanzania',
+  'Thailand','Togo','Tonga','Trinidad and Tobago','Tunisia','Turkey','Turkmenistan','Tuvalu',
+  'Uganda','Ukraine','United Arab Emirates','United Kingdom','Uruguay','Uzbekistan','Vanuatu',
+  'Vatican City','Venezuela','Vietnam','Yemen','Zambia','Zimbabwe',
 ];
 
-export type LocationStatus = 'detecting' | 'success' | 'ip-success' | 'denied' | 'failed' | 'manual' | null;
+export type LocationStatus =
+  | 'detecting'
+  | 'success'
+  | 'denied'
+  | 'failed'
+  | 'manual'
+  | null;
 
+/* ═══ Address state populated from Google geocode ═══ */
+export interface DetectedAddress {
+  addressLine1: string;
+  addressLine2: string;
+  city: string;
+  state: string;
+  stateCode: string;
+  country: string;
+  countryCode: string;
+  zipCode: string;
+  fullAddress: string;
+  latitude: number;
+  longitude: number;
+}
+
+const EMPTY_ADDRESS: DetectedAddress = {
+  addressLine1: '', addressLine2: '', city: '', state: '', stateCode: '',
+  country: '', countryCode: '', zipCode: '', fullAddress: '',
+  latitude: 0, longitude: 0,
+};
+
+/* ═══ Hook return type ═══ */
 export interface Step4Logic {
-  citizenshipCountry: string; residenceCountry: string;
-  isLoading: boolean; isFooterVisible: boolean;
-  isDetectingLocation: boolean; locationDetected: boolean;
-  locationStatus: LocationStatus; detectedLocation: string;
-  userConfirmedManual: boolean; showPermissionHelp: boolean;
-  showLocationModal: boolean; canContinue: boolean;
-  isErrorStatus: boolean; isSuccessStatus: boolean;
-  shouldShowForm: boolean; canConfirmSelection: boolean;
+  citizenshipCountry: string;
+  address: DetectedAddress;
+  isLoading: boolean;
+  isFooterVisible: boolean;
+  isDetectingLocation: boolean;
+  locationStatus: LocationStatus;
+  showLocationModal: boolean;
+  canContinue: boolean;
+  showPermissionHelp: boolean;
   handleCitizenshipChange: (v: string) => void;
-  handleResidenceChange: (v: string) => void;
-  handleConfirmManualSelection: () => void;
-  handleRetry: () => Promise<void>;
   handleAllowLocation: () => Promise<void>;
   handleDontAllow: () => void;
+  handleRedetect: () => Promise<void>;
   handleContinue: () => Promise<void>;
   handleBack: () => void;
   handleSkip: () => void;
   setShowPermissionHelp: (v: boolean) => void;
 }
 
+/* ═══ Main Hook ═══ */
 export const useStep4Logic = (): Step4Logic => {
   const navigate = useNavigate();
+  const isFooterVisible = useFooterVisibility();
+
   const [userId, setUserId] = useState<string | null>(null);
   const [citizenshipCountry, setCitizenshipCountry] = useState('');
-  const [residenceCountry, setResidenceCountry] = useState('');
-  const [plaidCity, setPlaidCity] = useState('');
-  const [citizenshipFromPlaid, setCitizenshipFromPlaid] = useState(false);
+  const [address, setAddress] = useState<DetectedAddress>(EMPTY_ADDRESS);
   const [isLoading, setIsLoading] = useState(false);
-  const isFooterVisible = useFooterVisibility();
   const [isDetectingLocation, setIsDetectingLocation] = useState(false);
-  const [locationDetected, setLocationDetected] = useState(false);
-  const [userManuallyChanged, setUserManuallyChanged] = useState(false);
   const [locationStatus, setLocationStatus] = useState<LocationStatus>(null);
-  const [detectedLocation, setDetectedLocation] = useState('');
-  const [userConfirmedManual, setUserConfirmedManual] = useState(false);
+  const [showLocationModal, setShowLocationModal] = useState(false);
   const [showPermissionHelp, setShowPermissionHelp] = useState(false);
   const [hasPreviousData, setHasPreviousData] = useState(false);
-  const [showLocationModal, setShowLocationModal] = useState(false);
 
-  const canContinue = locationDetected || userConfirmedManual;
-  const isErrorStatus = locationStatus === 'denied' || locationStatus === 'failed';
-  const isSuccessStatus = locationStatus === 'success' || locationStatus === 'ip-success';
-  const shouldShowForm = Boolean(locationStatus || hasPreviousData);
-  const canConfirmSelection = Boolean(citizenshipCountry && residenceCountry && !userConfirmedManual);
+  // Can continue only if we have an address (GPS or saved)
+  const canContinue = Boolean(address.country);
 
+  // Scroll to top on mount
   useEffect(() => { window.scrollTo(0, 0); }, []);
 
+  /* ── Parse Google geocode result into address fields ── */
+  const parseLocationData = (data: LocationData): DetectedAddress => {
+    const countryName = COUNTRY_CODE_TO_NAME[data.countryCode] || data.country;
+    // Build address line from formatted address (take first part before city)
+    let line1 = '';
+    if (data.formattedAddress) {
+      const parts = data.formattedAddress.split(',').map((p: string) => p.trim());
+      // Usually: "Street, City, State ZIP, Country"
+      // Take first part(s) before city as address line
+      if (parts.length >= 3) {
+        line1 = parts[0];
+      } else {
+        line1 = data.formattedAddress;
+      }
+    }
+
+    return {
+      addressLine1: line1,
+      addressLine2: '',
+      city: data.city || '',
+      state: data.state || '',
+      stateCode: data.stateCode || '',
+      country: countryName,
+      countryCode: data.countryCode || '',
+      zipCode: data.postalCode || '',
+      fullAddress: data.formattedAddress || '',
+      latitude: data.latitude || 0,
+      longitude: data.longitude || 0,
+    };
+  };
+
+  /* ── GPS detect → Google reverse geocode ── */
+  const detectLocation = useCallback(async (uid: string) => {
+    setIsDetectingLocation(true);
+    setLocationStatus('detecting');
+    try {
+      const result = await locationService.detectLocation();
+
+      if (result.source === 'detected' && result.data) {
+        const parsed = parseLocationData(result.data);
+        setAddress(parsed);
+        // Set residence = detected country, citizenship = same (if not already set)
+        if (!citizenshipCountry) {
+          const cName = COUNTRY_CODE_TO_NAME[result.data.countryCode] || result.data.country;
+          if (countries.includes(cName)) setCitizenshipCountry(cName);
+        }
+        setLocationStatus('success');
+        console.log('[Step4] GPS success:', parsed.fullAddress);
+
+        // Save GPS data to DB in background
+        locationService.saveLocationToOnboarding(uid, result.data)
+          .catch((e: unknown) => console.warn('[Step4] GPS background save failed:', e));
+
+      } else if (result.source === 'denied') {
+        setLocationStatus('denied');
+        console.log('[Step4] GPS denied by user');
+      } else {
+        setLocationStatus('failed');
+        console.log('[Step4] GPS detection failed');
+      }
+    } catch (err) {
+      console.error('[Step4] Location error:', err);
+      setLocationStatus('failed');
+    } finally {
+      setIsDetectingLocation(false);
+    }
+  }, [citizenshipCountry]);
+
+  /* ── Load saved data + Plaid identity on mount ── */
   useEffect(() => {
-    const getCurrentUser = async () => {
+    const init = async () => {
       if (!config.supabaseClient) return;
       const { data: { user } } = await config.supabaseClient.auth.getUser();
       if (!user) { navigate('/login'); return; }
       setUserId(user.id);
 
-      /* Load previously saved onboarding data */
-      const { data } = await config.supabaseClient.from('onboarding_data').select('*').eq('user_id', user.id).maybeSingle();
-      if (data) {
-        if (data.citizenship_country) { setCitizenshipCountry(data.citizenship_country); setUserManuallyChanged(true); setHasPreviousData(true); }
-        if (data.residence_country) setResidenceCountry(data.residence_country);
+      // Load saved onboarding data
+      const { data } = await config.supabaseClient
+        .from('onboarding_data')
+        .select('citizenship_country, residence_country, address_line_1, address_line_2, address_country, state, city, zip_code, gps_latitude, gps_longitude, gps_full_address')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (data?.address_line_1) {
+        // Return visit — restore saved address
+        setAddress({
+          addressLine1: data.address_line_1 || '',
+          addressLine2: data.address_line_2 || '',
+          city: data.city || '',
+          state: data.state || '',
+          stateCode: data.state || '',
+          country: COUNTRY_CODE_TO_NAME[data.address_country] || data.residence_country || '',
+          countryCode: data.address_country || '',
+          zipCode: data.zip_code || '',
+          fullAddress: data.gps_full_address || '',
+          latitude: data.gps_latitude || 0,
+          longitude: data.gps_longitude || 0,
+        });
+        setLocationStatus('success');
+        setHasPreviousData(true);
+        console.log('[Step4] Restored saved address from DB');
       }
 
-      /* ── Fetch Plaid identity data for citizenship pre-fill ── */
+      if (data?.citizenship_country) {
+        setCitizenshipCountry(data.citizenship_country);
+      }
+
+      // Plaid identity — pre-fill citizenship if available
       try {
         const { data: finData } = await config.supabaseClient
           .from('user_financial_data')
@@ -111,117 +239,100 @@ export const useStep4Logic = (): Step4Logic => {
           .maybeSingle();
 
         if (finData?.identity_data) {
-          const identityAccounts = finData.identity_data.accounts || [];
-          const owners = identityAccounts[0]?.owners || [];
-          const owner = owners[0];
+          const accounts = finData.identity_data.accounts || [];
+          const owner = accounts[0]?.owners?.[0];
           if (owner?.addresses?.length) {
-            /* Find primary address, or fall back to first */
             const primaryAddr = owner.addresses.find((a: any) => a.primary) || owner.addresses[0];
             const addrData = primaryAddr?.data || {};
-
-            /* Country of citizenship from bank identity */
             if (addrData.country && !data?.citizenship_country) {
-              const plaidCountryCode = addrData.country.toUpperCase();
-              const plaidCountryName = COUNTRY_CODE_TO_NAME[plaidCountryCode] || addrData.country;
-              if (countries.includes(plaidCountryName)) {
-                setCitizenshipCountry(plaidCountryName);
-                setCitizenshipFromPlaid(true);
-                setHasPreviousData(true);
-                console.log('[Step4] Citizenship pre-filled from Plaid:', plaidCountryName);
+              const code = addrData.country.toUpperCase();
+              const name = COUNTRY_CODE_TO_NAME[code] || addrData.country;
+              if (countries.includes(name)) {
+                setCitizenshipCountry(name);
+                console.log('[Step4] Citizenship pre-filled from Plaid:', name);
               }
-            }
-
-            /* City from bank identity */
-            if (addrData.city) {
-              setPlaidCity(addrData.city);
-              console.log('[Step4] City from Plaid:', addrData.city);
             }
           }
         }
       } catch (err) {
-        console.warn('[Step4] Failed to fetch Plaid identity data:', err);
+        console.warn('[Step4] Plaid identity fetch failed:', err);
+      }
+
+      // Show location modal if no saved address
+      if (!data?.address_line_1) {
+        setShowLocationModal(true);
       }
     };
-    getCurrentUser();
+
+    init();
     return () => { locationService.cancel(); };
   }, [navigate]);
 
-  useEffect(() => {
-    if (!locationStatus && !hasPreviousData && userId) setShowLocationModal(true);
-  }, [userId, locationStatus, hasPreviousData]);
-
-  const detectLocation = async (uid: string) => {
-    setIsDetectingLocation(true); setLocationStatus('detecting');
-    try {
-      const result = await locationService.detectLocation();
-      if ((result.source === 'detected' || result.source === 'ip-detected') && result.data) {
-        const locationData: LocationData = result.data;
-        const countryName = COUNTRY_CODE_TO_NAME[locationData.countryCode] || locationData.country;
-        /* GPS sets residence; only set citizenship if Plaid didn't already */
-        if (countries.includes(countryName)) {
-          setResidenceCountry(countryName);
-          if (!citizenshipFromPlaid) setCitizenshipCountry(countryName);
-        }
-        setDetectedLocation(locationData.city || locationData.state || countryName);
-        setLocationDetected(true);
-        setLocationStatus(result.source === 'detected' ? 'success' : 'ip-success');
-        setHasPreviousData(false);
-        try { await locationService.saveLocationToOnboarding(uid, locationData); } catch (e) { console.warn('[Step4] Cache failed:', e); }
-      } else if (result.source === 'denied') { setLocationStatus('denied'); }
-      else { setLocationStatus('failed'); }
-    } catch (error) { console.error('[Step4] Location error:', error); setLocationStatus('failed'); }
-    finally { setIsDetectingLocation(false); }
-  };
-
+  /* ── Handlers ── */
   const handleCitizenshipChange = (value: string) => {
-    setCitizenshipCountry(value); setUserManuallyChanged(true);
-    if (userConfirmedManual) { setUserConfirmedManual(false); setLocationStatus('manual'); }
+    setCitizenshipCountry(value);
   };
 
-  const handleResidenceChange = (value: string) => {
-    setResidenceCountry(value); setUserManuallyChanged(true);
-    if (userConfirmedManual) { setUserConfirmedManual(false); setLocationStatus('manual'); }
+  const handleAllowLocation = async () => {
+    if (!userId) return;
+    setShowLocationModal(false);
+    await detectLocation(userId);
   };
 
-  const handleConfirmManualSelection = () => {
-    if (citizenshipCountry && residenceCountry) { setUserConfirmedManual(true); setLocationStatus('manual'); }
+  const handleDontAllow = () => {
+    setShowLocationModal(false);
+    setLocationStatus('denied');
   };
 
-  const handleRetry = async () => {
-    setLocationDetected(false); setUserManuallyChanged(false); setUserConfirmedManual(false);
-    if (userId) await detectLocation(userId);
+  const handleRedetect = async () => {
+    if (!userId) return;
+    setAddress(EMPTY_ADDRESS);
+    setLocationStatus(null);
+    await detectLocation(userId);
   };
-
-  const handleAllowLocation = async () => { if (!userId) return; setShowLocationModal(false); await detectLocation(userId); };
-  const handleDontAllow = () => { setShowLocationModal(false); setLocationStatus('manual'); };
 
   const handleContinue = async () => {
     if (!userId || !config.supabaseClient || !canContinue) return;
     setIsLoading(true);
     try {
-      const updatePayload: Record<string, any> = {
+      const payload: Record<string, any> = {
         citizenship_country: citizenshipCountry,
-        residence_country: residenceCountry,
+        residence_country: address.country || citizenshipCountry,
+        address_line_1: address.addressLine1,
+        address_line_2: address.addressLine2,
+        address_country: address.countryCode || address.country,
+        state: address.stateCode || address.state,
+        city: address.city,
+        zip_code: address.zipCode,
+        gps_latitude: address.latitude || null,
+        gps_longitude: address.longitude || null,
+        gps_full_address: address.fullAddress || null,
+        gps_city: address.city || null,
+        gps_state: address.state || null,
+        gps_country: address.country || null,
+        gps_zip_code: address.zipCode || null,
+        gps_detected_at: new Date().toISOString(),
         current_step: 4,
       };
-      /* Save city from Plaid identity if available */
-      if (plaidCity) updatePayload.city = plaidCity;
-      await upsertOnboardingData(userId, updatePayload);
+      console.log('[Step4] Saving full address:', payload);
+      await upsertOnboardingData(userId, payload);
       navigate('/onboarding/step-5');
-    } catch (error) { console.error('Error:', error); }
-    finally { setIsLoading(false); }
+    } catch (error) {
+      console.error('[Step4] Save error:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleBack = () => navigate('/onboarding/step-2');
   const handleSkip = () => navigate('/onboarding/step-5');
 
   return {
-    citizenshipCountry, residenceCountry, isLoading, isFooterVisible,
-    isDetectingLocation, locationDetected, locationStatus, detectedLocation,
-    userConfirmedManual, showPermissionHelp, showLocationModal, canContinue,
-    isErrorStatus, isSuccessStatus, shouldShowForm, canConfirmSelection,
-    handleCitizenshipChange, handleResidenceChange, handleConfirmManualSelection,
-    handleRetry, handleAllowLocation, handleDontAllow, handleContinue,
-    handleBack, handleSkip, setShowPermissionHelp,
+    citizenshipCountry, address, isLoading, isFooterVisible,
+    isDetectingLocation, locationStatus, showLocationModal,
+    canContinue, showPermissionHelp,
+    handleCitizenshipChange, handleAllowLocation, handleDontAllow,
+    handleRedetect, handleContinue, handleBack, handleSkip,
+    setShowPermissionHelp,
   };
 };

--- a/src/pages/onboarding/step-4/ui.tsx
+++ b/src/pages/onboarding/step-4/ui.tsx
@@ -1,7 +1,6 @@
 /**
- * Step 4 — Confirm Your Residence
- * Premium Hushh design matching Step 1 & Step 2.
- * Logic stays in logic.ts — zero logic changes.
+ * Step 4 — Location & Address (Merged KYC Step)
+ * GPS detect → full address READ-ONLY + citizenship editable.
  * Uses HushhTechBackHeader + HushhTechCta reusable components.
  */
 import {
@@ -17,373 +16,260 @@ import HushhTechCta, {
 } from "../../../components/hushh-tech-cta/HushhTechCta";
 import PermissionHelpModal from "../../../components/PermissionHelpModal";
 
+/* Note: HushhTechCta uses children (not label), variant BLACK/WHITE */
+
 export default function OnboardingStep4() {
   const s = useStep4Logic();
 
   return (
     <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white relative overflow-hidden">
-      {/* ═══ Background layer (blurs when location modal is open) ═══ */}
+      {/* ═══ Background layer (blurs when location modal open) ═══ */}
       <div
         className={`flex-1 flex flex-col transition-all duration-300 ${
           s.showLocationModal
-            ? "scale-[0.98] blur-[2px] opacity-40 pointer-events-none select-none"
+            ? "scale-[0.98] blur-[2px] opacity-40 pointer-events-none"
             : ""
         }`}
       >
-        {/* ═══ Header ═══ */}
+        {/* Header */}
         <HushhTechBackHeader onBackClick={s.handleBack} rightLabel="FAQs" />
 
-        <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48">
-          {/* ── Progress Bar ── */}
-          <div className="py-4">
-            <div className="flex justify-between text-[11px] font-semibold tracking-wide text-gray-500 mb-3">
-              <span>
-                Step {CURRENT_STEP}/{TOTAL_STEPS}
+        <main className="px-6 flex-grow max-w-md mx-auto w-full pt-4 pb-32">
+          {/* Progress */}
+          <div className="mb-6">
+            <div className="flex justify-between items-center mb-2">
+              <span className="text-xs font-medium text-gray-500">
+                Step {CURRENT_STEP} of {TOTAL_STEPS}
               </span>
-              <span>{PROGRESS_PCT}% Complete</span>
+              <span className="text-xs font-semibold text-gray-700">
+                {PROGRESS_PCT}%
+              </span>
             </div>
-            <div className="h-0.5 w-full bg-gray-200 rounded-full overflow-hidden">
+            <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
               <div
-                className="h-full bg-hushh-blue transition-all duration-500"
+                className="h-full bg-gradient-to-r from-blue-500 to-purple-500 rounded-full transition-all duration-500"
                 style={{ width: `${PROGRESS_PCT}%` }}
               />
             </div>
           </div>
 
-          {/* ── Title Section ── */}
-          <section className="py-8">
-            <h3 className="text-[10px] tracking-[0.2em] text-gray-400 uppercase mb-4 font-medium">
-              Verification
-            </h3>
-            <h1
-              className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight font-serif"
-              style={{ fontFamily: "'Playfair Display', serif" }}
-            >
-              Confirm Your
-              <br />
-              <span className="text-gray-400 italic font-light">
-                Residence
-              </span>
-            </h1>
-            <p className="text-sm text-gray-500 mt-4 leading-relaxed font-light">
-              We need to know where you live and pay taxes to open your
-              investment account.
-            </p>
-          </section>
+          {/* Title */}
+          <h1 className="text-2xl font-bold text-gray-900 mb-1">
+            Location & Address
+          </h1>
+          <p className="text-sm text-gray-500 mb-6">
+            We detect your address automatically for KYC verification.
+          </p>
 
-          {/* ── Status Banners ── */}
+          {/* ═══ Detection Status ═══ */}
           {s.locationStatus === "detecting" && (
-            <div className="flex items-center gap-3 py-4 px-1 mb-4 border-b border-gray-100">
-              <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
-                <div className="animate-spin h-5 w-5 border-2 border-hushh-blue border-t-transparent rounded-full" />
-              </div>
-              <p className="text-sm font-medium text-gray-700">
-                Detecting your location...
-              </p>
+            <div className="flex items-center gap-3 p-4 bg-blue-50 rounded-xl mb-6 animate-pulse">
+              <div className="w-5 h-5 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm text-blue-700 font-medium">
+                Detecting your location…
+              </span>
             </div>
           )}
 
-          {s.isSuccessStatus && (
-            <div className="flex items-center gap-4 py-5 px-1 mb-6 border-b border-gray-100">
-              <div className="w-10 h-10 rounded-full bg-ios-green/10 border border-ios-green/20 flex items-center justify-center shrink-0">
-                <span
-                  className="material-symbols-outlined text-ios-green text-lg"
-                  style={{
-                    fontVariationSettings: "'FILL' 1, 'wght' 600",
-                  }}
-                >
-                  check
-                </span>
-              </div>
+          {s.locationStatus === "success" && s.address.country && (
+            <div className="flex items-center gap-3 p-4 bg-green-50 rounded-xl mb-6">
+              <span className="text-green-600 text-lg">✅</span>
               <div>
-                <p className="text-sm font-semibold text-gray-900">
-                  Location Detected
+                <p className="text-sm font-semibold text-green-800">
+                  Location detected
                 </p>
-                <p className="text-xs text-gray-500 font-medium">
-                  {s.detectedLocation}
+                <p className="text-xs text-green-600 mt-0.5 line-clamp-1">
+                  {s.address.fullAddress || `${s.address.city}, ${s.address.state}, ${s.address.country}`}
                 </p>
               </div>
             </div>
           )}
 
-          {s.isErrorStatus && (
-            <div className="mb-6">
-              <div className="flex items-center justify-between py-4 px-1 border-b border-gray-100">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-red-50 border border-red-200 flex items-center justify-center shrink-0">
-                    <span
-                      className="material-symbols-outlined text-red-500 text-lg"
-                      style={{
-                        fontVariationSettings: "'FILL' 1, 'wght' 600",
-                      }}
-                    >
-                      error
-                    </span>
-                  </div>
-                  <p className="text-sm font-medium text-gray-700">
-                    {s.locationStatus === "denied"
-                      ? "Location access denied"
-                      : "Could not detect location"}
+          {s.locationStatus === "denied" && (
+            <div className="p-4 bg-amber-50 rounded-xl mb-6">
+              <div className="flex items-center gap-3">
+                <span className="text-amber-600 text-lg">⚠️</span>
+                <div>
+                  <p className="text-sm font-semibold text-amber-800">
+                    Location access denied
+                  </p>
+                  <p className="text-xs text-amber-600 mt-0.5">
+                    Please enable location access for KYC verification.
                   </p>
                 </div>
-                <button
-                  onClick={s.handleRetry}
-                  className="text-black text-xs font-bold uppercase tracking-wide shrink-0 hover:underline"
-                >
-                  Retry
-                </button>
               </div>
-              {s.locationStatus === "denied" && (
-                <button
-                  onClick={(e) => {
-                    e.preventDefault();
-                    s.setShowPermissionHelp(true);
-                  }}
-                  className="mt-2 ml-14 text-[11px] font-semibold text-gray-500 hover:text-hushh-blue transition-colors underline"
-                >
-                  How to enable location
-                </button>
+              <button
+                onClick={() => s.setShowPermissionHelp(true)}
+                className="mt-3 text-xs text-amber-700 underline"
+              >
+                How to enable location access?
+              </button>
+            </div>
+          )}
+
+          {s.locationStatus === "failed" && (
+            <div className="p-4 bg-red-50 rounded-xl mb-6">
+              <div className="flex items-center gap-3">
+                <span className="text-red-600 text-lg">❌</span>
+                <div>
+                  <p className="text-sm font-semibold text-red-800">
+                    Location detection failed
+                  </p>
+                  <p className="text-xs text-red-600 mt-0.5">
+                    Please try again or check your device settings.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* ═══ Re-detect button ═══ */}
+          {(s.locationStatus === "denied" ||
+            s.locationStatus === "failed" ||
+            s.locationStatus === "success") && (
+            <button
+              onClick={s.handleRedetect}
+              disabled={s.isDetectingLocation}
+              className="w-full mb-6 py-3 px-4 border border-gray-200 rounded-xl text-sm font-medium text-gray-700 hover:bg-gray-50 active:bg-gray-100 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+              aria-label="Re-detect location"
+            >
+              <span>📍</span>
+              Re-detect Location
+            </button>
+          )}
+
+          {/* ═══ Citizenship Dropdown (EDITABLE) ═══ */}
+          <div className="mb-6">
+            <label
+              htmlFor="citizenship"
+              className="block text-sm font-semibold text-gray-700 mb-2"
+            >
+              Citizenship Country
+            </label>
+            <select
+              id="citizenship"
+              value={s.citizenshipCountry}
+              onChange={(e) => s.handleCitizenshipChange(e.target.value)}
+              className="w-full px-4 py-3 bg-white border border-gray-200 rounded-xl text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent appearance-none"
+              aria-label="Select citizenship country"
+            >
+              <option value="">Select your citizenship</option>
+              {countries.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* ═══ Detected Address (READ-ONLY) ═══ */}
+          {s.address.country && (
+            <div className="space-y-4">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-sm font-semibold text-gray-700">
+                  Detected Address
+                </span>
+                <span className="text-[10px] bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full font-medium">
+                  READ-ONLY
+                </span>
+              </div>
+
+              {/* Address Line 1 */}
+              {s.address.addressLine1 && (
+                <ReadOnlyField
+                  label="Address"
+                  value={s.address.addressLine1}
+                  icon="🏠"
+                />
+              )}
+
+              {/* City */}
+              {s.address.city && (
+                <ReadOnlyField
+                  label="City"
+                  value={s.address.city}
+                  icon="🏙️"
+                />
+              )}
+
+              {/* State */}
+              {s.address.state && (
+                <ReadOnlyField
+                  label="State / Province"
+                  value={s.address.state}
+                  icon="📍"
+                />
+              )}
+
+              {/* Country */}
+              <ReadOnlyField
+                label="Country"
+                value={`${s.address.country}${s.address.countryCode ? ` (${s.address.countryCode})` : ""}`}
+                icon="🌍"
+              />
+
+              {/* ZIP */}
+              {s.address.zipCode && (
+                <ReadOnlyField
+                  label="ZIP / Postal Code"
+                  value={s.address.zipCode}
+                  icon="📮"
+                />
+              )}
+
+              {/* Full address (collapsed) */}
+              {s.address.fullAddress && (
+                <div className="mt-3 p-3 bg-gray-50 rounded-xl">
+                  <p className="text-[10px] text-gray-400 uppercase tracking-wider mb-1">
+                    Full Address (Google)
+                  </p>
+                  <p className="text-xs text-gray-600 leading-relaxed">
+                    {s.address.fullAddress}
+                  </p>
+                </div>
               )}
             </div>
           )}
-
-          {/* ── Country Selection ── */}
-          {s.shouldShowForm && (
-            <section className="space-y-2 mb-8">
-              {/* Citizenship Country */}
-              <div className="py-5 border-b border-gray-200">
-                <div className="flex items-center gap-4">
-                  <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
-                    <span
-                      className="material-symbols-outlined text-gray-700 text-lg"
-                      style={{ fontVariationSettings: "'wght' 400" }}
-                    >
-                      flag
-                    </span>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-gray-900 mb-0.5">
-                      Country of Citizenship
-                    </p>
-                    <div className="relative">
-                      <select
-                        value={s.citizenshipCountry}
-                        onChange={(e) =>
-                          s.handleCitizenshipChange(e.target.value)
-                        }
-                        disabled={s.isDetectingLocation}
-                        className="w-full text-xs text-gray-500 font-medium bg-transparent border-none outline-none cursor-pointer appearance-none pr-6 p-0"
-                        aria-label="Select citizenship country"
-                      >
-                        <option disabled value="">
-                          Select Country
-                        </option>
-                        {countries.map((c) => (
-                          <option key={c} value={c}>
-                            {c}
-                          </option>
-                        ))}
-                      </select>
-                      <span className="material-symbols-outlined absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 text-base pointer-events-none">
-                        expand_more
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Residence Country */}
-              <div className="py-5 border-b border-gray-200">
-                <div className="flex items-center gap-4">
-                  <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
-                    <span
-                      className="material-symbols-outlined text-gray-700 text-lg"
-                      style={{ fontVariationSettings: "'wght' 400" }}
-                    >
-                      home
-                    </span>
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-gray-900 mb-0.5">
-                      Country of Residence
-                    </p>
-                    <div className="relative">
-                      <select
-                        value={s.residenceCountry}
-                        onChange={(e) =>
-                          s.handleResidenceChange(e.target.value)
-                        }
-                        disabled={s.isDetectingLocation}
-                        className="w-full text-xs text-gray-500 font-medium bg-transparent border-none outline-none cursor-pointer appearance-none pr-6 p-0"
-                        aria-label="Select residence country"
-                      >
-                        <option disabled value="">
-                          Select Country
-                        </option>
-                        {countries.map((c) => (
-                          <option key={c} value={c}>
-                            {c}
-                          </option>
-                        ))}
-                      </select>
-                      <span className="material-symbols-outlined absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 text-base pointer-events-none">
-                        expand_more
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Confirm manual selection */}
-              {!s.locationDetected &&
-                s.canConfirmSelection &&
-                !s.userConfirmedManual && (
-                  <div className="pt-4">
-                    <button
-                      onClick={s.handleConfirmManualSelection}
-                      className="w-full py-3 text-xs font-bold uppercase tracking-widest text-hushh-blue border border-hushh-blue rounded-2xl hover:bg-hushh-blue hover:text-white transition-all active:scale-[0.98]"
-                    >
-                      Confirm Selection
-                    </button>
-                  </div>
-                )}
-            </section>
-          )}
-
-          {/* ── Detect Location Button ── */}
-          {!s.showLocationModal &&
-            !s.isDetectingLocation &&
-            !s.isSuccessStatus && (
-              <div className="py-5 border-b border-gray-200 mb-8">
-                <button
-                  onClick={s.handleAllowLocation}
-                  className="flex items-center gap-4 w-full text-left group"
-                  aria-label="Detect my location"
-                >
-                  <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 group-hover:bg-gray-200 transition-colors">
-                    <span
-                      className="material-symbols-outlined text-gray-700 text-lg"
-                      style={{ fontVariationSettings: "'wght' 400" }}
-                    >
-                      my_location
-                    </span>
-                  </div>
-                  <div>
-                    <p className="text-sm font-semibold text-gray-900">
-                      Detect My Location
-                    </p>
-                    <p className="text-xs text-gray-500 font-medium">
-                      Auto-fill country using GPS
-                    </p>
-                  </div>
-                </button>
-              </div>
-            )}
-
-          {/* ── CTAs — Continue & Skip ── */}
-          <section className="pb-12 space-y-3 mt-4">
-            <HushhTechCta
-              variant={HushhTechCtaVariant.BLACK}
-              onClick={s.handleContinue}
-              disabled={
-                !s.canContinue || s.isLoading || s.isDetectingLocation
-              }
-            >
-              {s.isDetectingLocation
-                ? "Detecting..."
-                : s.isLoading
-                ? "Saving..."
-                : "Continue"}
-            </HushhTechCta>
-
-            <HushhTechCta
-              variant={HushhTechCtaVariant.WHITE}
-              onClick={s.handleSkip}
-            >
-              Skip
-            </HushhTechCta>
-          </section>
-
-          {/* ── Trust Badges ── */}
-          <section className="flex flex-col items-center justify-center text-center gap-2 pb-8">
-            <div className="flex items-center gap-1">
-              <span className="material-symbols-outlined text-[12px] text-hushh-blue">
-                lock
-              </span>
-              <span className="text-[10px] text-gray-500 tracking-wide uppercase font-medium">
-                256 Bit Encryption
-              </span>
-            </div>
-          </section>
         </main>
       </div>
 
-      {/* ═══ Location Permission Modal — Premium Design ═══ */}
+      {/* ═══ Location Permission Modal ═══ */}
       {s.showLocationModal && (
-        <>
-          {/* Dark glass overlay */}
-          <div className="fixed inset-0 z-40 bg-white/60 backdrop-blur-sm" />
-
-          {/* Modal card */}
-          <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-4 pb-6 sm:pb-0">
-            <div className="relative w-full max-w-sm bg-white rounded-3xl shadow-[0_20px_40px_-10px_rgba(0,0,0,0.08),0_0_1px_rgba(0,0,0,0.04)] p-8 flex flex-col items-center text-center border border-gray-100/50">
-              {/* Arrow icon in circle */}
-              <div className="mb-8">
-                <div className="w-20 h-20 rounded-full border border-gray-200 bg-white flex items-center justify-center shadow-sm">
-                  <span
-                    className="material-symbols-outlined text-black text-[2rem] -rotate-45"
-                    style={{ fontVariationSettings: "'wght' 200" }}
-                  >
-                    arrow_forward
-                  </span>
-                </div>
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+            onClick={s.handleDontAllow}
+          />
+          {/* Modal */}
+          <div className="relative bg-white rounded-t-3xl sm:rounded-2xl w-full max-w-sm mx-auto p-6 shadow-2xl animate-slide-up">
+            <div className="flex flex-col items-center text-center">
+              <div className="w-16 h-16 bg-blue-50 rounded-full flex items-center justify-center mb-4">
+                <span className="text-3xl">📍</span>
               </div>
-
-              {/* Heading & description */}
-              <div className="space-y-4 mb-10 px-2">
-                <h2
-                  className="text-[1.75rem] leading-[1.2] text-black tracking-tight font-serif"
-                  style={{ fontFamily: "'Playfair Display', serif" }}
-                >
-                  Enable Location Access
-                </h2>
-                <p className="text-gray-500 text-[0.85rem] leading-relaxed font-light max-w-[90%] mx-auto">
-                  Hushh uses your location to automatically determine your
-                  country and streamline the secure verification process.
-                </p>
-              </div>
-
-              {/* Action buttons */}
-              <div className="w-full space-y-4">
-                {/* Allow while using app — primary black */}
-                <button
-                  onClick={s.handleAllowLocation}
-                  className="w-full h-12 bg-hushh-blue text-white font-medium text-[0.8rem] flex items-center justify-center shadow-lg hover:shadow-xl transition-all active:scale-[0.99] border border-hushh-blue rounded-2xl hover:bg-hushh-blue/90"
-                >
-                  Allow while using app
-                </button>
-
-                {/* Allow once — outlined */}
-                <button
-                  onClick={s.handleAllowLocation}
-                  className="w-full h-12 border border-gray-200 bg-white text-black font-medium text-[0.8rem] rounded-2xl hover:bg-gray-50 transition-colors active:scale-[0.99]"
-                >
-                  Allow once
-                </button>
-
-                {/* Don't allow — text link */}
-                <div className="pt-2">
-                  <button
-                    onClick={s.handleDontAllow}
-                    className="text-xs font-medium text-gray-400 hover:text-black transition-colors"
-                  >
-                    Don&apos;t allow
-                  </button>
-                </div>
-              </div>
+              <h2 className="text-lg font-bold text-gray-900 mb-2">
+                Allow Location Access
+              </h2>
+              <p className="text-sm text-gray-500 mb-6">
+                We need your location to auto-fill your address for KYC verification. Your data is secure and encrypted.
+              </p>
+              <button
+                onClick={s.handleAllowLocation}
+                className="w-full py-3.5 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-xl font-semibold text-sm mb-3 active:scale-[0.98] transition-transform"
+                aria-label="Allow location access"
+              >
+                Allow Location Access
+              </button>
+              <button
+                onClick={s.handleDontAllow}
+                className="w-full py-3 text-gray-500 text-sm font-medium"
+                aria-label="Don't allow location access"
+              >
+                Don't Allow
+              </button>
             </div>
           </div>
-        </>
+        </div>
       )}
 
       {/* ═══ Permission Help Modal ═══ */}
@@ -391,6 +277,51 @@ export default function OnboardingStep4() {
         isOpen={s.showPermissionHelp}
         onClose={() => s.setShowPermissionHelp(false)}
       />
+
+      {/* ═══ Bottom CTA ═══ */}
+      <div className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-md border-t border-gray-100 px-6 py-4 z-40">
+        <div className="max-w-md mx-auto flex gap-3">
+          <HushhTechCta
+            variant={HushhTechCtaVariant.WHITE}
+            onClick={s.handleSkip}
+            className="flex-1"
+          >
+            Skip
+          </HushhTechCta>
+          <HushhTechCta
+            variant={HushhTechCtaVariant.BLACK}
+            onClick={s.handleContinue}
+            disabled={!s.canContinue || s.isLoading}
+            className="flex-[2]"
+          >
+            {s.isLoading ? "Saving…" : "Continue"}
+          </HushhTechCta>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ═══ Read-Only Field Component ═══ */
+function ReadOnlyField({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 p-3.5 bg-gray-50 rounded-xl border border-gray-100">
+      <span className="text-base mt-0.5 shrink-0">{icon}</span>
+      <div className="flex-1 min-w-0">
+        <p className="text-[10px] text-gray-400 uppercase tracking-wider mb-0.5">
+          {label}
+        </p>
+        <p className="text-sm font-medium text-gray-800 truncate">{value}</p>
+      </div>
+      <span className="text-gray-300 text-xs mt-1 shrink-0">🔒</span>
     </div>
   );
 }

--- a/src/pages/onboarding/step-7/logic.ts
+++ b/src/pages/onboarding/step-7/logic.ts
@@ -119,7 +119,7 @@ export function useStep7Logic() {
     });
 
     if (upsertError) { setError('Failed to save data'); setIsLoading(false); return; }
-    navigate('/onboarding/step-8');
+    navigate('/onboarding/step-9');
   };
 
   const handleBack = () => navigate('/onboarding/step-5');
@@ -133,8 +133,8 @@ export function useStep7Logic() {
         const { data: { user } } = await config.supabaseClient.auth.getUser();
         if (user) await upsertOnboardingData(user.id, { current_step: 7 });
       }
-      navigate('/onboarding/step-8');
-    } catch { navigate('/onboarding/step-8'); }
+      navigate('/onboarding/step-9');
+    } catch { navigate('/onboarding/step-9'); }
     finally { setIsLoading(false); }
   };
 


### PR DESCRIPTION
## Changes
- **step-4/logic.ts**: GPS detection + Google reverse geocode + full address auto-fill + citizenship dropdown
- **step-4/ui.tsx**: READ-ONLY address fields, editable citizenship, location permission modal
- **step-7/logic.ts**: Navigation refs skip step-8 → step-9
- **App.tsx**: /step-8 redirects to /step-9, removed dead import

## Why
Step 8 was a duplicate address step that conflicted with Step 4 GPS auto-detection.

## Testing
- Geocode endpoints tested via curl (India, USA, edge cases)
- DB schema verified (16 address columns)
- TypeScript compiles clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPS-based location detection with automatic address population
  * Editable citizenship selection integrated into address collection step

* **Changes**
  * Enhanced Step 4 with location detection status indicators and read-only address display
  * Streamlined onboarding flow proceeding directly from Step 7 to Step 9

* **Documentation**
  * Added comprehensive audit report detailing address entry workflow and backend integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->