### PR TITLE
fix: Responsive CTA buttons — prevent stacking/breaking on all screens

### DIFF
--- a/src/components/hushh-tech-cta/HushhTechCta.tsx
+++ b/src/components/hushh-tech-cta/HushhTechCta.tsx
@@ -41,9 +41,9 @@ const VARIANT_CLASSES: Record<HushhTechCtaVariant, string> = {
 
 /** Base classes shared by both variants — always full-width, consistent height */
 const BASE_CLASSES = [
-  "w-full h-14 px-8 rounded-xl",
-  "font-semibold text-sm tracking-wide whitespace-nowrap capitalize",
-  "flex items-center justify-center gap-2",
+  "w-full min-h-[3.5rem] px-4 sm:px-8 rounded-xl",
+  "font-semibold text-sm tracking-wide capitalize",
+  "flex items-center justify-center gap-2 flex-nowrap",
   "disabled:opacity-50 disabled:cursor-not-allowed",
 ].join(" ");
 

--- a/src/pages/login/ui.tsx
+++ b/src/pages/login/ui.tsx
@@ -64,8 +64,8 @@ export default function LoginPage() {
             onClick={handleAppleSignIn}
             disabled={isSigningIn}
           >
-            <FaApple className="text-lg" />
-            <span>Continue with Apple</span>
+            <FaApple className="text-lg shrink-0" />
+            <span className="truncate">Continue with Apple</span>
           </HushhTechCta>
 
           <HushhTechCta
@@ -73,8 +73,8 @@ export default function LoginPage() {
             onClick={handleGoogleSignIn}
             disabled={isSigningIn}
           >
-            <FcGoogle className="text-lg" />
-            <span>Continue with Google</span>
+            <FcGoogle className="text-lg shrink-0" />
+            <span className="truncate">Continue with Google</span>
           </HushhTechCta>
         </section>
 

--- a/src/pages/signup/ui.tsx
+++ b/src/pages/signup/ui.tsx
@@ -64,8 +64,8 @@ export default function SignupPage() {
             onClick={handleAppleSignIn}
             disabled={isSigningIn}
           >
-            <FaApple className="text-lg" />
-            <span>Continue with Apple</span>
+            <FaApple className="text-lg shrink-0" />
+            <span className="truncate">Continue with Apple</span>
           </HushhTechCta>
 
           <HushhTechCta
@@ -73,8 +73,8 @@ export default function SignupPage() {
             onClick={handleGoogleSignIn}
             disabled={isSigningIn}
           >
-            <FcGoogle className="text-lg" />
-            <span>Continue with Google</span>
+            <FcGoogle className="text-lg shrink-0" />
+            <span className="truncate">Continue with Google</span>
           </HushhTechCta>
         </section>
 


### PR DESCRIPTION
Fixes CTAs stacking and breaking on responsive views. Buttons now look identical on phone and responsive — only layout changes.

**CTA Component changes:**
- `h-14` → `min-h-[3.5rem]` (flexible height)
- `px-8` → `px-4 sm:px-8` (responsive padding)
- Removed `whitespace-nowrap`, added `flex-nowrap`

**Login + Signup pages:**
- Icons: `shrink-0` (never collapse)
- Text: `truncate` (never overflow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive design with flexible spacing and height adjustments across components.
  * Enhanced overflow handling for sign-in and signup buttons—icons now maintain their size while long labels truncate gracefully instead of wrapping, improving layout consistency on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->