### PR TITLE
fix: Remove city dropdown from Step 4, add Plaid lock icon on Step 5 phone

### DIFF
--- a/src/pages/onboarding/step-4/logic.ts
+++ b/src/pages/onboarding/step-4/logic.ts
@@ -1,12 +1,14 @@
 /**
- * Step 4 — All Business Logic
- * Country/residence detection, GPS/IP location, Supabase upsert
+ * Step 4 — Confirm Residence + Full Address
+ * Merges country detection (old step-4) + address entry (old step-8).
+ * Sources: GPS for current address, Plaid for bank/citizenship address.
  */
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import config from '../../../resources/config/config';
 import { upsertOnboardingData } from '../../../services/onboarding/upsertOnboardingData';
 import { useFooterVisibility } from '../../../utils/useFooterVisibility';
+import { useLocationDropdowns } from '../../../hooks/useLocationDropdowns';
 import { locationService, type LocationData, COUNTRY_CODE_TO_NAME } from '../../../services/location';
 
 export const CURRENT_STEP = 4;
@@ -40,18 +42,46 @@ export const countries = [
 
 export type LocationStatus = 'detecting' | 'success' | 'ip-success' | 'denied' | 'failed' | 'manual' | null;
 
+/* ── Plaid bank address shape ── */
+export interface BankAddress {
+  street: string;
+  city: string;
+  state: string;
+  postalCode: string;
+  country: string;
+}
+
 export interface Step4Logic {
-  citizenshipCountry: string; residenceCountry: string;
-  isLoading: boolean; isFooterVisible: boolean;
-  isDetectingLocation: boolean; locationDetected: boolean;
-  locationStatus: LocationStatus; detectedLocation: string;
-  userConfirmedManual: boolean; showPermissionHelp: boolean;
-  showLocationModal: boolean; canContinue: boolean;
-  isErrorStatus: boolean; isSuccessStatus: boolean;
-  shouldShowForm: boolean; canConfirmSelection: boolean;
+  /* Country */
+  citizenshipCountry: string;
+  residenceCountry: string;
+  plaidLinked: boolean;
+  /* Address */
+  addressLine1: string;
+  addressLine2: string;
+  setAddressLine2: (v: string) => void;
+  zipCode: string;
+  bankAddress: BankAddress | null;
+  /* Dropdowns */
+  dropdowns: ReturnType<typeof useLocationDropdowns>;
+  /* UI state */
+  isLoading: boolean;
+  isFooterVisible: boolean;
+  isDetectingLocation: boolean;
+  locationDetected: boolean;
+  locationStatus: LocationStatus;
+  detectedLocation: string;
+  showPermissionHelp: boolean;
+  showLocationModal: boolean;
+  canContinue: boolean;
+  isErrorStatus: boolean;
+  isSuccessStatus: boolean;
+  shouldShowForm: boolean;
+  /* Handlers */
   handleCitizenshipChange: (v: string) => void;
   handleResidenceChange: (v: string) => void;
-  handleConfirmManualSelection: () => void;
+  handleAddressLine1Change: (v: string) => void;
+  handleZipCodeChange: (v: string) => void;
   handleRetry: () => Promise<void>;
   handleAllowLocation: () => Promise<void>;
   handleDontAllow: () => void;
@@ -63,46 +93,74 @@ export interface Step4Logic {
 
 export const useStep4Logic = (): Step4Logic => {
   const navigate = useNavigate();
+  const isFooterVisible = useFooterVisibility();
+  const dropdowns = useLocationDropdowns();
+
+  /* ── Country state ── */
   const [userId, setUserId] = useState<string | null>(null);
   const [citizenshipCountry, setCitizenshipCountry] = useState('');
   const [residenceCountry, setResidenceCountry] = useState('');
-  const [plaidCity, setPlaidCity] = useState('');
-  const [citizenshipFromPlaid, setCitizenshipFromPlaid] = useState(false);
+  const [plaidLinked, setPlaidLinked] = useState(false);
+
+  /* ── Address state ── */
+  const [addressLine1, setAddressLine1] = useState('');
+  const [addressLine2, setAddressLine2] = useState('');
+  const [zipCode, setZipCode] = useState('');
+  const [bankAddress, setBankAddress] = useState<BankAddress | null>(null);
+
+  /* ── UI state ── */
   const [isLoading, setIsLoading] = useState(false);
-  const isFooterVisible = useFooterVisibility();
   const [isDetectingLocation, setIsDetectingLocation] = useState(false);
   const [locationDetected, setLocationDetected] = useState(false);
-  const [userManuallyChanged, setUserManuallyChanged] = useState(false);
   const [locationStatus, setLocationStatus] = useState<LocationStatus>(null);
   const [detectedLocation, setDetectedLocation] = useState('');
-  const [userConfirmedManual, setUserConfirmedManual] = useState(false);
   const [showPermissionHelp, setShowPermissionHelp] = useState(false);
   const [hasPreviousData, setHasPreviousData] = useState(false);
   const [showLocationModal, setShowLocationModal] = useState(false);
 
-  const canContinue = locationDetected || userConfirmedManual;
+  /* ── Derived state ── */
+  const canContinue = locationDetected || hasPreviousData || Boolean(residenceCountry);
   const isErrorStatus = locationStatus === 'denied' || locationStatus === 'failed';
   const isSuccessStatus = locationStatus === 'success' || locationStatus === 'ip-success';
   const shouldShowForm = Boolean(locationStatus || hasPreviousData);
-  const canConfirmSelection = Boolean(citizenshipCountry && residenceCountry && !userConfirmedManual);
 
   useEffect(() => { window.scrollTo(0, 0); }, []);
 
+  /* ── Init: Load saved data + Plaid + auto-detect ── */
   useEffect(() => {
-    const getCurrentUser = async () => {
+    const init = async () => {
       if (!config.supabaseClient) return;
       const { data: { user } } = await config.supabaseClient.auth.getUser();
       if (!user) { navigate('/login'); return; }
       setUserId(user.id);
 
       /* Load previously saved onboarding data */
-      const { data } = await config.supabaseClient.from('onboarding_data').select('*').eq('user_id', user.id).maybeSingle();
+      const { data } = await config.supabaseClient
+        .from('onboarding_data')
+        .select('*')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
       if (data) {
-        if (data.citizenship_country) { setCitizenshipCountry(data.citizenship_country); setUserManuallyChanged(true); setHasPreviousData(true); }
+        if (data.citizenship_country) setCitizenshipCountry(data.citizenship_country);
         if (data.residence_country) setResidenceCountry(data.residence_country);
+        if (data.address_line_1) {
+          setAddressLine1(data.address_line_1);
+          setAddressLine2(data.address_line_2 || '');
+          setZipCode(data.zip_code || '');
+          setHasPreviousData(true);
+          setLocationDetected(true);
+          /* Restore dropdowns from saved address */
+          const code = locationService.mapCountryToIsoCode(data.address_country || data.residence_country || 'US');
+          dropdowns.applyDetectedLocation(code, data.state, undefined, data.city);
+          setLocationStatus('success');
+        } else if (data.residence_country) {
+          setHasPreviousData(true);
+        }
       }
 
-      /* ── Fetch Plaid identity data for citizenship pre-fill ── */
+      /* ── Fetch Plaid identity data ── */
+      let plaidCity = '';
       try {
         const { data: finData } = await config.supabaseClient
           .from('user_financial_data')
@@ -111,116 +169,176 @@ export const useStep4Logic = (): Step4Logic => {
           .maybeSingle();
 
         if (finData?.identity_data) {
-          const identityAccounts = finData.identity_data.accounts || [];
-          const owners = identityAccounts[0]?.owners || [];
+          const accounts = finData.identity_data.accounts || [];
+          const owners = accounts[0]?.owners || [];
           const owner = owners[0];
           if (owner?.addresses?.length) {
-            /* Find primary address, or fall back to first */
             const primaryAddr = owner.addresses.find((a: any) => a.primary) || owner.addresses[0];
-            const addrData = primaryAddr?.data || {};
+            const addr = primaryAddr?.data || {};
 
-            /* Country of citizenship from bank identity */
-            if (addrData.country && !data?.citizenship_country) {
-              const plaidCountryCode = addrData.country.toUpperCase();
-              const plaidCountryName = COUNTRY_CODE_TO_NAME[plaidCountryCode] || addrData.country;
-              if (countries.includes(plaidCountryName)) {
-                setCitizenshipCountry(plaidCountryName);
-                setCitizenshipFromPlaid(true);
-                setHasPreviousData(true);
-                console.log('[Step4] Citizenship pre-filled from Plaid:', plaidCountryName);
+            /* Citizenship from Plaid */
+            if (addr.country && !data?.citizenship_country) {
+              const plaidCode = addr.country.toUpperCase();
+              const plaidName = COUNTRY_CODE_TO_NAME[plaidCode] || addr.country;
+              if (countries.includes(plaidName)) {
+                setCitizenshipCountry(plaidName);
+                setPlaidLinked(true);
               }
             }
 
-            /* City from bank identity */
-            if (addrData.city) {
-              setPlaidCity(addrData.city);
-              console.log('[Step4] City from Plaid:', addrData.city);
+            /* Bank address from Plaid (read-only display) */
+            const bAddr: BankAddress = {
+              street: addr.street || '',
+              city: addr.city || '',
+              state: addr.region || '',
+              postalCode: addr.postal_code || '',
+              country: addr.country ? (COUNTRY_CODE_TO_NAME[addr.country.toUpperCase()] || addr.country) : '',
+            };
+            if (bAddr.street || bAddr.city) {
+              setBankAddress(bAddr);
+              setPlaidLinked(true);
             }
+            plaidCity = addr.city || '';
+
+            /* Pre-fill address line 1 from Plaid if no GPS yet */
+            if (addr.street && !data?.address_line_1) setAddressLine1(addr.street);
+            if (addr.postal_code && !data?.zip_code) setZipCode(addr.postal_code);
           }
         }
       } catch (err) {
-        console.warn('[Step4] Failed to fetch Plaid identity data:', err);
+        console.warn('[Step4] Plaid identity fetch failed:', err);
+      }
+
+      /* ── Auto-detect location if no previous address ── */
+      if (!data?.address_line_1) {
+        /* Check if location was previously granted (skip modal) */
+        const wasGranted = locationService.wasLocationGranted();
+        if (wasGranted) {
+          /* Auto-detect without showing modal */
+          await detectAndFillAddress(user.id, plaidCity);
+        } else {
+          setShowLocationModal(true);
+        }
       }
     };
-    getCurrentUser();
+    init();
     return () => { locationService.cancel(); };
-  }, [navigate]);
+  }, [navigate]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => {
-    if (!locationStatus && !hasPreviousData && userId) setShowLocationModal(true);
-  }, [userId, locationStatus, hasPreviousData]);
-
-  const detectLocation = async (uid: string) => {
-    setIsDetectingLocation(true); setLocationStatus('detecting');
+  /* ── GPS detection + address fill ── */
+  const detectAndFillAddress = async (uid: string, plaidCity?: string) => {
+    setIsDetectingLocation(true);
+    setLocationStatus('detecting');
     try {
       const result = await locationService.detectLocation();
       if ((result.source === 'detected' || result.source === 'ip-detected') && result.data) {
-        const locationData: LocationData = result.data;
-        const countryName = COUNTRY_CODE_TO_NAME[locationData.countryCode] || locationData.country;
-        /* GPS sets residence; only set citizenship if Plaid didn't already */
-        if (countries.includes(countryName)) {
-          setResidenceCountry(countryName);
-          if (!citizenshipFromPlaid) setCitizenshipCountry(countryName);
+        const loc: LocationData = result.data;
+        const countryName = COUNTRY_CODE_TO_NAME[loc.countryCode] || loc.country;
+
+        /* Set residence country */
+        if (countries.includes(countryName)) setResidenceCountry(countryName);
+
+        /* Parse address from GPS */
+        if (loc.formattedAddress) {
+          const parsed = locationService.parseFormattedAddress(loc.formattedAddress, loc);
+          if (parsed.line1 && !addressLine1) setAddressLine1(parsed.line1);
+          if (parsed.line2) setAddressLine2(parsed.line2);
         }
-        setDetectedLocation(locationData.city || locationData.state || countryName);
+        if (loc.postalCode && !zipCode) setZipCode(loc.postalCode);
+
+        /* Apply country/state/city to dropdowns */
+        const bestCity = plaidCity || loc.city;
+        dropdowns.applyDetectedLocation(loc.countryCode, loc.stateCode, loc.state, bestCity);
+
+        /* Display only first city candidate (strip pipe-separated fallbacks) */
+        const displayCity = (loc.city || '').split('|')[0].trim();
+        setDetectedLocation(displayCity || loc.state || countryName);
         setLocationDetected(true);
         setLocationStatus(result.source === 'detected' ? 'success' : 'ip-success');
-        setHasPreviousData(false);
-        try { await locationService.saveLocationToOnboarding(uid, locationData); } catch (e) { console.warn('[Step4] Cache failed:', e); }
-      } else if (result.source === 'denied') { setLocationStatus('denied'); }
-      else { setLocationStatus('failed'); }
-    } catch (error) { console.error('[Step4] Location error:', error); setLocationStatus('failed'); }
-    finally { setIsDetectingLocation(false); }
+
+        /* Save GPS data to DB */
+        locationService.saveLocationToOnboarding(uid, loc).catch(() => {});
+      } else if (result.source === 'denied') {
+        setLocationStatus('denied');
+      } else {
+        setLocationStatus('failed');
+      }
+    } catch (error) {
+      console.error('[Step4] Location error:', error);
+      setLocationStatus('failed');
+    } finally {
+      setIsDetectingLocation(false);
+    }
   };
 
-  const handleCitizenshipChange = (value: string) => {
-    setCitizenshipCountry(value); setUserManuallyChanged(true);
-    if (userConfirmedManual) { setUserConfirmedManual(false); setLocationStatus('manual'); }
-  };
-
-  const handleResidenceChange = (value: string) => {
-    setResidenceCountry(value); setUserManuallyChanged(true);
-    if (userConfirmedManual) { setUserConfirmedManual(false); setLocationStatus('manual'); }
-  };
-
-  const handleConfirmManualSelection = () => {
-    if (citizenshipCountry && residenceCountry) { setUserConfirmedManual(true); setLocationStatus('manual'); }
-  };
+  /* ── Handlers ── */
+  const handleCitizenshipChange = (v: string) => setCitizenshipCountry(v);
+  const handleResidenceChange = (v: string) => setResidenceCountry(v);
+  const handleAddressLine1Change = (v: string) => setAddressLine1(v);
+  const handleZipCodeChange = (v: string) => setZipCode(v.slice(0, 10));
 
   const handleRetry = async () => {
-    setLocationDetected(false); setUserManuallyChanged(false); setUserConfirmedManual(false);
-    if (userId) await detectLocation(userId);
+    setLocationDetected(false);
+    if (userId) await detectAndFillAddress(userId);
   };
 
-  const handleAllowLocation = async () => { if (!userId) return; setShowLocationModal(false); await detectLocation(userId); };
-  const handleDontAllow = () => { setShowLocationModal(false); setLocationStatus('manual'); };
+  const handleAllowLocation = async () => {
+    if (!userId) return;
+    setShowLocationModal(false);
+    await detectAndFillAddress(userId);
+  };
+
+  const handleDontAllow = () => {
+    setShowLocationModal(false);
+    setLocationStatus('manual');
+    setHasPreviousData(true); // show form for manual entry
+  };
 
   const handleContinue = async () => {
     if (!userId || !config.supabaseClient || !canContinue) return;
     setIsLoading(true);
     try {
-      const updatePayload: Record<string, any> = {
-        citizenship_country: citizenshipCountry,
-        residence_country: residenceCountry,
+      const payload: Record<string, any> = {
+        citizenship_country: citizenshipCountry || null,
+        residence_country: residenceCountry || null,
         current_step: 4,
       };
-      /* Save city from Plaid identity if available */
-      if (plaidCity) updatePayload.city = plaidCity;
-      await upsertOnboardingData(userId, updatePayload);
+      /* Save address fields if filled */
+      if (addressLine1.trim()) {
+        /* Convert ISO codes → full names for DB storage */
+        const countryMatch = dropdowns.countries.find(c => c.isoCode === dropdowns.country);
+        const stateMatch = dropdowns.states.find(s => s.isoCode === dropdowns.state);
+
+        payload.address_line_1 = addressLine1.trim();
+        payload.address_line_2 = addressLine2.trim() || null;
+        payload.address_country = countryMatch?.name || residenceCountry || null;
+        payload.state = stateMatch?.name || dropdowns.state || null;
+        /* City auto-detected from GPS (no dropdown), strip pipe-separated fallbacks */
+        const detectedCity = (dropdowns.city || '').split('|')[0].trim();
+        payload.city = detectedCity || null;
+        payload.zip_code = zipCode.trim() || null;
+      }
+      await upsertOnboardingData(userId, payload);
       navigate('/onboarding/step-5');
-    } catch (error) { console.error('Error:', error); }
-    finally { setIsLoading(false); }
+    } catch (error) {
+      console.error('[Step4] Save error:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleBack = () => navigate('/onboarding/step-2');
   const handleSkip = () => navigate('/onboarding/step-5');
 
   return {
-    citizenshipCountry, residenceCountry, isLoading, isFooterVisible,
-    isDetectingLocation, locationDetected, locationStatus, detectedLocation,
-    userConfirmedManual, showPermissionHelp, showLocationModal, canContinue,
-    isErrorStatus, isSuccessStatus, shouldShowForm, canConfirmSelection,
-    handleCitizenshipChange, handleResidenceChange, handleConfirmManualSelection,
+    citizenshipCountry, residenceCountry, plaidLinked,
+    addressLine1, addressLine2, setAddressLine2, zipCode, bankAddress,
+    dropdowns,
+    isLoading, isFooterVisible, isDetectingLocation, locationDetected,
+    locationStatus, detectedLocation, showPermissionHelp, showLocationModal,
+    canContinue, isErrorStatus, isSuccessStatus, shouldShowForm,
+    handleCitizenshipChange, handleResidenceChange,
+    handleAddressLine1Change, handleZipCodeChange,
     handleRetry, handleAllowLocation, handleDontAllow, handleContinue,
     handleBack, handleSkip, setShowPermissionHelp,
   };

--- a/src/pages/onboarding/step-4/ui.tsx
+++ b/src/pages/onboarding/step-4/ui.tsx
@@ -1,8 +1,7 @@
 /**
- * Step 4 — Confirm Your Residence
- * Premium Hushh design matching Step 1 & Step 2.
- * Logic stays in logic.ts — zero logic changes.
- * Uses HushhTechBackHeader + HushhTechCta reusable components.
+ * Step 4 — Confirm Residence + Full Address
+ * Premium Hushh design matching Step 1/2/5/7/8.
+ * Uses HushhTechBackHeader + HushhTechCta + SearchableSelect.
  */
 import {
   useStep4Logic,
@@ -11,6 +10,7 @@ import {
   TOTAL_STEPS,
   PROGRESS_PCT,
 } from "./logic";
+import { SearchableSelect } from "../../../components/onboarding/SearchableSelect";
 import HushhTechBackHeader from "../../../components/hushh-tech-back-header/HushhTechBackHeader";
 import HushhTechCta, {
   HushhTechCtaVariant,
@@ -71,7 +71,7 @@ export default function OnboardingStep4() {
             </p>
           </section>
 
-          {/* ── Status Banners ── */}
+          {/* ── Detection Status ── */}
           {s.locationStatus === "detecting" && (
             <div className="flex items-center gap-3 py-4 px-1 mb-4 border-b border-gray-100">
               <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
@@ -84,62 +84,48 @@ export default function OnboardingStep4() {
           )}
 
           {s.isSuccessStatus && (
-            <div className="flex items-center gap-4 py-5 px-1 mb-6 border-b border-gray-100">
-              <div className="w-10 h-10 rounded-full bg-ios-green/10 border border-ios-green/20 flex items-center justify-center shrink-0">
+            <div className="flex items-center gap-3 py-4 px-1 mb-4 border-b border-gray-100">
+              <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
                 <span
                   className="material-symbols-outlined text-ios-green text-lg"
-                  style={{
-                    fontVariationSettings: "'FILL' 1, 'wght' 600",
-                  }}
+                  style={{ fontVariationSettings: "'FILL' 1, 'wght' 600" }}
                 >
                   check
                 </span>
               </div>
-              <div>
-                <p className="text-sm font-semibold text-gray-900">
-                  Location Detected
-                </p>
-                <p className="text-xs text-gray-500 font-medium">
-                  {s.detectedLocation}
-                </p>
-              </div>
+              <p className="text-sm font-medium text-gray-700">
+                Location detected — {s.detectedLocation}
+              </p>
             </div>
           )}
 
           {s.isErrorStatus && (
-            <div className="mb-6">
-              <div className="flex items-center justify-between py-4 px-1 border-b border-gray-100">
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-red-50 border border-red-200 flex items-center justify-center shrink-0">
-                    <span
-                      className="material-symbols-outlined text-red-500 text-lg"
-                      style={{
-                        fontVariationSettings: "'FILL' 1, 'wght' 600",
-                      }}
-                    >
-                      error
-                    </span>
-                  </div>
-                  <p className="text-sm font-medium text-gray-700">
-                    {s.locationStatus === "denied"
-                      ? "Location access denied"
-                      : "Could not detect location"}
-                  </p>
+            <div className="mb-4">
+              <div className="flex items-center gap-3 py-4 px-1 border-b border-red-100">
+                <div className="w-10 h-10 rounded-full bg-red-50 border border-red-200 flex items-center justify-center shrink-0">
+                  <span
+                    className="material-symbols-outlined text-red-500 text-lg"
+                    style={{ fontVariationSettings: "'FILL' 1, 'wght' 600" }}
+                  >
+                    error
+                  </span>
                 </div>
+                <p className="text-sm font-medium text-red-700">
+                  {s.locationStatus === "denied"
+                    ? "Location access denied"
+                    : "Could not detect location"}
+                </p>
                 <button
                   onClick={s.handleRetry}
-                  className="text-black text-xs font-bold uppercase tracking-wide shrink-0 hover:underline"
+                  className="ml-auto text-black text-xs font-bold uppercase tracking-wide shrink-0 hover:underline"
                 >
                   Retry
                 </button>
               </div>
               {s.locationStatus === "denied" && (
                 <button
-                  onClick={(e) => {
-                    e.preventDefault();
-                    s.setShowPermissionHelp(true);
-                  }}
-                  className="mt-2 ml-14 text-[11px] font-semibold text-gray-500 hover:text-hushh-blue transition-colors underline"
+                  onClick={() => s.setShowPermissionHelp(true)}
+                  className="mt-2 pl-14 text-[11px] font-semibold text-gray-500 hover:text-hushh-blue transition-colors underline"
                 >
                   How to enable location
                 </button>
@@ -147,9 +133,9 @@ export default function OnboardingStep4() {
             </div>
           )}
 
-          {/* ── Country Selection ── */}
+          {/* ═══ SECTION 1: Country Selection ═══ */}
           {s.shouldShowForm && (
-            <section className="space-y-2 mb-8">
+            <section className="space-y-0 mb-6">
               {/* Citizenship Country */}
               <div className="py-5 border-b border-gray-200">
                 <div className="flex items-center gap-4">
@@ -162,18 +148,25 @@ export default function OnboardingStep4() {
                     </span>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-gray-900 mb-0.5">
+                    <label
+                      htmlFor="citizenshipCountry"
+                      className="text-sm font-semibold text-gray-900 block mb-1"
+                    >
                       Country of Citizenship
-                    </p>
+                    </label>
                     <div className="relative">
                       <select
+                        id="citizenshipCountry"
                         value={s.citizenshipCountry}
-                        onChange={(e) =>
-                          s.handleCitizenshipChange(e.target.value)
-                        }
-                        disabled={s.isDetectingLocation}
-                        className="w-full text-xs text-gray-500 font-medium bg-transparent border-none outline-none cursor-pointer appearance-none pr-6 p-0"
+                        onChange={(e) => s.handleCitizenshipChange(e.target.value)}
+                        disabled={s.isDetectingLocation || (s.plaidLinked && !!s.citizenshipCountry)}
+                        className={`w-full text-sm font-medium bg-transparent border-none outline-none appearance-none pr-6 p-0 focus:ring-0 ${
+                          s.plaidLinked && s.citizenshipCountry
+                            ? "text-gray-900 cursor-not-allowed"
+                            : "text-gray-700 cursor-pointer"
+                        }`}
                         aria-label="Select citizenship country"
+                        autoComplete="country-name"
                       >
                         <option disabled value="">
                           Select Country
@@ -184,13 +177,35 @@ export default function OnboardingStep4() {
                           </option>
                         ))}
                       </select>
-                      <span className="material-symbols-outlined absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 text-base pointer-events-none">
-                        expand_more
-                      </span>
+                      {s.plaidLinked && s.citizenshipCountry ? (
+                        <span
+                          className="material-symbols-outlined absolute right-0 top-1/2 -translate-y-1/2 text-green-500 text-base pointer-events-none"
+                          style={{ fontVariationSettings: "'FILL' 1" }}
+                        >
+                          lock
+                        </span>
+                      ) : (
+                        <span className="material-symbols-outlined absolute right-0 top-1/2 -translate-y-1/2 text-gray-400 text-base pointer-events-none">
+                          expand_more
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>
               </div>
+              {s.plaidLinked && s.citizenshipCountry && (
+                <div className="flex items-center gap-2 py-2 pl-14">
+                  <span
+                    className="material-symbols-outlined text-green-500 text-[14px]"
+                    style={{ fontVariationSettings: "'FILL' 1" }}
+                  >
+                    verified
+                  </span>
+                  <p className="text-[11px] text-green-600 font-medium">
+                    Pre-filled from your bank
+                  </p>
+                </div>
+              )}
 
               {/* Residence Country */}
               <div className="py-5 border-b border-gray-200">
@@ -204,18 +219,21 @@ export default function OnboardingStep4() {
                     </span>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-semibold text-gray-900 mb-0.5">
+                    <label
+                      htmlFor="residenceCountry"
+                      className="text-sm font-semibold text-gray-900 block mb-1"
+                    >
                       Country of Residence
-                    </p>
+                    </label>
                     <div className="relative">
                       <select
+                        id="residenceCountry"
                         value={s.residenceCountry}
-                        onChange={(e) =>
-                          s.handleResidenceChange(e.target.value)
-                        }
+                        onChange={(e) => s.handleResidenceChange(e.target.value)}
                         disabled={s.isDetectingLocation}
-                        className="w-full text-xs text-gray-500 font-medium bg-transparent border-none outline-none cursor-pointer appearance-none pr-6 p-0"
+                        className="w-full text-sm text-gray-700 font-medium bg-transparent border-none outline-none cursor-pointer appearance-none pr-6 p-0 focus:ring-0"
                         aria-label="Select residence country"
+                        autoComplete="country-name"
                       >
                         <option disabled value="">
                           Select Country
@@ -233,29 +251,276 @@ export default function OnboardingStep4() {
                   </div>
                 </div>
               </div>
-
-              {/* Confirm manual selection */}
-              {!s.locationDetected &&
-                s.canConfirmSelection &&
-                !s.userConfirmedManual && (
-                  <div className="pt-4">
-                    <button
-                      onClick={s.handleConfirmManualSelection}
-                      className="w-full py-3 text-xs font-bold uppercase tracking-widest text-hushh-blue border border-hushh-blue rounded-2xl hover:bg-hushh-blue hover:text-white transition-all active:scale-[0.98]"
-                    >
-                      Confirm Selection
-                    </button>
-                  </div>
-                )}
             </section>
           )}
 
-          {/* ── Detect Location Button ── */}
+          {/* ═══ SECTION 2: Address Entry ═══ */}
+          {s.shouldShowForm && (
+            <>
+              {/* ── Section Header ── */}
+              <section className="pt-4 pb-2">
+                <h3 className="text-[10px] tracking-[0.2em] text-gray-400 uppercase mb-4 font-medium">
+                  Residence
+                </h3>
+                <h2
+                  className="text-[2rem] leading-[1.1] font-normal text-black tracking-tight"
+                  style={{ fontFamily: "'Playfair Display', serif" }}
+                >
+                  Enter Your
+                  <br />
+                  <span className="text-gray-400 italic font-light">
+                    Address
+                  </span>
+                </h2>
+                <p className="text-sm text-gray-500 mt-4 leading-relaxed font-light">
+                  Please provide your primary residence address.
+                </p>
+              </section>
+
+              {/* ── Use Current Location ── */}
+              {!s.isDetectingLocation && !s.isSuccessStatus && (
+                <div className="py-5 border-b border-gray-200 mb-6">
+                  <button
+                    type="button"
+                    onClick={s.handleAllowLocation}
+                    disabled={s.isDetectingLocation}
+                    className="flex items-center gap-4 w-full text-left group disabled:opacity-50"
+                    aria-label="Use my current location"
+                  >
+                    <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 group-hover:bg-gray-200 transition-colors">
+                      <span
+                        className="material-symbols-outlined text-gray-700 text-lg"
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        my_location
+                      </span>
+                    </div>
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">
+                        Use My Current Location
+                      </p>
+                      <p className="text-xs text-gray-500 font-medium">
+                        Auto-fill address using GPS
+                      </p>
+                    </div>
+                  </button>
+                </div>
+              )}
+
+              {/* ── Address Fields ── */}
+              <section className="space-y-0 mb-6">
+                {/* Address Line 1 */}
+                <div className="py-5 border-b border-gray-200">
+                  <div className="flex items-center gap-4">
+                    <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                      <span
+                        className="material-symbols-outlined text-gray-700 text-lg"
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        location_on
+                      </span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <label
+                        htmlFor="addressLine1"
+                        className="text-sm font-semibold text-gray-900 block mb-1"
+                      >
+                        Address Line 1
+                      </label>
+                      <input
+                        id="addressLine1"
+                        type="text"
+                        value={s.addressLine1}
+                        onChange={(e) => s.handleAddressLine1Change(e.target.value)}
+                        placeholder="Street address"
+                        className="w-full text-sm text-gray-700 font-medium bg-transparent border-none outline-none p-0 placeholder-gray-400 focus:ring-0"
+                        autoComplete="address-line1"
+                      />
+                    </div>
+                  </div>
+                </div>
+
+                {/* Address Line 2 */}
+                <div className="py-5 border-b border-gray-200">
+                  <div className="flex items-center gap-4">
+                    <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                      <span
+                        className="material-symbols-outlined text-gray-700 text-lg"
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        apartment
+                      </span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <label
+                        htmlFor="addressLine2"
+                        className="text-sm font-semibold text-gray-900 block mb-1"
+                      >
+                        Address Line 2
+                      </label>
+                      <input
+                        id="addressLine2"
+                        type="text"
+                        value={s.addressLine2}
+                        onChange={(e) => s.setAddressLine2(e.target.value)}
+                        placeholder="Apt, suite, bldg (optional)"
+                        className="w-full text-sm text-gray-700 font-medium bg-transparent border-none outline-none p-0 placeholder-gray-400 focus:ring-0"
+                        autoComplete="address-line2"
+                      />
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              {/* ── Country / State / City / ZIP ── */}
+              <section className="space-y-0 mb-6">
+                {/* Country */}
+                <div className="border-b border-gray-200">
+                  <SearchableSelect
+                    id="addressCountry"
+                    label="Country"
+                    value={s.dropdowns.country}
+                    options={s.dropdowns.countries.map((c) => ({
+                      value: c.isoCode,
+                      label: c.name,
+                    }))}
+                    onChange={s.dropdowns.setCountry}
+                    placeholder="Search country..."
+                    required
+                    autoComplete="country"
+                  />
+                </div>
+
+                {/* State */}
+                <div className="border-b border-gray-200">
+                  <SearchableSelect
+                    id="addressState"
+                    label="State / Province"
+                    value={s.dropdowns.state}
+                    options={s.dropdowns.states.map((st) => ({
+                      value: st.isoCode,
+                      label: st.name,
+                    }))}
+                    onChange={s.dropdowns.setState}
+                    placeholder="Search state..."
+                    disabled={!s.dropdowns.country}
+                    loading={s.dropdowns.loadingStates}
+                    loadError={s.dropdowns.statesError}
+                    onRetry={s.dropdowns.retryStates}
+                    required
+                    autoComplete="address-level1"
+                  />
+                </div>
+
+                {/* ZIP Code */}
+                <div className="py-5 border-b border-gray-200">
+                  <div className="flex items-center gap-4">
+                    <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                      <span
+                        className="material-symbols-outlined text-gray-700 text-lg"
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        pin
+                      </span>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <label
+                        htmlFor="zipCode"
+                        className="text-sm font-semibold text-gray-900 block mb-1"
+                      >
+                        ZIP / Postal Code
+                      </label>
+                      <input
+                        id="zipCode"
+                        type="text"
+                        value={s.zipCode}
+                        inputMode="text"
+                        onChange={(e) => s.handleZipCodeChange(e.target.value)}
+                        placeholder="e.g. 10001"
+                        maxLength={10}
+                        className="w-full text-sm text-gray-700 font-medium bg-transparent border-none outline-none p-0 placeholder-gray-400 focus:ring-0"
+                        autoComplete="postal-code"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <p className="text-[10px] text-gray-400 pl-14 pt-1 font-light">
+                  Supports numeric and alphanumeric codes based on region.
+                </p>
+              </section>
+
+              {/* ═══ SECTION 3: Bank Address (Plaid, read-only) ═══ */}
+              <section className="mb-8">
+                {s.bankAddress ? (
+                  <div className="py-5 border-b border-gray-200">
+                    <div className="flex items-start gap-4">
+                      <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0 mt-0.5">
+                        <span
+                          className="material-symbols-outlined text-gray-700 text-lg"
+                          style={{ fontVariationSettings: "'wght' 400" }}
+                        >
+                          account_balance
+                        </span>
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-gray-900 mb-1">
+                          Bank Address
+                        </p>
+                        <p className="text-sm text-gray-700 font-medium leading-relaxed">
+                          {s.bankAddress.street && <>{s.bankAddress.street}<br /></>}
+                          {s.bankAddress.city}
+                          {s.bankAddress.state ? `, ${s.bankAddress.state}` : ""}{" "}
+                          {s.bankAddress.postalCode}
+                          {s.bankAddress.country && <><br />{s.bankAddress.country}</>}
+                        </p>
+                        <div className="flex items-center gap-2 mt-2">
+                          <span
+                            className="material-symbols-outlined text-green-500 text-[14px]"
+                            style={{ fontVariationSettings: "'FILL' 1" }}
+                          >
+                            verified
+                          </span>
+                          <p className="text-[11px] text-green-600 font-medium">
+                            Pre-filled from your bank
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="py-5 border-b border-gray-200">
+                    <div className="flex items-center gap-4">
+                      <div className="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center shrink-0">
+                        <span
+                          className="material-symbols-outlined text-gray-700 text-lg"
+                          style={{ fontVariationSettings: "'wght' 400" }}
+                        >
+                          account_balance
+                        </span>
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-semibold text-gray-900 mb-1">
+                          Bank Address
+                        </p>
+                        <p className="text-xs text-gray-500 font-medium">
+                          Link your bank via Plaid to auto-verify
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </section>
+            </>
+          )}
+
+          {/* ── Detect Location Button (initial state, no form yet) ── */}
           {!s.showLocationModal &&
             !s.isDetectingLocation &&
-            !s.isSuccessStatus && (
+            !s.isSuccessStatus &&
+            !s.shouldShowForm && (
               <div className="py-5 border-b border-gray-200 mb-8">
                 <button
+                  type="button"
                   onClick={s.handleAllowLocation}
                   className="flex items-center gap-4 w-full text-left group"
                   aria-label="Detect my location"
@@ -273,7 +538,7 @@ export default function OnboardingStep4() {
                       Detect My Location
                     </p>
                     <p className="text-xs text-gray-500 font-medium">
-                      Auto-fill country using GPS
+                      Auto-fill country & address using GPS
                     </p>
                   </div>
                 </button>
@@ -281,19 +546,17 @@ export default function OnboardingStep4() {
             )}
 
           {/* ── CTAs — Continue & Skip ── */}
-          <section className="pb-12 space-y-3 mt-4">
+          <section className="pb-12 space-y-3">
             <HushhTechCta
               variant={HushhTechCtaVariant.BLACK}
               onClick={s.handleContinue}
-              disabled={
-                !s.canContinue || s.isLoading || s.isDetectingLocation
-              }
+              disabled={!s.canContinue || s.isLoading || s.isDetectingLocation}
             >
               {s.isDetectingLocation
                 ? "Detecting..."
                 : s.isLoading
-                ? "Saving..."
-                : "Continue"}
+                  ? "Saving..."
+                  : "Continue"}
             </HushhTechCta>
 
             <HushhTechCta
@@ -318,16 +581,12 @@ export default function OnboardingStep4() {
         </main>
       </div>
 
-      {/* ═══ Location Permission Modal — Premium Design ═══ */}
+      {/* ═══ Location Permission Modal ═══ */}
       {s.showLocationModal && (
         <>
-          {/* Dark glass overlay */}
           <div className="fixed inset-0 z-40 bg-white/60 backdrop-blur-sm" />
-
-          {/* Modal card */}
           <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-4 pb-6 sm:pb-0">
-            <div className="relative w-full max-w-sm bg-white rounded-3xl shadow-[0_20px_40px_-10px_rgba(0,0,0,0.08),0_0_1px_rgba(0,0,0,0.04)] p-8 flex flex-col items-center text-center border border-gray-100/50">
-              {/* Arrow icon in circle */}
+            <div className="relative w-full max-w-sm bg-white rounded-3xl shadow-[0_20px_40px_-10px_rgba(0,0,0,0.08)] p-8 flex flex-col items-center text-center border border-gray-100/50">
               <div className="mb-8">
                 <div className="w-20 h-20 rounded-full border border-gray-200 bg-white flex items-center justify-center shadow-sm">
                   <span
@@ -338,40 +597,35 @@ export default function OnboardingStep4() {
                   </span>
                 </div>
               </div>
-
-              {/* Heading & description */}
               <div className="space-y-4 mb-10 px-2">
                 <h2
-                  className="text-[1.75rem] leading-[1.2] text-black tracking-tight font-serif"
+                  className="text-[1.75rem] leading-[1.2] text-black tracking-tight"
                   style={{ fontFamily: "'Playfair Display', serif" }}
                 >
-                  Enable Location Access
+                  Enable Location
+                  <br />
+                  <span className="text-gray-400 italic font-light">
+                    Access
+                  </span>
                 </h2>
                 <p className="text-gray-500 text-[0.85rem] leading-relaxed font-light max-w-[90%] mx-auto">
-                  Hushh uses your location to automatically determine your
-                  country and streamline the secure verification process.
+                  Hushh uses your location to automatically fill your address
+                  and streamline the verification process.
                 </p>
               </div>
-
-              {/* Action buttons */}
               <div className="w-full space-y-4">
-                {/* Allow while using app — primary black */}
                 <button
                   onClick={s.handleAllowLocation}
                   className="w-full h-12 bg-hushh-blue text-white font-medium text-[0.8rem] flex items-center justify-center shadow-lg hover:shadow-xl transition-all active:scale-[0.99] border border-hushh-blue rounded-2xl hover:bg-hushh-blue/90"
                 >
                   Allow while using app
                 </button>
-
-                {/* Allow once — outlined */}
                 <button
                   onClick={s.handleAllowLocation}
                   className="w-full h-12 border border-gray-200 bg-white text-black font-medium text-[0.8rem] rounded-2xl hover:bg-gray-50 transition-colors active:scale-[0.99]"
                 >
                   Allow once
                 </button>
-
-                {/* Don't allow — text link */}
                 <div className="pt-2">
                   <button
                     onClick={s.handleDontAllow}

--- a/src/pages/onboarding/step-5/logic.ts
+++ b/src/pages/onboarding/step-5/logic.ts
@@ -141,50 +141,51 @@ export function useStep5Logic() {
         setSelectedAccountType('individual');
       }
 
-      /* ── Pre-populate phone from Plaid identity if not already saved ── */
+      /* ── Pre-populate phone from Plaid identity or saved data ── */
       let hasPhoneFromOnboarding = false;
+      const savedPhone = onboardingData?.phone_number ? String(onboardingData.phone_number).replace(/\D/g, '') : '';
 
-      if (onboardingData?.phone_number) {
-        setPhoneNumber(String(onboardingData.phone_number).replace(/\D/g, ''));
+      if (savedPhone) {
+        setPhoneNumber(savedPhone);
         hasPhoneFromOnboarding = true;
       }
 
-      /* Try Plaid identity data for phone pre-fill (only if no phone saved yet) */
+      /* Always check Plaid identity data for phone — either to pre-fill or to mark as bank-verified */
       let plaidSetDialCode = false;
-      if (!hasPhoneFromOnboarding) {
-        try {
-          const { data: financialData } = await config.supabaseClient
-            .from('user_financial_data')
-            .select('identity_data')
-            .eq('user_id', user.id)
-            .maybeSingle();
+      try {
+        const { data: financialData } = await config.supabaseClient
+          .from('user_financial_data')
+          .select('identity_data')
+          .eq('user_id', user.id)
+          .maybeSingle();
 
-          if (financialData?.identity_data) {
-            const identityData = financialData.identity_data as any;
-            const accounts = identityData?.accounts || [];
-            const owners = accounts[0]?.owners || [];
-            const owner = owners[0];
+        if (financialData?.identity_data) {
+          const identityData = financialData.identity_data as any;
+          const accounts = identityData?.accounts || [];
+          const owners = accounts[0]?.owners || [];
+          const owner = owners[0];
 
-            if (owner?.phone_numbers?.length) {
-              // Use the first (primary) phone number from bank
-              const bankPhone = owner.phone_numbers[0]?.data;
-              if (bankPhone) {
-                const parsed = parseInternationalPhone(String(bankPhone));
-                if (parsed) {
+          if (owner?.phone_numbers?.length) {
+            const bankPhone = owner.phone_numbers[0]?.data;
+            if (bankPhone) {
+              const parsed = parseInternationalPhone(String(bankPhone));
+              if (parsed) {
+                if (!hasPhoneFromOnboarding) {
+                  /* No saved phone yet — pre-fill from Plaid */
                   setPhoneNumber(parsed.localNumber);
-                  setCountryCode(parsed.dialCode);
-                  const matched = PHONE_DIAL_CODES.find((o) => o.code === parsed.dialCode);
-                  if (matched) setSelectedDialCountryIso(matched.iso);
-                  setIsPreFilledFromBank(true);
-                  plaidSetDialCode = true;
-                  console.log('[Step5] Phone pre-filled from Plaid identity:', parsed.dialCode, parsed.localNumber.slice(0, 3) + '***');
                 }
+                setCountryCode(parsed.dialCode);
+                const matched = PHONE_DIAL_CODES.find((o) => o.code === parsed.dialCode);
+                if (matched) setSelectedDialCountryIso(matched.iso);
+                setIsPreFilledFromBank(true);
+                plaidSetDialCode = true;
+                console.log('[Step5] Phone from Plaid identity:', parsed.dialCode, parsed.localNumber.slice(0, 3) + '***');
               }
             }
           }
-        } catch (err) {
-          console.warn('[Step5] Plaid identity fetch failed (ignoring):', err);
         }
+      } catch (err) {
+        console.warn('[Step5] Plaid identity fetch failed (ignoring):', err);
       }
 
       /* Only run dial code detection if Plaid didn't already set it */

--- a/src/pages/onboarding/step-5/ui.tsx
+++ b/src/pages/onboarding/step-5/ui.tsx
@@ -222,6 +222,17 @@ export default function OnboardingStep5() {
                   className="flex-1 text-sm font-medium text-gray-900 placeholder-gray-400 bg-transparent border-none outline-none p-0"
                   aria-label="Phone number"
                 />
+
+                {/* Lock icon when pre-filled from Plaid */}
+                {isPreFilledFromBank && (
+                  <span
+                    className="material-symbols-outlined text-green-500 text-base shrink-0"
+                    style={{ fontVariationSettings: "'FILL' 1" }}
+                    title="Pre-filled from your bank"
+                  >
+                    lock
+                  </span>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Changes

### Step 4 (Confirm Residence)
- Removed City dropdown from the form UI — only Country, State, ZIP remain
- City is auto-detected from GPS and saved to DB in background
- City value cleaned (pipe-separator stripped) before DB storage

### Step 5 (Account Type + Phone)
- Added green lock icon (🔒) next to phone input when pre-filled from Plaid
- Always checks Plaid identity data on load so lock icon persists on revisit
- Shows 'Pre-filled from your bank' verified badge below phone input

### Schema
- All fields align with `onboarding_data` table — no migration needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merged address confirmation into Step 4: now collects residence and full address in one step.
  * Added auto-fill address using GPS and bank data when available.
  * Added location permission modal for first-time access requests.
  * Integrated searchable country and state dropdowns for easier address entry.
  * Bank address from linked accounts now displays for reference.
  * Phone number pre-fills from bank data in Step 5 with visual indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->