### PR TITLE
feat: Add refresh icon to every address field in Step 4

### DIFF
--- a/src/pages/onboarding/step-4/ui.tsx
+++ b/src/pages/onboarding/step-4/ui.tsx
@@ -337,6 +337,22 @@ export default function OnboardingStep4() {
                         autoComplete="address-line1"
                       />
                     </div>
+                    {/* Refresh icon — re-detect GPS */}
+                    <button
+                      type="button"
+                      onClick={s.handleRetry}
+                      disabled={s.isDetectingLocation}
+                      className="w-8 h-8 rounded-full bg-gray-50 hover:bg-gray-100 flex items-center justify-center shrink-0 transition-colors disabled:opacity-40"
+                      aria-label="Re-detect address line 1"
+                      title="Re-detect from GPS"
+                    >
+                      <span
+                        className={`material-symbols-outlined text-gray-500 text-[16px] ${s.isDetectingLocation ? 'animate-spin' : ''}`}
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        refresh
+                      </span>
+                    </button>
                   </div>
                 </div>
 
@@ -368,6 +384,22 @@ export default function OnboardingStep4() {
                         autoComplete="address-line2"
                       />
                     </div>
+                    {/* Refresh icon — re-detect GPS */}
+                    <button
+                      type="button"
+                      onClick={s.handleRetry}
+                      disabled={s.isDetectingLocation}
+                      className="w-8 h-8 rounded-full bg-gray-50 hover:bg-gray-100 flex items-center justify-center shrink-0 transition-colors disabled:opacity-40"
+                      aria-label="Re-detect address line 2"
+                      title="Re-detect from GPS"
+                    >
+                      <span
+                        className={`material-symbols-outlined text-gray-500 text-[16px] ${s.isDetectingLocation ? 'animate-spin' : ''}`}
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        refresh
+                      </span>
+                    </button>
                   </div>
                 </div>
               </section>
@@ -376,40 +408,80 @@ export default function OnboardingStep4() {
               <section className="space-y-0 mb-6">
                 {/* Country */}
                 <div className="border-b border-gray-200">
-                  <SearchableSelect
-                    id="addressCountry"
-                    label="Country"
-                    value={s.dropdowns.country}
-                    options={s.dropdowns.countries.map((c) => ({
-                      value: c.isoCode,
-                      label: c.name,
-                    }))}
-                    onChange={s.dropdowns.setCountry}
-                    placeholder="Search country..."
-                    required
-                    autoComplete="country"
-                  />
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <SearchableSelect
+                        id="addressCountry"
+                        label="Country"
+                        value={s.dropdowns.country}
+                        options={s.dropdowns.countries.map((c) => ({
+                          value: c.isoCode,
+                          label: c.name,
+                        }))}
+                        onChange={s.dropdowns.setCountry}
+                        placeholder="Search country..."
+                        required
+                        autoComplete="country"
+                      />
+                    </div>
+                    {/* Refresh icon — re-detect GPS */}
+                    <button
+                      type="button"
+                      onClick={s.handleRetry}
+                      disabled={s.isDetectingLocation}
+                      className="w-8 h-8 rounded-full bg-gray-50 hover:bg-gray-100 flex items-center justify-center shrink-0 transition-colors disabled:opacity-40 mt-6"
+                      aria-label="Re-detect country"
+                      title="Re-detect from GPS"
+                    >
+                      <span
+                        className={`material-symbols-outlined text-gray-500 text-[16px] ${s.isDetectingLocation ? 'animate-spin' : ''}`}
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        refresh
+                      </span>
+                    </button>
+                  </div>
                 </div>
 
                 {/* State */}
                 <div className="border-b border-gray-200">
-                  <SearchableSelect
-                    id="addressState"
-                    label="State / Province"
-                    value={s.dropdowns.state}
-                    options={s.dropdowns.states.map((st) => ({
-                      value: st.isoCode,
-                      label: st.name,
-                    }))}
-                    onChange={s.dropdowns.setState}
-                    placeholder="Search state..."
-                    disabled={!s.dropdowns.country}
-                    loading={s.dropdowns.loadingStates}
-                    loadError={s.dropdowns.statesError}
-                    onRetry={s.dropdowns.retryStates}
-                    required
-                    autoComplete="address-level1"
-                  />
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0">
+                      <SearchableSelect
+                        id="addressState"
+                        label="State / Province"
+                        value={s.dropdowns.state}
+                        options={s.dropdowns.states.map((st) => ({
+                          value: st.isoCode,
+                          label: st.name,
+                        }))}
+                        onChange={s.dropdowns.setState}
+                        placeholder="Search state..."
+                        disabled={!s.dropdowns.country}
+                        loading={s.dropdowns.loadingStates}
+                        loadError={s.dropdowns.statesError}
+                        onRetry={s.dropdowns.retryStates}
+                        required
+                        autoComplete="address-level1"
+                      />
+                    </div>
+                    {/* Refresh icon — re-detect GPS */}
+                    <button
+                      type="button"
+                      onClick={s.handleRetry}
+                      disabled={s.isDetectingLocation}
+                      className="w-8 h-8 rounded-full bg-gray-50 hover:bg-gray-100 flex items-center justify-center shrink-0 transition-colors disabled:opacity-40 mt-6"
+                      aria-label="Re-detect state"
+                      title="Re-detect from GPS"
+                    >
+                      <span
+                        className={`material-symbols-outlined text-gray-500 text-[16px] ${s.isDetectingLocation ? 'animate-spin' : ''}`}
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        refresh
+                      </span>
+                    </button>
+                  </div>
                 </div>
 
                 {/* ZIP Code */}
@@ -442,6 +514,22 @@ export default function OnboardingStep4() {
                         autoComplete="postal-code"
                       />
                     </div>
+                    {/* Refresh icon — re-detect GPS */}
+                    <button
+                      type="button"
+                      onClick={s.handleRetry}
+                      disabled={s.isDetectingLocation}
+                      className="w-8 h-8 rounded-full bg-gray-50 hover:bg-gray-100 flex items-center justify-center shrink-0 transition-colors disabled:opacity-40"
+                      aria-label="Re-detect ZIP code"
+                      title="Re-detect from GPS"
+                    >
+                      <span
+                        className={`material-symbols-outlined text-gray-500 text-[16px] ${s.isDetectingLocation ? 'animate-spin' : ''}`}
+                        style={{ fontVariationSettings: "'wght' 400" }}
+                      >
+                        refresh
+                      </span>
+                    </button>
                   </div>
                 </div>
                 <p className="text-[10px] text-gray-400 pl-14 pt-1 font-light">


### PR DESCRIPTION
## Changes

Every address field in Step 4 now has a **refresh ↻ icon** on the right side:

- **Address Line 1** — refresh icon
- **Address Line 2** — refresh icon
- **Country** (SearchableSelect) — refresh icon
- **State / Province** (SearchableSelect) — refresh icon
- **ZIP / Postal Code** — refresh icon

### Behavior
- Tapping the refresh icon re-triggers GPS location detection
- All address fields get updated with fresh GPS data
- Icon **spins** during detection (animate-spin)
- Button is **disabled** while detection is in progress
- Accessible: `aria-label` + `title` tooltip on each button

### Edge Case Handling
If any auto-detected value is wrong, user can tap refresh to re-detect, or manually edit the field directly.