### PR TITLE
fix: Hushh Agents nav menu, dedicated login page, auth isolation

### DIFF
--- a/src/hushh-agents/App.tsx
+++ b/src/hushh-agents/App.tsx
@@ -14,7 +14,7 @@ import { FaApple } from 'react-icons/fa';
 import { FcGoogle } from 'react-icons/fc';
 import { useAuth } from './hooks/useAuth';
 import { HUSHH_BRANDING } from './core/constants';
-import HushhLogo from '../components/images/Hushhogo.png';
+import HushhLogo from './assets/Hushhogo.png';
 
 // Lazy load pages
 const HomePage = lazy(() => import('./pages/HomePage'));
@@ -25,6 +25,7 @@ const KirklandAgentsPage = lazy(() => import('./pages/KirklandAgentsPage'));
 const AgentDetailPage = lazy(() => import('./pages/AgentDetailPage'));
 const AgentChatPage = lazy(() => import('./pages/AgentChatPage'));
 const AgentOnboardPage = lazy(() => import('./pages/AgentOnboardPage'));
+const LoginPage = lazy(() => import('./pages/LoginPage'));
 
 // Playfair heading style
 const playfair = { fontFamily: "'Playfair Display', serif" };
@@ -223,15 +224,12 @@ const LoginScreen: React.FC<{
   </div>
 );
 
-const App: React.FC = () => {
-  const { isAuthenticated, isLoading, user, signIn, signOut, error } = useAuth();
+// Auth-gated wrapper — redirects to login if not authenticated
+const AuthGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isAuthenticated, isLoading, signIn, error } = useAuth();
 
-  // Loading state
-  if (isLoading) {
-    return <LoadingScreen />;
-  }
+  if (isLoading) return <LoadingScreen />;
 
-  // Not authenticated - show login
   if (!isAuthenticated) {
     return (
       <LoginScreen
@@ -243,11 +241,14 @@ const App: React.FC = () => {
     );
   }
 
-  // Authenticated - show app
+  return <>{children}</>;
+};
+
+const App: React.FC = () => {
   return (
     <Suspense fallback={<LoadingScreen />}>
       <Routes>
-        {/* Home - Agent Selection */}
+        {/* Home - Public landing page (no auth gate) */}
         <Route
           index
           element={<HomePage />}
@@ -293,6 +294,12 @@ const App: React.FC = () => {
         <Route
           path="onboard"
           element={<AgentOnboardPage />}
+        />
+
+        {/* Dedicated Login Page (stays within /hushh-agents) */}
+        <Route
+          path="login"
+          element={<LoginPage />}
         />
 
         {/* Default chat (Hushh agent) */}

--- a/src/hushh-agents/components/AgentCard.tsx
+++ b/src/hushh-agents/components/AgentCard.tsx
@@ -1,0 +1,188 @@
+/**
+ * AgentCard — Premium agent showcase card
+ *
+ * Replaces the old AgentNudge with a richer, more visual card.
+ * Features gradient border, status indicator, hover animations,
+ * and a clear visual hierarchy.
+ */
+import React, { useState } from 'react';
+
+/** Status badge variants */
+type AgentStatus = 'live' | 'online' | 'new' | 'soon' | 'beta';
+
+interface AgentCardProps {
+  /** Agent display name */
+  title: string;
+  /** Short category or label */
+  subtitle: string;
+  /** Brief description (1-2 lines) */
+  description: string;
+  /** Material Symbols icon name */
+  icon: string;
+  /** Accent color (hex) */
+  color: string;
+  /** Status badge */
+  status: AgentStatus;
+  /** Feature chips shown at bottom */
+  chips?: string[];
+  /** Click handler — navigates to agent */
+  onClick: () => void;
+  /** Optional: mark as featured/highlighted */
+  featured?: boolean;
+}
+
+/** Status config — colors and labels */
+const STATUS_CONFIG: Record<AgentStatus, { label: string; bg: string; text: string; dot: string }> = {
+  live: { label: 'Live', bg: 'bg-blue-50', text: 'text-blue-600', dot: 'bg-blue-500' },
+  online: { label: 'Online', bg: 'bg-emerald-50', text: 'text-emerald-600', dot: 'bg-emerald-500' },
+  new: { label: 'New', bg: 'bg-amber-50', text: 'text-amber-600', dot: 'bg-amber-500' },
+  soon: { label: 'Soon', bg: 'bg-gray-100', text: 'text-gray-400', dot: 'bg-gray-300' },
+  beta: { label: 'Beta', bg: 'bg-purple-50', text: 'text-purple-600', dot: 'bg-purple-500' },
+};
+
+const AgentCard: React.FC<AgentCardProps> = ({
+  title,
+  subtitle,
+  description,
+  icon,
+  color,
+  status,
+  chips = [],
+  onClick,
+  featured = false,
+}) => {
+  const [isPressed, setIsPressed] = useState(false);
+  const statusCfg = STATUS_CONFIG[status];
+  const isDisabled = status === 'soon';
+
+  return (
+    <button
+      onClick={isDisabled ? undefined : onClick}
+      onMouseDown={() => setIsPressed(true)}
+      onMouseUp={() => setIsPressed(false)}
+      onMouseLeave={() => setIsPressed(false)}
+      disabled={isDisabled}
+      className={[
+        'text-left w-full rounded-2xl transition-all duration-200 group relative overflow-hidden',
+        isDisabled
+          ? 'opacity-50 cursor-not-allowed'
+          : 'cursor-pointer hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0',
+        isPressed && !isDisabled ? 'scale-[0.98]' : '',
+        featured
+          ? 'bg-gradient-to-br from-gray-900 to-gray-800 text-white border border-gray-700'
+          : 'bg-white border border-gray-200/80 hover:border-gray-300',
+      ].join(' ')}
+      aria-label={`${title} — ${description}`}
+    >
+      {/* Subtle gradient overlay for featured cards */}
+      {featured && (
+        <div
+          className="absolute inset-0 opacity-10 pointer-events-none"
+          style={{
+            background: `radial-gradient(ellipse at top right, ${color}, transparent 70%)`,
+          }}
+        />
+      )}
+
+      <div className="relative p-5 sm:p-6">
+        {/* Top row: icon + status */}
+        <div className="flex items-start justify-between mb-4">
+          {/* Icon container */}
+          <div
+            className="w-12 h-12 rounded-xl flex items-center justify-center transition-transform group-hover:scale-110 duration-300"
+            style={{
+              backgroundColor: featured ? `${color}25` : `${color}10`,
+            }}
+          >
+            <span
+              className="material-symbols-outlined text-[24px]"
+              style={{ color }}
+            >
+              {icon}
+            </span>
+          </div>
+
+          {/* Status badge */}
+          <span
+            className={[
+              'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider',
+              featured ? 'bg-white/10 text-white/80' : `${statusCfg.bg} ${statusCfg.text}`,
+            ].join(' ')}
+          >
+            <span
+              className={[
+                'w-1.5 h-1.5 rounded-full',
+                featured ? 'bg-white/60' : statusCfg.dot,
+                status === 'online' || status === 'live' ? 'animate-pulse' : '',
+              ].join(' ')}
+            />
+            {statusCfg.label}
+          </span>
+        </div>
+
+        {/* Title section */}
+        <div className="mb-3">
+          <p
+            className={[
+              'text-[10px] uppercase tracking-[0.15em] font-medium mb-0.5',
+              featured ? 'text-white/40' : 'text-gray-400',
+            ].join(' ')}
+          >
+            {subtitle}
+          </p>
+          <h3
+            className={[
+              'text-[17px] font-semibold leading-tight',
+              featured ? 'text-white' : 'text-gray-900',
+            ].join(' ')}
+            style={{ fontFamily: "'Playfair Display', serif" }}
+          >
+            {title}
+          </h3>
+        </div>
+
+        {/* Description */}
+        <p
+          className={[
+            'text-[12.5px] font-light leading-relaxed mb-4',
+            featured ? 'text-white/60' : 'text-gray-500',
+          ].join(' ')}
+        >
+          {description}
+        </p>
+
+        {/* Chips + Arrow */}
+        <div className="flex items-end justify-between">
+          <div className="flex flex-wrap gap-1.5">
+            {chips.map((chip) => (
+              <span
+                key={chip}
+                className={[
+                  'px-2.5 py-1 rounded-lg text-[10px] font-medium',
+                  featured
+                    ? 'bg-white/10 text-white/50 border border-white/10'
+                    : 'bg-gray-50 text-gray-500 border border-gray-100',
+                ].join(' ')}
+              >
+                {chip}
+              </span>
+            ))}
+          </div>
+
+          {!isDisabled && (
+            <span
+              className={[
+                'material-symbols-outlined text-[20px] transition-transform group-hover:translate-x-1 duration-200',
+                featured ? 'text-white/30' : 'text-gray-300',
+              ].join(' ')}
+            >
+              arrow_forward
+            </span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default AgentCard;

--- a/src/hushh-agents/components/StepIndicator.tsx
+++ b/src/hushh-agents/components/StepIndicator.tsx
@@ -1,0 +1,56 @@
+/**
+ * StepIndicator — Visual step number with connecting line
+ *
+ * Shows a numbered step with title and optional subtitle.
+ * Used in the agents homepage to create a guided journey feel.
+ */
+import React from 'react';
+
+interface StepIndicatorProps {
+  /** Step number (1-4) */
+  step: number;
+  /** Step title */
+  title: string;
+  /** Optional subtitle */
+  subtitle?: string;
+  /** Whether this step has a connecting line below */
+  hasLine?: boolean;
+}
+
+const StepIndicator: React.FC<StepIndicatorProps> = ({
+  step,
+  title,
+  subtitle,
+  hasLine = true,
+}) => {
+  return (
+    <div className="flex items-start gap-4 mb-1">
+      {/* Step number circle + line */}
+      <div className="flex flex-col items-center shrink-0">
+        <div className="w-8 h-8 rounded-full bg-black text-white flex items-center justify-center text-[12px] font-bold">
+          {step}
+        </div>
+        {hasLine && (
+          <div className="w-px h-4 bg-gray-200 mt-1" />
+        )}
+      </div>
+
+      {/* Text */}
+      <div className="pt-0.5">
+        <h2
+          className="text-[18px] sm:text-[20px] font-semibold text-gray-900 leading-tight"
+          style={{ fontFamily: "'Playfair Display', serif" }}
+        >
+          {title}
+        </h2>
+        {subtitle && (
+          <p className="text-[12px] text-gray-400 font-light mt-0.5">
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default StepIndicator;

--- a/src/hushh-agents/hooks/useAgentOnboard.ts
+++ b/src/hushh-agents/hooks/useAgentOnboard.ts
@@ -1,8 +1,11 @@
 import { useState } from 'react';
 import { createClient } from '@supabase/supabase-js';
 
+/** Supabase URL — read from env, used for both client and edge function calls */
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL || '';
+
 const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL || 'https://ibsisfnjxeowvdtvgzff.supabase.co',
+  SUPABASE_URL,
   import.meta.env.VITE_SUPABASE_ANON_KEY || ''
 );
 
@@ -41,8 +44,6 @@ const INITIAL_FORM: AgentOnboardForm = {
   years_in_business: null,
   photo_url: '',
 };
-
-const SUPABASE_URL = 'https://ibsisfnjxeowvdtvgzff.supabase.co';
 
 export const useAgentOnboard = () => {
   const [form, setForm] = useState<AgentOnboardForm>(INITIAL_FORM);

--- a/src/hushh-agents/pages/AgentDetailPage.tsx
+++ b/src/hushh-agents/pages/AgentDetailPage.tsx
@@ -1,18 +1,27 @@
 /**
  * Agent Detail Page
- * 
- * MCP endpoint section + agent-specific chatbot powered by Hushh Intelligence.
- * Follows KYC onboarding UI patterns.
+ *
+ * Luxury redesign matching HomePage/KirklandAgentsPage design system.
+ * MCP endpoint + agent-specific chat + contact info.
+ * Logic unchanged — only UI revamped + responsive.
  */
 
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { createClient } from '@supabase/supabase-js';
-import HushhTechBackHeader from '../../components/hushh-tech-back-header/HushhTechBackHeader';
-import HushhTechCta, { HushhTechCtaVariant } from '../../components/hushh-tech-cta/HushhTechCta';
-import AgentAvatar from '../components/AgentAvatar';
 
-const playfair = { fontFamily: "'Playfair Display', serif" };
+/* ── Font helpers ── */
+const serif = { fontFamily: "'Playfair Display', serif" };
+const sans = { fontFamily: "'Inter', sans-serif" };
+
+/* ── Color palette ── */
+const C = {
+  primary: '#1A1A1B',
+  accent: '#C1A050',
+  textSub: '#6B7280',
+  border: '#E5E7EB',
+  bg: '#FFFFFF',
+};
 
 const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL || 'https://ibsisfnjxeowvdtvgzff.supabase.co',
@@ -45,59 +54,59 @@ const formatAddress = (a: AgentFull): string => {
   return parts.join(', ') || 'Address not available';
 };
 
-/** Star rating display */
-const Stars: React.FC<{ rating: number | null }> = ({ rating }) => {
-  if (!rating) return <span className="text-[11px] text-gray-400">No rating yet</span>;
-  const full = Math.floor(rating);
+/* ── Avatar initials ── */
+const AVATAR_COLORS = ['#1e3a5f', '#1e40af', '#166534', '#7e22ce', '#374151', '#0f766e', '#9f1239', '#92400e'];
+const AvatarInitials: React.FC<{ name: string; size?: 'md' | 'xl' }> = ({ name, size = 'md' }) => {
+  const initials = name.split(/\s+/).slice(0, 2).map(w => w[0]).join('').toUpperCase();
+  const colorIdx = name.split('').reduce((a, c) => a + c.charCodeAt(0), 0) % AVATAR_COLORS.length;
+  const sizeClass = size === 'xl' ? 'w-20 h-20 text-2xl' : 'w-12 h-12 text-lg';
   return (
-    <div className="flex items-center gap-0.5">
-      {[...Array(5)].map((_, i) => (
-        <span
-          key={i}
-          className={`material-symbols-outlined text-[18px] ${
-            i < full ? 'text-amber-400' : 'text-gray-200'
-          }`}
-          style={{ fontVariationSettings: i < full ? "'FILL' 1" : "'FILL' 0" }}
-        >
-          star
-        </span>
-      ))}
-      <span className="text-[14px] text-gray-900 ml-1.5 font-semibold">{rating.toFixed(1)}</span>
+    <div
+      className={`${sizeClass} rounded-2xl flex items-center justify-center text-white font-semibold shrink-0`}
+      style={{ backgroundColor: AVATAR_COLORS[colorIdx] }}
+    >
+      {initials}
     </div>
   );
 };
 
-/** Info row — matches KYC info card styling */
-const InfoRow: React.FC<{
-  icon: string;
-  label: string;
-  value: string;
-  onClick?: () => void;
-}> = ({ icon, label, value, onClick }) => (
+/* ── Rating text ── */
+const RatingText: React.FC<{ rating: number | null; count: number }> = ({ rating, count }) => {
+  if (!rating) return <span className="text-sm font-light" style={{ color: C.textSub }}>No rating yet</span>;
+  return (
+    <div className="flex items-center gap-1">
+      <span className="text-sm font-semibold" style={{ color: C.primary }}>{rating.toFixed(1)}</span>
+      <span className="text-amber-400 text-sm">★</span>
+      {count > 0 && <span className="text-xs font-light" style={{ color: C.textSub }}>({count} review{count !== 1 ? 's' : ''})</span>}
+    </div>
+  );
+};
+
+/* ── Section label ── */
+const SectionLabel = ({ children }: { children: string }) => (
+  <p className="text-[10px] uppercase tracking-[0.2em] font-medium mb-3" style={{ color: C.textSub, ...sans }}>{children}</p>
+);
+
+/* ── Info row card ── */
+const InfoRow: React.FC<{ icon: string; label: string; value: string; onClick?: () => void }> = ({ icon, label, value, onClick }) => (
   <button
     onClick={onClick}
     disabled={!onClick}
-    className={`flex items-start gap-3.5 p-4 rounded-2xl border border-gray-200/60 bg-white w-full text-left transition-all ${
-      onClick ? 'hover:border-gray-300 active:scale-[0.99] cursor-pointer' : ''
-    }`}
+    className={`flex items-start gap-4 p-4 sm:p-5 rounded-2xl border w-full text-left transition-all ${onClick ? 'hover:shadow-sm active:scale-[0.99] cursor-pointer' : ''}`}
+    style={{ borderColor: C.border, background: C.bg, ...sans }}
   >
-    <div className="w-9 h-9 rounded-xl bg-gray-50 flex items-center justify-center shrink-0">
-      <span className="material-symbols-outlined text-[18px] text-gray-500">{icon}</span>
+    <div className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0" style={{ background: '#F9FAFB' }}>
+      <span className="material-symbols-outlined text-lg" style={{ color: C.textSub }}>{icon}</span>
     </div>
     <div className="flex-1 min-w-0">
-      <p className="text-[10px] text-gray-400 uppercase tracking-[0.15em] font-medium">{label}</p>
-      <p className="text-[13px] text-gray-900 mt-0.5 break-words font-light leading-relaxed">{value}</p>
+      <p className="text-[10px] uppercase tracking-[0.15em] font-medium" style={{ color: C.textSub }}>{label}</p>
+      <p className="text-sm mt-0.5 break-words font-light leading-relaxed" style={{ color: C.primary }}>{value}</p>
     </div>
-    {onClick && (
-      <span className="material-symbols-outlined text-gray-300 text-[16px] shrink-0 mt-1">
-        open_in_new
-      </span>
-    )}
+    {onClick && <span className="material-symbols-outlined text-sm shrink-0 mt-1" style={{ color: C.border }}>open_in_new</span>}
   </button>
 );
 
-
-/** MCP Endpoint Row with copy */
+/* ── MCP Endpoint row ── */
 const McpEndpointRow: React.FC<{ agentId: string }> = ({ agentId }) => {
   const [copied, setCopied] = useState(false);
   const endpoint = `https://hushhtech.com/api/mcp/agents/${agentId}`;
@@ -105,46 +114,38 @@ const McpEndpointRow: React.FC<{ agentId: string }> = ({ agentId }) => {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(endpoint);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     } catch {
-      // fallback
       const el = document.createElement('textarea');
       el.value = endpoint;
       document.body.appendChild(el);
       el.select();
       document.execCommand('copy');
       document.body.removeChild(el);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
     }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   };
 
   return (
-    <div className="p-4 rounded-2xl border border-gray-200/60 bg-white">
-      <div className="flex items-center gap-2 mb-2">
-        <span className="px-2 py-0.5 bg-emerald-50 text-emerald-600 text-[8px] font-bold rounded-full uppercase tracking-wider border border-emerald-200/60">
-          MCP
-        </span>
-        <p className="text-[10px] text-gray-400 uppercase tracking-[0.15em] font-medium">Endpoint</p>
+    <div className="p-4 sm:p-5 rounded-2xl border" style={{ borderColor: C.border, background: C.bg, ...sans }}>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="bg-emerald-50 text-emerald-600 border border-emerald-100 text-[10px] font-semibold px-2 py-1 rounded-full uppercase tracking-wider">MCP</span>
+        <span className="text-[10px] uppercase tracking-[0.15em] font-medium" style={{ color: C.textSub }}>Endpoint</span>
       </div>
-      <div className="flex items-center gap-2 mt-1">
-        <code className="flex-1 text-[11px] text-gray-600 bg-gray-50 px-3 py-2 rounded-lg font-mono break-all leading-relaxed">
+      <div className="flex items-center gap-2">
+        <code className="flex-1 text-[11px] bg-gray-50 px-3 py-2.5 rounded-lg font-mono break-all leading-relaxed" style={{ color: C.textSub }}>
           {endpoint}
         </code>
         <button
           onClick={handleCopy}
-          className="w-8 h-8 rounded-lg bg-gray-100 hover:bg-gray-200 flex items-center justify-center shrink-0 transition-colors"
+          className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 transition-colors hover:bg-gray-100"
+          style={{ background: '#F3F4F6' }}
           aria-label="Copy endpoint"
         >
-          <span className="material-symbols-outlined text-[14px] text-gray-500">
-            {copied ? 'check' : 'content_copy'}
-          </span>
+          <span className="material-symbols-outlined text-sm" style={{ color: C.textSub }}>{copied ? 'check' : 'content_copy'}</span>
         </button>
       </div>
-      <p className="text-[10px] text-gray-400 font-light mt-2">
-        Connect to this agent via MCP from any AI tool.
-      </p>
+      <p className="text-[10px] font-light mt-2" style={{ color: C.textSub }}>Connect to this agent via MCP from any AI tool.</p>
     </div>
   );
 };
@@ -159,48 +160,34 @@ const AgentDetailPage: React.FC = () => {
     const fetchAgent = async () => {
       if (!agentId) return;
       setIsLoading(true);
-      const { data, error } = await supabase
-        .from('kirkland_agents')
-        .select('*')
-        .eq('id', agentId)
-        .single();
-
+      const { data, error } = await supabase.from('kirkland_agents').select('*').eq('id', agentId).single();
       if (!error && data) setAgent(data);
       setIsLoading(false);
     };
     fetchAgent();
   }, [agentId]);
 
-  // Loading state
+  /* Loading */
   if (isLoading) {
     return (
-      <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
-        <HushhTechBackHeader onBackClick={() => navigate('/hushh-agents/kirkland')} rightLabel="FAQs" />
-        <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48 flex items-center justify-center">
-          <div className="text-center">
-            <div className="w-12 h-12 rounded-2xl bg-gray-100 animate-pulse mx-auto mb-3" />
-            <p className="text-[13px] text-gray-400 font-light">Loading...</p>
-          </div>
-        </main>
+      <div className="min-h-screen flex items-center justify-center" style={{ background: C.bg, ...sans }}>
+        <div className="text-center">
+          <div className="w-12 h-12 rounded-2xl bg-gray-100 animate-pulse mx-auto mb-3" />
+          <p className="text-sm font-light" style={{ color: C.textSub }}>Loading...</p>
+        </div>
       </div>
     );
   }
 
-  // Not found state
+  /* Not found */
   if (!agent) {
     return (
-      <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
-        <HushhTechBackHeader onBackClick={() => navigate('/hushh-agents/kirkland')} rightLabel="FAQs" />
-        <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48 flex flex-col items-center justify-center">
-          <span className="material-symbols-outlined text-gray-200 text-[48px] mb-4">person_off</span>
-          <p className="text-gray-500 text-[15px] font-light">Agent not found</p>
-          <button
-            onClick={() => navigate('/hushh-agents/kirkland')}
-            className="mt-4 text-hushh-blue text-[13px] font-medium underline underline-offset-2"
-          >
-            Back to Directory
-          </button>
-        </main>
+      <div className="min-h-screen flex flex-col items-center justify-center" style={{ background: C.bg, ...sans }}>
+        <span className="material-symbols-outlined text-5xl mb-4" style={{ color: C.border }}>person_off</span>
+        <p className="text-base font-light" style={{ color: C.textSub }}>Agent not found</p>
+        <button onClick={() => navigate('/hushh-agents/kirkland')} className="mt-4 text-sm font-medium underline underline-offset-2" style={{ color: C.primary }}>
+          Back to Directory
+        </button>
       </div>
     );
   }
@@ -210,179 +197,152 @@ const AgentDetailPage: React.FC = () => {
     : `https://www.google.com/maps/search/${encodeURIComponent(formatAddress(agent))}`;
 
   return (
-    <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
-      <HushhTechBackHeader onBackClick={() => navigate('/hushh-agents/kirkland')} rightLabel="FAQs" />
+    <div className="min-h-screen pb-12" style={{ background: C.bg, color: C.primary, ...sans }}>
 
-      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48">
+      {/* ═══ Header ═══ */}
+      <header className="px-4 sm:px-6 md:px-8 pt-8 sm:pt-10 pb-4 max-w-md sm:max-w-lg md:max-w-3xl lg:max-w-4xl mx-auto">
+        <button onClick={() => navigate('/hushh-agents/kirkland')} className="flex items-center gap-1 transition-opacity hover:opacity-70" style={{ color: C.textSub }}>
+          <span className="material-symbols-outlined text-lg">arrow_back</span>
+          <span className="text-xs font-medium uppercase tracking-wider">Back to Directory</span>
+        </button>
+      </header>
 
-        {/* ── Profile Hero ── */}
-        <section className="pt-8 pb-6 text-center">
-          <AgentAvatar name={agent.name} size="xl" className="mx-auto mb-4" />
+      <main className="px-4 sm:px-6 md:px-8 max-w-md sm:max-w-lg md:max-w-3xl lg:max-w-4xl mx-auto">
 
-          <h1
-            className="text-[1.75rem] leading-[1.1] font-normal text-black tracking-tight font-serif"
-            style={playfair}
-          >
-            {agent.name}
-          </h1>
-
-          {agent.alias && (
-            <p className="text-[11px] text-gray-400 mt-1.5 font-light">@{agent.alias}</p>
-          )}
-
-          {/* MCP + Status badges */}
-          <div className="flex items-center justify-center gap-2 mt-3">
-            <span className="px-2.5 py-0.5 bg-emerald-50 text-emerald-600 text-[9px] font-bold rounded-full uppercase tracking-wider border border-emerald-200/60">
-              MCP Enabled
-            </span>
-            {agent.is_closed ? (
-              <span className="flex items-center gap-1 px-3 py-1 bg-red-50 text-red-500 rounded-full text-[10px] font-medium uppercase tracking-wider">
-                <span className="w-1.5 h-1.5 bg-red-400 rounded-full" />
-                Closed
-              </span>
-            ) : (
-              <span className="flex items-center gap-1 px-3 py-1 bg-green-50 text-green-600 rounded-full text-[10px] font-medium uppercase tracking-wider">
-                <span className="w-1.5 h-1.5 bg-green-500 rounded-full animate-pulse" />
-                Open
-              </span>
-            )}
+        {/* ═══ Profile Hero ═══ */}
+        <section className="pt-6 pb-8 text-center md:text-left md:flex md:items-start md:gap-8">
+          <div className="flex justify-center md:justify-start">
+            <AvatarInitials name={agent.name} size="xl" />
           </div>
+          <div className="mt-4 md:mt-0 flex-1">
+            <h1 className="text-2xl sm:text-3xl font-semibold leading-tight" style={serif}>{agent.name}</h1>
+            {agent.alias && <p className="text-xs font-light mt-1" style={{ color: C.textSub }}>@{agent.alias}</p>}
 
-          {/* Rating */}
-          <div className="flex flex-col items-center mt-4">
-            <Stars rating={agent.avg_rating} />
-            {agent.review_count > 0 && (
-              <p className="text-[11px] text-gray-400 mt-1 font-light">
-                {agent.review_count} review{agent.review_count !== 1 ? 's' : ''}
-              </p>
-            )}
-          </div>
-        </section>
-
-        {/* ── Chat with Agent (navigates to full chat page) ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-            AI Assistant
-          </p>
-          <button
-            onClick={() => navigate(`/hushh-agents/kirkland/${agent.id}/chat`)}
-            className="w-full flex items-center gap-3.5 p-4 rounded-2xl border border-emerald-200/60 bg-emerald-50/40 hover:border-emerald-300 transition-all active:scale-[0.99]"
-          >
-            <div className="w-9 h-9 rounded-xl bg-emerald-100 flex items-center justify-center shrink-0">
-              <span className="material-symbols-outlined text-[18px] text-emerald-600">smart_toy</span>
-            </div>
-            <div className="flex-1 text-left">
-              <p className="text-[13px] text-gray-900 font-medium">Chat with {agent.name}</p>
-              <p className="text-[11px] text-gray-400 font-light mt-0.5">Powered by Gemini · Hushh Intelligence</p>
-            </div>
-            <span className="material-symbols-outlined text-emerald-400 text-[18px]">arrow_forward</span>
-          </button>
-        </section>
-
-        {/* ── MCP Endpoint ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-            MCP & API
-          </p>
-          <McpEndpointRow agentId={agent.id} />
-        </section>
-
-        {/* ── Categories ── */}
-        {agent.categories?.length > 0 && (
-          <section className="pb-6">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-2.5 font-medium">
-              Categories
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {agent.categories.map((cat) => (
-                <span
-                  key={cat}
-                  className="px-3 py-1.5 bg-gray-50 border border-gray-200/60 text-gray-600 text-[11px] rounded-full font-medium"
-                >
-                  {cat}
+            {/* Badges */}
+            <div className="flex items-center justify-center md:justify-start gap-2 mt-3">
+              <span className="bg-emerald-50 text-emerald-600 border border-emerald-100 text-[9px] font-semibold px-2.5 py-0.5 rounded-full uppercase tracking-wider">MCP Enabled</span>
+              {agent.is_closed ? (
+                <span className="flex items-center gap-1 px-3 py-1 bg-red-50 text-red-500 rounded-full text-[10px] font-medium uppercase tracking-wider">
+                  <span className="w-1.5 h-1.5 bg-red-400 rounded-full" /> Closed
                 </span>
-              ))}
+              ) : (
+                <span className="flex items-center gap-1 px-3 py-1 bg-green-50 text-green-600 rounded-full text-[10px] font-medium uppercase tracking-wider">
+                  <span className="w-1.5 h-1.5 bg-green-500 rounded-full animate-pulse" /> Open
+                </span>
+              )}
             </div>
-          </section>
-        )}
 
-        {/* ── Contact Information ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-            Contact Information
-          </p>
-          <div className="space-y-3">
-            {agent.phone && (
-              <InfoRow
-                icon="call"
-                label="Phone"
-                value={agent.phone}
-                onClick={() => window.open(`tel:${agent.phone}`, '_self')}
-              />
-            )}
-            <InfoRow
-              icon="location_on"
-              label="Address"
-              value={formatAddress(agent)}
-              onClick={() => window.open(googleMapsUrl, '_blank')}
-            />
-            {agent.latitude && agent.longitude && (
-              <InfoRow
-                icon="directions"
-                label="Get Directions"
-                value={`${agent.latitude.toFixed(4)}, ${agent.longitude.toFixed(4)}`}
-                onClick={() => window.open(googleMapsUrl, '_blank')}
-              />
-            )}
+            {/* Rating */}
+            <div className="flex justify-center md:justify-start mt-3">
+              <RatingText rating={agent.avg_rating} count={agent.review_count} />
+            </div>
           </div>
         </section>
 
-        {/* ── Map Preview ── */}
-        {agent.latitude && agent.longitude && (
-          <section className="pb-8">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-              Location
-            </p>
-            <a
-              href={googleMapsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block rounded-2xl overflow-hidden border border-gray-200/60 hover:border-gray-300 transition-colors"
-            >
-              <img
-                src={`https://maps.googleapis.com/maps/api/staticmap?center=${agent.latitude},${agent.longitude}&zoom=14&size=600x200&markers=color:red%7C${agent.latitude},${agent.longitude}&key=AIzaSyBFw0Qbyq9zTFTd-tUY6dZWTgaQzuU17R8`}
-                alt={`Map of ${agent.name}`}
-                className="w-full h-[140px] object-cover bg-gray-50"
-                loading="lazy"
-                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-              />
-              <div className="p-3 flex items-center justify-between">
-                <span className="text-[11px] text-gray-400 font-light">View on Google Maps</span>
-                <span className="material-symbols-outlined text-gray-300 text-[14px]">open_in_new</span>
-              </div>
-            </a>
-          </section>
-        )}
+        {/* ═══ Two-column layout on desktop ═══ */}
+        <div className="md:grid md:grid-cols-2 md:gap-8">
 
-        {/* ── Action CTAs ── */}
-        <section className="space-y-3 pb-8">
+          {/* Left column */}
+          <div>
+            {/* Chat CTA */}
+            <section className="pb-6">
+              <SectionLabel>AI Assistant</SectionLabel>
+              <button
+                onClick={() => navigate(`/hushh-agents/kirkland/${agent.id}/chat`)}
+                className="w-full flex items-center gap-4 p-4 sm:p-5 rounded-2xl border transition-all hover:shadow-sm active:scale-[0.99]"
+                style={{ borderColor: '#d1fae5', background: '#ecfdf5' }}
+              >
+                <div className="w-10 h-10 rounded-xl bg-emerald-100 flex items-center justify-center shrink-0">
+                  <span className="material-symbols-outlined text-lg text-emerald-600">smart_toy</span>
+                </div>
+                <div className="flex-1 text-left">
+                  <p className="text-sm font-medium" style={{ color: C.primary }}>Chat with {agent.name}</p>
+                  <p className="text-xs font-light mt-0.5" style={{ color: C.textSub }}>Powered by Gemini · Hushh Intelligence</p>
+                </div>
+                <span className="material-symbols-outlined text-emerald-400 text-lg">arrow_forward</span>
+              </button>
+            </section>
+
+            {/* MCP Endpoint */}
+            <section className="pb-6">
+              <SectionLabel>MCP & API</SectionLabel>
+              <McpEndpointRow agentId={agent.id} />
+            </section>
+
+            {/* Categories */}
+            {agent.categories?.length > 0 && (
+              <section className="pb-6">
+                <SectionLabel>Categories</SectionLabel>
+                <div className="flex flex-wrap gap-2">
+                  {agent.categories.map((cat) => (
+                    <span key={cat} className="px-3 py-1.5 bg-gray-50 border text-[11px] rounded-full font-medium" style={{ borderColor: C.border, color: C.textSub }}>
+                      {cat}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+
+          {/* Right column */}
+          <div>
+            {/* Contact Info */}
+            <section className="pb-6">
+              <SectionLabel>Contact Information</SectionLabel>
+              <div className="space-y-3">
+                {agent.phone && (
+                  <InfoRow icon="call" label="Phone" value={agent.phone} onClick={() => window.open(`tel:${agent.phone}`, '_self')} />
+                )}
+                <InfoRow icon="location_on" label="Address" value={formatAddress(agent)} onClick={() => window.open(googleMapsUrl, '_blank')} />
+                {agent.latitude && agent.longitude && (
+                  <InfoRow icon="directions" label="Get Directions" value={`${agent.latitude.toFixed(4)}, ${agent.longitude.toFixed(4)}`} onClick={() => window.open(googleMapsUrl, '_blank')} />
+                )}
+              </div>
+            </section>
+
+            {/* Map Preview */}
+            {agent.latitude && agent.longitude && (
+              <section className="pb-6">
+                <SectionLabel>Location</SectionLabel>
+                <a href={googleMapsUrl} target="_blank" rel="noopener noreferrer" className="block rounded-2xl overflow-hidden border transition-shadow hover:shadow-sm" style={{ borderColor: C.border }}>
+                  <img
+                    src={`https://maps.googleapis.com/maps/api/staticmap?center=${agent.latitude},${agent.longitude}&zoom=14&size=600x200&markers=color:red%7C${agent.latitude},${agent.longitude}&key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY || ''}`}
+                    alt={`Map of ${agent.name}`}
+                    className="w-full h-[160px] object-cover bg-gray-50"
+                    loading="lazy"
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  />
+                  <div className="p-3 flex items-center justify-between">
+                    <span className="text-[11px] font-light" style={{ color: C.textSub }}>View on Google Maps</span>
+                    <span className="material-symbols-outlined text-sm" style={{ color: C.border }}>open_in_new</span>
+                  </div>
+                </a>
+              </section>
+            )}
+          </div>
+        </div>
+
+        {/* ═══ Action CTAs ═══ */}
+        <div className="max-w-md mx-auto md:max-w-sm space-y-3 pt-4 pb-8">
           {agent.phone && (
-            <HushhTechCta
-              variant={HushhTechCtaVariant.BLACK}
+            <button
               onClick={() => window.open(`tel:${agent.phone}`, '_self')}
+              className="w-full py-4 rounded-2xl font-medium text-sm flex items-center justify-center gap-2 transition-transform active:scale-[0.99]"
+              style={{ background: C.primary, color: '#FFFFFF' }}
             >
-              <span className="material-symbols-outlined text-[18px]">call</span>
+              <span className="material-symbols-outlined text-lg">call</span>
               Call Now
-            </HushhTechCta>
+            </button>
           )}
-          <HushhTechCta
-            variant={HushhTechCtaVariant.WHITE}
+          <button
             onClick={() => window.open(googleMapsUrl, '_blank')}
+            className="w-full py-4 rounded-2xl font-medium text-sm flex items-center justify-center gap-2 border transition-transform active:scale-[0.99]"
+            style={{ borderColor: C.border, color: C.primary, background: C.bg }}
           >
-            <span className="material-symbols-outlined text-[18px]">directions</span>
+            <span className="material-symbols-outlined text-lg">directions</span>
             Get Directions
-          </HushhTechCta>
-        </section>
+          </button>
+        </div>
       </main>
     </div>
   );

--- a/src/hushh-agents/pages/ChatPage.tsx
+++ b/src/hushh-agents/pages/ChatPage.tsx
@@ -79,12 +79,8 @@ export default function ChatPage() {
     }
   }, [messages, sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Redirect if not authenticated
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      navigate('/login', { state: { redirectTo: '/hushh-agents/chat' } });
-    }
-  }, [isAuthenticated, isLoading, navigate]);
+  // Auth is optional — users can chat without logging in
+  // Login only needed for cloud sync (future feature)
 
   // Handle send message
   const handleSend = async () => {
@@ -187,8 +183,6 @@ export default function ChatPage() {
     );
   }
 
-  if (!isAuthenticated) return null;
-
   return (
     <div className="bg-white text-gray-900 min-h-screen min-h-[100dvh] antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
       
@@ -223,7 +217,7 @@ export default function ChatPage() {
       {showHistory && (
         <>
           <div className="fixed inset-0 bg-black/30 z-[60]" onClick={() => setShowHistory(false)} />
-          <div className="fixed right-0 top-0 bottom-0 w-80 md:w-96 bg-white border-l border-gray-200 z-[70] flex flex-col shadow-2xl">
+          <div className="fixed right-0 top-0 bottom-0 w-[min(85vw,20rem)] md:w-96 bg-white border-l border-gray-200 z-[70] flex flex-col shadow-2xl">
             <div className="flex items-center justify-between px-4 py-4 border-b border-gray-100">
               <h3 className="text-sm font-semibold text-gray-900 flex items-center gap-2">
                 <span className="material-symbols-outlined text-base text-gray-500">history</span>

--- a/src/hushh-agents/pages/CodePage.tsx
+++ b/src/hushh-agents/pages/CodePage.tsx
@@ -85,12 +85,7 @@ export default function CodePage() {
     setMounted(true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Redirect if not authenticated
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      navigate('/login', { state: { redirectTo: '/hushh-agents/code' } });
-    }
-  }, [isAuthenticated, isLoading, navigate]);
+  // Auth is optional — code assistant works without login
 
   // Auto-save thread to localStorage whenever it changes
   useEffect(() => {
@@ -274,8 +269,6 @@ export default function CodePage() {
       </div>
     );
   }
-
-  if (!isAuthenticated) return null;
 
   const messageCount = thread.filter((m) => m.role === 'user').length;
 

--- a/src/hushh-agents/pages/HomePage.tsx
+++ b/src/hushh-agents/pages/HomePage.tsx
@@ -1,347 +1,817 @@
 /**
- * Hushh Agents — Home Page
- * 
- * Follows KYC onboarding UI patterns with Apple primary bright colors.
- * HushhTechHeader, max-w-md centered layout, Playfair headings.
+ * Hushh Agents — Landing Page (Saturn-inspired)
+ *
+ * Clean, editorial layout with dashed corner borders,
+ * serif headings, feature sections, CEO testimonial,
+ * enterprise security badges, and KPI stats.
+ * Fully public — no auth gate.
  */
-import { useNavigate, Link } from 'react-router-dom';
 import { useState, useEffect } from 'react';
-import HushhTechCta, { HushhTechCtaVariant } from '../../components/hushh-tech-cta/HushhTechCta';
-import { useAuth } from '../hooks/useAuth';
-import HushhLogo from '../../components/images/Hushhogo.png';
+import { useNavigate, Link } from 'react-router-dom';
+import HushhLogo from '../assets/Hushhogo.png';
 
-const playfair = { fontFamily: "'Playfair Display', serif" };
+/* ── Fonts ── */
+const serif = { fontFamily: "'Playfair Display', serif" };
+const sans = { fontFamily: "'Inter', sans-serif" };
 
-/* Apple system colors */
-const APPLE = {
-  blue: '#007AFF',
-  green: '#34C759',
-  orange: '#FF9500',
-  red: '#FF3B30',
-  purple: '#AF52DE',
-  teal: '#5AC8FA',
-  indigo: '#5856D6',
-  pink: '#FF2D55',
+/* ── Colors ── */
+const C = {
+  primary: '#1A1A1B',
+  accent: '#1400FF',
+  textSub: '#8A8A8A',
+  divider: '#E5E5E5',
+  bg: '#FFFFFF',
+  bgLight: '#F5F5F5',
 };
 
-/** Agent card — clean bordered card matching KYC style */
-const AgentNudge = ({
-  title,
-  subtitle,
-  description,
-  icon,
-  color,
-  badge,
-  badgeColor,
-  chips,
-  onClick,
+/* ═══════════════════════════════════════
+   Dashed Corner Section Wrapper
+   Saturn-style crop mark borders
+   ═══════════════════════════════════════ */
+const DashedSection = ({
+  children,
+  className = '',
+  id,
 }: {
-  title: string;
-  subtitle: string;
-  description: string;
-  icon: string;
-  color: string;
-  badge: string;
-  badgeColor: string;
-  chips: string[];
-  onClick: () => void;
+  children: React.ReactNode;
+  className?: string;
+  id?: string;
 }) => (
-  <button
-    onClick={onClick}
-    className="text-left w-full border border-gray-200/60 rounded-2xl p-5 transition-all active:scale-[0.98] hover:border-gray-300 bg-white"
-    aria-label={title}
+  <section
+    id={id}
+    className={`relative mx-4 sm:mx-6 md:mx-8 my-2 ${className}`}
+    style={{
+      borderLeft: `1px solid ${C.divider}`,
+      borderRight: `1px solid ${C.divider}`,
+      borderTop: `1px solid ${C.divider}`,
+      borderBottom: `1px solid ${C.divider}`,
+      clipPath:
+        'polygon(0 0, 20px 0, 20px 0, 20px 0, calc(100% - 20px) 0, 100% 0, 100% 20px, 100% 20px, 100% calc(100% - 20px), 100% 100%, calc(100% - 20px) 100%, 20px 100%, 0 100%, 0 calc(100% - 20px), 0 20px)',
+    }}
   >
-    <div className="flex items-start gap-3.5">
-      {/* Icon */}
-      <div
-        className="w-12 h-12 rounded-2xl flex items-center justify-center shrink-0"
-        style={{ backgroundColor: `${color}12` }}
-      >
-        <span className="material-symbols-outlined text-[24px]" style={{ color }}>
-          {icon}
-        </span>
-      </div>
-
-      {/* Content */}
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center justify-between mb-1">
-          <div>
-            <p className="text-[10px] text-gray-400 uppercase tracking-[0.15em] font-medium">
-              {subtitle}
-            </p>
-            <h3 className="text-[15px] font-semibold text-gray-900 leading-tight" style={playfair}>
-              {title}
-            </h3>
-          </div>
-          <span
-            className="px-2.5 py-0.5 rounded-full text-[9px] font-bold uppercase tracking-wider shrink-0"
-            style={{
-              backgroundColor: `${badgeColor}15`,
-              color: badgeColor,
-            }}
-          >
-            {badge}
-          </span>
-        </div>
-
-        <p className="text-[12px] text-gray-500 font-light leading-relaxed mt-1.5">
-          {description}
-        </p>
-
-        {/* Chips */}
-        <div className="flex flex-wrap gap-1.5 mt-3">
-          {chips.map((chip) => (
-            <span
-              key={chip}
-              className="px-2.5 py-1 bg-gray-50 border border-gray-100 rounded-full text-[10px] font-medium text-gray-500"
-            >
-              {chip}
-            </span>
-          ))}
-        </div>
-      </div>
-
-      {/* Chevron */}
-      <span className="material-symbols-outlined text-gray-300 text-[18px] shrink-0 mt-1">
-        chevron_right
-      </span>
-    </div>
-  </button>
+    {/* Top-left corner */}
+    <div
+      className="absolute top-0 left-0 w-5 h-5 pointer-events-none"
+      style={{
+        borderTop: `1px solid ${C.primary}`,
+        borderLeft: `1px solid ${C.primary}`,
+      }}
+    />
+    {/* Top-right corner */}
+    <div
+      className="absolute top-0 right-0 w-5 h-5 pointer-events-none"
+      style={{
+        borderTop: `1px solid ${C.primary}`,
+        borderRight: `1px solid ${C.primary}`,
+      }}
+    />
+    {/* Bottom-left corner */}
+    <div
+      className="absolute bottom-0 left-0 w-5 h-5 pointer-events-none"
+      style={{
+        borderBottom: `1px solid ${C.primary}`,
+        borderLeft: `1px solid ${C.primary}`,
+      }}
+    />
+    {/* Bottom-right corner */}
+    <div
+      className="absolute bottom-0 right-0 w-5 h-5 pointer-events-none"
+      style={{
+        borderBottom: `1px solid ${C.primary}`,
+        borderRight: `1px solid ${C.primary}`,
+      }}
+    />
+    {children}
+  </section>
 );
 
-export default function AgentsHomePage() {
+/* ═══════════════════════════════════════
+   Feature Section Component
+   Visual card + label + heading + desc
+   ═══════════════════════════════════════ */
+const FeatureSection = ({
+  label,
+  heading,
+  description,
+  description2,
+  linkText,
+  linkTo,
+  mockupIcon,
+  mockupItems,
+}: {
+  label: string;
+  heading: string;
+  description: string;
+  description2?: string;
+  linkText: string;
+  linkTo: string;
+  mockupIcon: string;
+  mockupItems?: string[];
+}) => {
   const navigate = useNavigate();
-  const { isAuthenticated, isLoading, user, signOut } = useAuth();
-  const [mounted, setMounted] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(0);
 
-  useEffect(() => { setMounted(true); }, []);
-
+  /* Auto-cycle through items every 2s — Saturn video-like effect */
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      navigate('/login', { state: { redirectTo: '/hushh-agents' } });
-    }
-  }, [isAuthenticated, isLoading, navigate]);
-
-  if (isLoading || !mounted) {
-    return (
-      <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col items-center justify-center">
-        <div className="w-14 h-14 rounded-2xl bg-gray-100 animate-pulse mb-3" />
-        <p className="text-[13px] text-gray-400 font-light">Loading...</p>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated) return null;
+    if (!mockupItems || mockupItems.length === 0) return;
+    const timer = setInterval(() => {
+      setActiveIdx((prev) => (prev + 1) % mockupItems.length);
+    }, 2000);
+    return () => clearInterval(timer);
+  }, [mockupItems]);
 
   return (
-    <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-blue-500 selection:text-white">
-
-      {/* ═══ Header — matches KYC sticky header ═══ */}
-      <header className="sticky top-0 z-40 bg-white/95 backdrop-blur-md px-6 py-4 flex items-center justify-between border-b border-gray-100">
-        <Link to="/hushh-agents" className="flex items-center gap-2.5">
-          <div className="w-9 h-9 rounded-xl bg-gray-900 flex items-center justify-center">
-            <img src={HushhLogo} alt="Hushh" className="w-6 h-6 object-contain" />
-          </div>
-          <div>
-            <span className="text-[13px] font-semibold text-gray-900 block leading-tight">Hushh Agents</span>
-            <span className="text-[9px] uppercase tracking-[0.2em] font-medium" style={{ color: APPLE.blue }}>
-              AI Platform
-            </span>
-          </div>
-        </Link>
-
-        <div className="flex items-center gap-3">
-          {user?.name && (
-            <span className="text-[11px] text-gray-400 hidden md:block font-light">
-              {user.name.split(' ')[0]}
-            </span>
-          )}
-          <button
-            onClick={signOut}
-            className="w-9 h-9 rounded-xl bg-gray-50 flex items-center justify-center hover:bg-gray-100 transition-colors"
-            aria-label="Sign Out"
+    <DashedSection>
+      {/* Visual Card — premium product mockup */}
+      <div
+        className="w-full py-8 sm:py-12 md:py-16 flex items-center justify-center relative overflow-hidden"
+        style={{ background: `linear-gradient(180deg, ${C.bgLight} 0%, #EBEBEB 100%)` }}
+      >
+        {mockupItems ? (
+          <div
+            className="w-[88%] max-w-[280px] sm:max-w-[320px] rounded-2xl overflow-hidden"
+            style={{
+              background: 'rgba(255,255,255,0.85)',
+              backdropFilter: 'blur(20px)',
+              boxShadow: '0 8px 32px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04)',
+              border: '1px solid rgba(255,255,255,0.6)',
+              animation: 'float-card 6s ease-in-out infinite',
+            }}
           >
-            <span className="material-symbols-outlined text-[18px] text-gray-400">logout</span>
+            {/* Mini app header bar */}
+            <div className="flex items-center gap-1.5 px-4 py-2.5" style={{ borderBottom: '1px solid #F0F0F0' }}>
+              <div className="w-2 h-2 rounded-full bg-[#FF5F57]" />
+              <div className="w-2 h-2 rounded-full bg-[#FFBD2E]" />
+              <div className="w-2 h-2 rounded-full bg-[#28C840]" />
+              <span className="ml-auto text-[9px] font-medium tracking-wider uppercase" style={{ color: '#BBB' }}>
+                hushh agents
+              </span>
+            </div>
+
+            {/* Items list */}
+            <div className="p-3 sm:p-4 flex flex-col gap-1.5 sm:gap-2">
+              {mockupItems.map((item, i) => {
+                const isActive = i === activeIdx;
+                return (
+                  <div
+                    key={item}
+                    className="flex items-center gap-2.5 px-3 sm:px-3.5 py-2 sm:py-2.5 rounded-lg transition-all duration-600"
+                    style={{
+                      background: isActive ? `linear-gradient(90deg, rgba(20,0,255,0.06) 0%, rgba(20,0,255,0.02) 100%)` : 'transparent',
+                      borderLeft: isActive ? `3px solid ${C.accent}` : '3px solid transparent',
+                      transform: isActive ? 'translateX(2px)' : 'translateX(0)',
+                      transition: 'all 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
+                    }}
+                  >
+                    {/* Check/radio icon */}
+                    <div
+                      className="w-4.5 h-4.5 sm:w-5 sm:h-5 rounded-full flex items-center justify-center flex-shrink-0 transition-all duration-400"
+                      style={{
+                        width: 18, height: 18,
+                        background: isActive ? C.accent : 'transparent',
+                        border: isActive ? 'none' : '1.5px solid #D0D0D0',
+                      }}
+                    >
+                      {isActive && (
+                        <span className="text-white text-[10px] font-bold">✓</span>
+                      )}
+                    </div>
+                    <span
+                      className="text-[12px] sm:text-[13px] transition-all duration-400"
+                      style={{
+                        color: isActive ? C.primary : '#B0B0B0',
+                        fontWeight: isActive ? 600 : 400,
+                        letterSpacing: isActive ? '0.01em' : '0',
+                      }}
+                    >
+                      {item}
+                    </span>
+                    {/* Animated arrow for active */}
+                    <span
+                      className="ml-auto transition-all duration-400"
+                      style={{
+                        opacity: isActive ? 0.6 : 0,
+                        transform: isActive ? 'translateX(0)' : 'translateX(-8px)',
+                        fontSize: 12,
+                        color: C.accent,
+                      }}
+                    >
+                      →
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Bottom progress indicator */}
+            <div className="px-4 pb-3">
+              <div className="flex gap-1.5">
+                {mockupItems.map((_, i) => (
+                  <div
+                    key={i}
+                    className="h-[3px] rounded-full flex-1 transition-all duration-500"
+                    style={{
+                      background: i <= activeIdx ? C.accent : '#E8E8E8',
+                      opacity: i === activeIdx ? 1 : i < activeIdx ? 0.4 : 0.2,
+                    }}
+                  />
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="relative">
+            {/* Concentric circles with pulse */}
+            <div
+              className="w-64 h-64 sm:w-72 sm:h-72 rounded-full border border-dashed flex items-center justify-center"
+              style={{ borderColor: '#D0D0D0', animation: 'pulse-ring 3s ease-in-out infinite' }}
+            >
+              <div
+                className="w-44 h-44 sm:w-52 sm:h-52 rounded-full border flex items-center justify-center"
+                style={{ borderColor: '#D8D8D8' }}
+              >
+                <div
+                  className="w-28 h-28 sm:w-36 sm:h-36 rounded-full flex items-center justify-center"
+                  style={{ background: C.accent }}
+                >
+                  <span className="material-symbols-outlined text-white text-4xl sm:text-5xl">
+                    {mockupIcon}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Text Content */}
+      <div className="px-5 sm:px-8 py-8 sm:py-10">
+        <p
+          className="text-[11px] tracking-[0.25em] uppercase mb-3 font-medium"
+          style={{ color: C.textSub, ...sans }}
+        >
+          {label}
+        </p>
+        <h3
+          className="text-2xl sm:text-3xl mb-4 font-normal"
+          style={{ ...serif, color: C.primary }}
+        >
+          {heading}
+        </h3>
+        <p
+          className="text-sm leading-relaxed mb-3 font-light"
+          style={{ color: C.textSub, ...sans }}
+        >
+          {description}
+        </p>
+        {description2 && (
+          <p
+            className="text-sm leading-relaxed mb-3 font-light"
+            style={{ color: C.textSub, ...sans }}
+          >
+            {description2}
+          </p>
+        )}
+        <button
+          onClick={() => navigate(linkTo)}
+          className="text-sm font-semibold mt-2 hover:opacity-70 transition-opacity"
+          style={{ color: C.accent, ...sans }}
+        >
+          {linkText}
+        </button>
+      </div>
+    </DashedSection>
+  );
+};
+
+/* ═══════════════════════════════════════
+   KPI Stat Block
+   ═══════════════════════════════════════ */
+const KpiBlock = ({ value, label }: { value: string; label: string }) => (
+  <DashedSection>
+    <div className="px-5 sm:px-8 py-16 sm:py-20">
+      <h3
+        className="text-5xl sm:text-6xl mb-6 font-normal"
+        style={{ ...serif, color: C.primary }}
+      >
+        {value}
+      </h3>
+      <p
+        className="text-sm leading-relaxed font-light max-w-md"
+        style={{ color: C.textSub, ...sans }}
+      >
+        {label}
+      </p>
+    </div>
+  </DashedSection>
+);
+
+/* ═══════════════════════════════════════
+   Main Page Component
+   ═══════════════════════════════════════ */
+export default function AgentsHomePage() {
+  const navigate = useNavigate();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  return (
+    <div
+      className="min-h-screen selection:bg-blue-100"
+      style={{ background: C.bg, color: C.primary, ...sans }}
+    >
+      {/* ═══ Header ═══ */}
+      <DashedSection>
+        <header className="px-5 sm:px-8 py-4 sm:py-5 flex items-center justify-between">
+          <Link to="/hushh-agents" className="flex items-center gap-3">
+            <img
+              src={HushhLogo}
+              alt="Hushh"
+              className="w-7 h-7 sm:w-8 sm:h-8 object-contain"
+            />
+            <span
+              className="text-lg sm:text-xl tracking-wide font-normal"
+              style={{ ...serif, color: C.primary }}
+            >
+              HUSHH AGENTS
+            </span>
+          </Link>
+          <button
+            onClick={() => setIsMenuOpen(true)}
+            className="w-10 h-10 flex items-center justify-center"
+            aria-label="Open menu"
+          >
+            <div className="flex flex-col gap-[5px]">
+              <span className="w-6 h-[1.5px]" style={{ background: C.primary }} />
+              <span className="w-6 h-[1.5px]" style={{ background: C.primary }} />
+            </div>
+          </button>
+        </header>
+      </DashedSection>
+
+      {/* ═══ Mobile Nav Drawer ═══ */}
+      {isMenuOpen && (
+        <div className="fixed inset-0 z-[100] bg-white flex flex-col" style={sans}>
+          {/* Drawer Header */}
+          <DashedSection>
+            <div className="px-5 sm:px-8 py-4 sm:py-5 flex items-center justify-between">
+              <Link to="/hushh-agents" className="flex items-center gap-3">
+                <img src={HushhLogo} alt="Hushh" className="w-7 h-7 sm:w-8 sm:h-8 object-contain" />
+                <span className="text-lg sm:text-xl tracking-wide font-normal" style={{ ...serif, color: C.primary }}>
+                  HUSHH AGENTS
+                </span>
+              </Link>
+              <button
+                onClick={() => setIsMenuOpen(false)}
+                className="w-10 h-10 flex items-center justify-center"
+                aria-label="Close menu"
+              >
+                <span className="material-symbols-outlined text-2xl" style={{ color: C.textSub }}>close</span>
+              </button>
+            </div>
+          </DashedSection>
+
+          {/* Nav Links — Home + 3 Agent types */}
+          <div className="flex-1 flex flex-col items-center justify-center gap-10">
+            {[
+              { label: 'Home', to: '/hushh-agents' },
+              { label: 'Chat', to: '/hushh-agents/chat' },
+              { label: 'Voice', to: '/hushh-agents/voice' },
+              { label: 'Code', to: '/hushh-agents/code' },
+            ].map((item) => (
+              <button
+                key={item.label}
+                onClick={() => { setIsMenuOpen(false); navigate(item.to); }}
+                className="text-base tracking-wide hover:opacity-60 transition-opacity"
+                style={{ color: C.textSub }}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Drawer Buttons */}
+          <div className="px-6 pb-10 space-y-3">
+            <button
+              onClick={() => { setIsMenuOpen(false); navigate('/hushh-agents/login'); }}
+              className="w-full py-4 text-center text-sm font-medium tracking-wide"
+              style={{ background: C.bgLight, color: C.primary }}
+            >
+              Login
+            </button>
+            <button
+              onClick={() => { setIsMenuOpen(false); navigate('/hushh-agents/kirkland'); }}
+              className="w-full py-4 text-center text-sm font-medium tracking-wide text-white"
+              style={{ background: C.accent }}
+            >
+              Get started
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ═══ Hero ═══ */}
+      <DashedSection>
+        <div className="px-5 sm:px-8 py-20 sm:py-28 md:py-32 text-center">
+          <h1
+            className="text-4xl sm:text-5xl md:text-6xl font-normal leading-tight mb-6"
+            style={{ ...serif, color: C.primary }}
+          >
+            Unlock your
+            <br />
+            <span className="italic" style={{ color: C.textSub }}>
+              advisory potential
+            </span>
+          </h1>
+          <p
+            className="text-sm sm:text-base leading-relaxed font-light max-w-lg mx-auto mb-10"
+            style={{ color: C.textSub, ...sans }}
+          >
+            AI-powered agents for Registered Investment Advisors and financial
+            professionals. Discover local advisors, automate workflows, and
+            deliver excellence at scale.
+          </p>
+          <button
+            onClick={() => navigate('/hushh-agents/kirkland')}
+            className="inline-flex items-center gap-2 px-8 py-4 text-sm font-medium text-white tracking-wide transition-opacity hover:opacity-90"
+            style={{ background: C.accent }}
+          >
+            Get started
+            <span className="text-lg">→</span>
           </button>
         </div>
-      </header>
+      </DashedSection>
 
-      {/* ═══ Main Content ═══ */}
-      <main className="px-4 sm:px-6 flex-grow max-w-md md:max-w-2xl lg:max-w-4xl mx-auto w-full pb-32 md:pb-16">
-
-        {/* ── Hero ── */}
-        <section className="pt-6 sm:pt-8 pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-2 font-medium">
-            Your AI Companions
-          </p>
-          <h1
-            className="text-[2rem] leading-[1.1] font-normal text-black tracking-tight font-serif"
-            style={playfair}
+      {/* ═══ Trusted By — Scrolling Marquee ═══ */}
+      <DashedSection>
+        <div className="py-14 sm:py-20 overflow-hidden" style={{ background: C.bgLight }}>
+          {/* Marquee with fade edges */}
+          <div
+            className="relative mb-10"
+            style={{
+              WebkitMaskImage: 'linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%)',
+              maskImage: 'linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%)',
+            }}
           >
-            Meet Your <br />
-            <span className="text-gray-400 italic font-light">Agents.</span>
-          </h1>
-          <p className="text-gray-500 text-[13px] font-light mt-3 leading-relaxed">
-            Intelligent assistants powered by GCP AI. Chat in English, Hindi, or Tamil.
-          </p>
-        </section>
-
-        {/* ── Primary Agents ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-            Available Agents
-          </p>
-          <div className="space-y-3 md:grid md:grid-cols-2 md:gap-4 md:space-y-0">
-            {/* Kirkland Agents Directory — Priority */}
-            <AgentNudge
-              title="Kirkland Agents"
-              subtitle="Local Directory · 771 Agents"
-              description="Browse and discover local agents. Search by name, category, or location. View ratings and get directions."
-              icon="location_city"
-              color={APPLE.indigo}
-              badge="Live"
-              badgeColor={APPLE.blue}
-              chips={['Search', 'Filter', 'Ratings', 'Directions']}
-              onClick={() => navigate('/hushh-agents/kirkland')}
-            />
-
-            {/* Hushh Chat Agent */}
-            <AgentNudge
-              title="Hushh"
-              subtitle="Primary Agent"
-              description="Your intelligent AI companion. Ask questions, get analysis, creative writing, coding help, and more."
-              icon="smart_toy"
-              color={APPLE.blue}
-              badge="Online"
-              badgeColor={APPLE.green}
-              chips={['Multi-language', 'Voice', 'Code', 'Analysis']}
-              onClick={() => navigate('/hushh-agents/chat')}
-            />
-
-            {/* Tamil Voice Agent */}
-            <AgentNudge
-              title="தமிழ் குரல்"
-              subtitle="Voice Agent · Gemini Live"
-              description="Speak in Tamil, get responses in Tamil. Real-time voice conversations powered by Google's most advanced AI."
-              icon="record_voice_over"
-              color={APPLE.orange}
-              badge="New"
-              badgeColor={APPLE.orange}
-              chips={['Real-time', 'Native Tamil', 'Low Latency', 'No Typing']}
-              onClick={() => navigate('/hushh-agents/voice?lang=ta-IN')}
-            />
-
-            {/* Code Agent */}
-            <AgentNudge
-              title="Hushh Code"
-              subtitle="Code Agent · Extended Thinking"
-              description="AI-powered code generation, debugging, explanation, and optimization with step-by-step reasoning."
-              icon="terminal"
-              color={APPLE.purple}
-              badge="Online"
-              badgeColor={APPLE.green}
-              chips={['Generate', 'Debug', 'Explain', 'TS · PY · GO']}
-              onClick={() => navigate('/hushh-agents/code')}
-            />
-          </div>
-        </section>
-
-        {/* ── Capabilities Grid ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-            Capabilities
-          </p>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            {[
-              { icon: 'chat', label: 'Chat', desc: 'Natural conversations', color: APPLE.blue },
-              { icon: 'translate', label: 'Languages', desc: 'EN · HI · TA', color: APPLE.green },
-              { icon: 'mic', label: 'Voice', desc: 'Speak naturally', color: APPLE.orange },
-              { icon: 'code', label: 'Code', desc: 'Programming help', color: APPLE.purple },
-            ].map((item) => (
-              <div
-                key={item.icon}
-                className="border border-gray-200/60 rounded-2xl p-4 bg-white"
-              >
-                <div
-                  className="w-9 h-9 rounded-xl flex items-center justify-center mb-2.5"
-                  style={{ backgroundColor: `${item.color}12` }}
-                >
-                  <span className="material-symbols-outlined text-[18px]" style={{ color: item.color }}>
-                    {item.icon}
+            <div
+              className="flex items-center whitespace-nowrap"
+              style={{
+                animation: 'marquee-scroll 30s linear infinite',
+                width: 'max-content',
+              }}
+            >
+              {[1, 2].map((set) => (
+                <div key={set} className="flex items-center" style={{ gap: '4.5rem' }}>
+                  {/* rockwealth */}
+                  <span
+                    className="text-2xl sm:text-3xl md:text-4xl tracking-tight"
+                    style={{ color: C.primary, opacity: 0.35, fontFamily: "'Inter', sans-serif", fontWeight: 700 }}
+                  >
+                    rock<span style={{ fontWeight: 300 }}>wealth</span>
                   </span>
+
+                  {/* Paradigm Norton | for life */}
+                  <span
+                    className="text-2xl sm:text-3xl md:text-4xl flex items-center"
+                    style={{ color: C.primary, opacity: 0.35 }}
+                  >
+                    <span style={{ fontFamily: "'Playfair Display', serif", fontWeight: 600 }}>Paradigm</span>
+                    <span className="inline-block w-px mx-3" style={{ height: '1.8em', background: '#AAAAAA' }} />
+                    <span style={{ fontFamily: "'Playfair Display', serif", fontWeight: 300, fontStyle: 'italic' }}>for life</span>
+                  </span>
+
+                  {/* COOPER PARRY */}
+                  <span
+                    className="text-2xl sm:text-3xl md:text-4xl uppercase"
+                    style={{ color: C.primary, opacity: 0.35, fontFamily: "'Inter', sans-serif", fontWeight: 900, letterSpacing: '0.12em' }}
+                  >
+                    Cooper Parry
+                  </span>
+
+                  {/* hushh.ai */}
+                  <span
+                    className="text-2xl sm:text-3xl md:text-4xl tracking-tight"
+                    style={{ color: C.primary, opacity: 0.35, fontFamily: "'Inter', sans-serif", fontWeight: 800 }}
+                  >
+                    hushh<span style={{ fontWeight: 300 }}>.ai</span>
+                  </span>
+
+                  {/* Kirkland Advisors */}
+                  <span
+                    className="text-2xl sm:text-3xl md:text-4xl"
+                    style={{ color: C.primary, opacity: 0.35, fontFamily: "'Playfair Display', serif", fontWeight: 600 }}
+                  >
+                    Kirkland <span style={{ fontWeight: 300, fontStyle: 'italic' }}>Advisors</span>
+                  </span>
+
+                  {/* Google Cloud */}
+                  <span
+                    className="text-2xl sm:text-3xl md:text-4xl"
+                    style={{ color: C.primary, opacity: 0.35, fontFamily: "'Inter', sans-serif", fontWeight: 500, letterSpacing: '0.02em' }}
+                  >
+                    Google Cloud
+                  </span>
+
+                  {/* spacer between sets */}
+                  <span className="inline-block" style={{ width: '4.5rem' }} />
                 </div>
-                <h5 className="text-[13px] font-medium text-gray-900">{item.label}</h5>
-                <p className="text-[10px] text-gray-400 font-light mt-0.5">{item.desc}</p>
+              ))}
+            </div>
+          </div>
+
+          <p
+            className="text-sm text-center font-light tracking-wide px-5"
+            style={{ color: C.textSub, fontFamily: "'Inter', sans-serif" }}
+          >
+            Trusted by over 500+ leading advice firms
+          </p>
+        </div>
+      </DashedSection>
+
+      {/* Animation keyframes */}
+      <style>{`
+        @keyframes marquee-scroll {
+          0% { transform: translateX(0); }
+          100% { transform: translateX(-50%); }
+        }
+        @keyframes pulse-ring {
+          0%, 100% { opacity: 0.6; transform: scale(1); }
+          50% { opacity: 1; transform: scale(1.03); }
+        }
+        @keyframes float-card {
+          0%, 100% { transform: translateY(0px); }
+          50% { transform: translateY(-6px); }
+        }
+      `}</style>
+
+      {/* ═══ Feature 1: Kirkland R.I.A. Agents (PRIMARY) ═══ */}
+      <FeatureSection
+        label="R.I.A. AGENT NETWORK"
+        heading="Discover advisors near you"
+        description="Browse and connect with Registered Investment Advisors in Kirkland and beyond. Search by name, specialty, or location to find the right financial expertise."
+        description2="Unify everything into a single source of truth through deep integrations with your advisory ecosystem and back-office platforms."
+        linkText="Learn more"
+        linkTo="/hushh-agents/kirkland"
+        mockupIcon="domain"
+        mockupItems={['R.I.A. Advisors', 'Fund Research', 'Compliance Reports', 'Client Matching']}
+      />
+
+      {/* ═══ Feature 2: AI Chat ═══ */}
+      <FeatureSection
+        label="INTELLIGENT CONVERSATIONS"
+        heading="Converse naturally in any language"
+        description="Your AI companion that understands context, nuance, and multiple languages. Ask questions, get analysis, creative writing, and more."
+        description2="Create a seamless conversational experience where your AI operates in perfect harmony, scaling effortlessly with your needs."
+        linkText="Learn more"
+        linkTo="/hushh-agents/chat"
+        mockupIcon="chat"
+        mockupItems={['Natural Language', 'Multi-turn Context', 'Creative Writing', 'Code Analysis']}
+      />
+
+      {/* ═══ Feature 3: Voice Agent ═══ */}
+      <FeatureSection
+        label="VOICE INTELLIGENCE"
+        heading="Speak naturally, get instant responses"
+        description="Real-time voice conversations powered by advanced AI. Speak in Tamil, Hindi, or English and get native responses instantly."
+        description2="Reinvent communication from text-only to voice-first with intelligent speech recognition across every interaction."
+        linkText="Learn more"
+        linkTo="/hushh-agents/voice"
+        mockupIcon="record_voice_over"
+      />
+
+      {/* ═══ Feature 4: Code Generation ═══ */}
+      <FeatureSection
+        label="CODE ASSISTANT"
+        heading="Generate, debug and optimize code"
+        description="AI-powered code generation, debugging, explanation, and optimization with step-by-step reasoning."
+        description2="From suitability analysis to code reviews, release your team from manual debugging to focus exclusively on value delivery."
+        linkText="Learn more"
+        linkTo="/hushh-agents/code"
+        mockupIcon="code"
+      />
+
+      {/* ═══ CEO Section ═══ */}
+      <DashedSection>
+        <div className="px-5 sm:px-8 pt-6 sm:pt-8">
+          {/* CEO Image */}
+          <div
+            className="w-full aspect-[4/3] sm:aspect-[16/10] rounded-sm overflow-hidden mb-8 flex items-center justify-center"
+            style={{ background: 'linear-gradient(135deg, #1a1a1b 0%, #333 100%)' }}
+          >
+            <div className="text-center">
+              <div
+                className="w-32 h-32 sm:w-40 sm:h-40 rounded-full mx-auto mb-4 flex items-center justify-center"
+                style={{ background: 'rgba(255,255,255,0.1)' }}
+              >
+                <span className="text-5xl sm:text-6xl" style={{ color: 'rgba(255,255,255,0.8)' }}>
+                  MS
+                </span>
               </div>
+              <span
+                className="text-xs uppercase tracking-[0.2em] font-medium"
+                style={{ color: 'rgba(255,255,255,0.4)' }}
+              >
+                hushh technologies
+              </span>
+            </div>
+            {/* Next Arrow */}
+            <button
+              className="absolute right-8 sm:right-10 bottom-[calc(50%+20px)] w-10 h-10 rounded flex items-center justify-center"
+              style={{ background: C.primary }}
+              aria-label="Next testimonial"
+            >
+              <span className="material-symbols-outlined text-white text-lg">chevron_right</span>
+            </button>
+          </div>
+
+          {/* Quote */}
+          <p
+            className="text-sm sm:text-base leading-relaxed font-light mb-8"
+            style={{ color: C.textSub, ...sans }}
+          >
+            We're redefining the data landscape. Our mission: empower users by making their
+            data universally accessible and valuable, all while placing paramount importance
+            on privacy and user control. Hushh Agents lets us focus on delivering that for
+            our users.
+          </p>
+
+          {/* Dashed Divider */}
+          <div
+            className="border-b border-dashed mb-6"
+            style={{ borderColor: C.divider }}
+          />
+
+          {/* CEO Info */}
+          <div className="pb-8">
+            <h4 className="text-base font-bold mb-1" style={{ color: C.primary, ...sans }}>
+              Manish Sainani
+            </h4>
+            <p className="text-sm font-light" style={{ color: C.textSub, ...sans }}>
+              CEO
+            </p>
+            <p className="text-sm font-light" style={{ color: C.textSub, ...sans }}>
+              Hushh Technologies
+            </p>
+          </div>
+        </div>
+      </DashedSection>
+
+      {/* ═══ Enterprise Security ═══ */}
+      <DashedSection>
+        <div className="px-5 sm:px-8 py-10 sm:py-14">
+          <h3
+            className="text-2xl sm:text-3xl mb-5 font-normal"
+            style={{ ...serif, color: C.primary }}
+          >
+            Enterprise security as standard
+          </h3>
+          <div className="space-y-1 mb-4">
+            <p className="text-sm font-light" style={{ color: C.textSub, ...sans }}>
+              Privacy. Security. Peace of mind.
+            </p>
+            <p className="text-sm font-light" style={{ color: C.textSub, ...sans }}>
+              Never used for training.
+            </p>
+            <p className="text-sm font-light" style={{ color: C.textSub, ...sans }}>
+              Round the clock enterprise security.
+            </p>
+          </div>
+          <button
+            className="text-sm font-semibold mt-2 mb-8 hover:opacity-70 transition-opacity"
+            style={{ color: C.accent, ...sans }}
+          >
+            Learn more
+          </button>
+
+          {/* Security Badges */}
+          <div className="flex items-center gap-6 sm:gap-10">
+            {/* SOC 2 */}
+            <div
+              className="w-20 h-20 sm:w-24 sm:h-24 rounded-full border flex flex-col items-center justify-center"
+              style={{ borderColor: C.divider }}
+            >
+              <span className="text-[11px] font-bold" style={{ color: C.primary }}>
+                AICPA
+              </span>
+              <span className="text-[10px] font-light" style={{ color: C.textSub }}>
+                SOC 2
+              </span>
+            </div>
+            {/* GDPR */}
+            <div
+              className="w-20 h-20 sm:w-24 sm:h-24 rounded-full border flex flex-col items-center justify-center"
+              style={{ borderColor: C.divider }}
+            >
+              <div className="flex items-center gap-0.5 mb-0.5">
+                {[...Array(5)].map((_, i) => (
+                  <span key={i} className="text-[8px]" style={{ color: C.textSub }}>
+                    ★
+                  </span>
+                ))}
+              </div>
+              <span className="text-[11px] font-bold" style={{ color: C.primary }}>
+                GDPR
+              </span>
+              <div className="flex items-center gap-0.5">
+                {[...Array(5)].map((_, i) => (
+                  <span key={i} className="text-[8px]" style={{ color: C.textSub }}>
+                    ★
+                  </span>
+                ))}
+              </div>
+            </div>
+            {/* Cyber Essentials */}
+            <div
+              className="w-20 h-20 sm:w-24 sm:h-24 rounded-full border flex flex-col items-center justify-center"
+              style={{ borderColor: C.divider }}
+            >
+              <span className="material-symbols-outlined text-sm mb-0.5" style={{ color: C.textSub }}>
+                check
+              </span>
+              <span className="text-[10px] font-medium text-center leading-tight" style={{ color: C.primary }}>
+                Cyber
+              </span>
+              <span className="text-[9px] font-light" style={{ color: C.textSub }}>
+                Essentials
+              </span>
+            </div>
+          </div>
+        </div>
+      </DashedSection>
+
+      {/* ═══ KPI Stats ═══ */}
+      <KpiBlock
+        value="500+"
+        label="Leading enterprises use Hushh Agents to automate workflows, generate insights and enhance productivity"
+      />
+      <KpiBlock
+        value="3,000+"
+        label="AI-powered conversations processed daily across multiple languages and modalities"
+      />
+      <KpiBlock
+        value="99.9%"
+        label="Uptime SLA backed by Google Cloud infrastructure with enterprise-grade reliability"
+      />
+
+      {/* ═══ CTA Footer ═══ */}
+      <div className="mx-4 sm:mx-6 md:mx-8 my-8">
+        <div
+          className="rounded-sm px-6 sm:px-10 py-14 sm:py-20"
+          style={{ background: C.primary }}
+        >
+          <h3
+            className="text-3xl sm:text-4xl text-white mb-8 font-normal"
+            style={serif}
+          >
+            Unlock your AI agents
+          </h3>
+          <button
+            onClick={() => navigate('/hushh-agents/kirkland')}
+            className="inline-flex items-center gap-2 px-7 py-4 text-sm font-medium tracking-wide text-white transition-opacity hover:opacity-80"
+            style={{ background: 'rgba(255,255,255,0.15)' }}
+          >
+            Get started
+            <span className="text-lg">→</span>
+          </button>
+        </div>
+      </div>
+
+      {/* ═══ Footer ═══ */}
+      <DashedSection>
+        <footer className="px-5 sm:px-8 py-10 sm:py-14">
+          <p className="text-sm mb-6" style={{ color: C.textSub, ...sans }}>
+            contact@hushh.ai
+          </p>
+          <div className="space-y-4 mb-8">
+            {['Careers', 'Journal', 'Security', 'Agents', 'About Us'].map((link) => (
+              <p key={link}>
+                <span
+                  className="text-sm cursor-pointer hover:opacity-60 transition-opacity"
+                  style={{ color: C.primary, ...sans }}
+                >
+                  {link}
+                </span>
+              </p>
             ))}
           </div>
-        </section>
-
-        {/* ── Coming Soon ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
-            Coming Soon
-          </p>
-          <div className="space-y-3 md:grid md:grid-cols-2 md:gap-4 md:space-y-0">
-            {[
-              { name: 'Kai', desc: 'Investment analysis & market insights', icon: 'trending_up', color: APPLE.teal },
-              { name: 'Luna', desc: 'Document processing & summaries', icon: 'description', color: APPLE.pink },
-            ].map((agent) => (
-              <div
-                key={agent.name}
-                className="border border-gray-200/60 rounded-2xl p-4 flex items-center gap-3.5 opacity-50"
-              >
-                <div
-                  className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-                  style={{ backgroundColor: `${agent.color}12` }}
-                >
-                  <span className="material-symbols-outlined text-[18px]" style={{ color: agent.color }}>
-                    {agent.icon}
-                  </span>
-                </div>
-                <div className="flex-1 min-w-0">
-                  <h5 className="text-[13px] font-medium text-gray-900 flex items-center gap-2">
-                    {agent.name}
-                    <span className="text-[8px] uppercase tracking-wider bg-gray-100 px-2 py-0.5 rounded-full text-gray-400 font-bold">
-                      Soon
-                    </span>
-                  </h5>
-                  <p className="text-[11px] text-gray-400 font-light mt-0.5">{agent.desc}</p>
-                </div>
-              </div>
-            ))}
+          <div className="border-t pt-6" style={{ borderColor: C.divider }}>
+            <div className="flex items-center gap-4 flex-wrap text-sm mb-3">
+              <Link to="/privacy-policy" className="hover:opacity-60" style={{ color: C.primary }}>
+                Privacy Policy
+              </Link>
+              <span style={{ color: C.divider }}>•</span>
+              <span style={{ color: C.primary }}>Terms of Service</span>
+            </div>
+            <p className="text-xs font-light" style={{ color: C.textSub }}>
+              Hushh Technologies LLC, Kirkland, Washington
+            </p>
+            <p className="text-xs font-light mt-1" style={{ color: C.textSub }}>
+              © {new Date().getFullYear()}, All rights reserved.
+            </p>
           </div>
-        </section>
+        </footer>
+      </DashedSection>
 
-        {/* ── Primary CTA ── */}
-        <section className="pb-8">
-          <HushhTechCta
-            onClick={() => navigate('/hushh-agents/chat')}
-            variant={HushhTechCtaVariant.BLACK}
-          >
-            <span className="material-symbols-outlined text-[18px]">chat</span>
-            Start Chatting with Hushh
-          </HushhTechCta>
-        </section>
-
-        {/* ── Trust Footer ── */}
-        <section className="pb-4 text-center">
-          <div className="flex items-center justify-center gap-2 mb-2">
-            <span className="material-symbols-outlined text-[14px]" style={{ color: APPLE.blue }}>
-              lock
-            </span>
-            <span className="text-[10px] text-gray-400 uppercase tracking-wider font-medium">
-              Secure · Private · No Data Stored
-            </span>
-          </div>
-          <p className="text-[10px] text-gray-300 font-light">
-            Powered by Hushh Intelligence & Google Cloud AI
-          </p>
-          <p className="text-[9px] text-gray-300 mt-1">
-            © {new Date().getFullYear()} Hushh Technologies
-          </p>
-        </section>
-      </main>
+      {/* Bottom spacing */}
+      <div className="h-8" />
     </div>
   );
 }

--- a/src/hushh-agents/pages/KirklandAgentsPage.tsx
+++ b/src/hushh-agents/pages/KirklandAgentsPage.tsx
@@ -1,18 +1,29 @@
 /**
- * Kirkland Agents — Listing Page
- * 
- * Major category filters (Finance, RIA, Insurance, etc.)
- * MCP badge on every agent card.
- * Follows KYC onboarding UI patterns.
+ * Kirkland Agents — Directory Page
+ *
+ * Luxury redesign with Playfair Display + Inter fonts.
+ * Category grid, search, rounded agent cards with MCP badges.
+ * Logic unchanged — only UI revamped + responsive.
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { createClient } from '@supabase/supabase-js';
-import HushhTechBackHeader from '../../components/hushh-tech-back-header/HushhTechBackHeader';
 import AgentAvatar from '../components/AgentAvatar';
 
-const playfair = { fontFamily: "'Playfair Display', serif" };
+/* ── Font helpers ── */
+const serif = { fontFamily: "'Playfair Display', serif" };
+const sans = { fontFamily: "'Inter', sans-serif" };
+
+/* ── Color palette (matches HomePage) ── */
+const C = {
+  primary: '#1A1A1B',
+  accent: '#C1A050',
+  textSub: '#6B7280',
+  border: '#E5E7EB',
+  surface: '#FDFDFD',
+  bg: '#FFFFFF',
+};
 
 const supabase = createClient(
   import.meta.env.VITE_SUPABASE_URL || 'https://ibsisfnjxeowvdtvgzff.supabase.co',
@@ -28,78 +39,16 @@ interface MajorCategory {
 }
 
 const MAJOR_CATEGORIES: MajorCategory[] = [
-  {
-    key: 'finance',
-    label: 'Finance',
-    icon: 'account_balance',
-    keywords: ['financial', 'accountant', 'tax', 'bank', 'credit union', 'bookkeeping', 'payroll', 'mortgage', 'loan', 'wealth'],
-  },
-  {
-    key: 'ria',
-    label: 'RIA',
-    icon: 'trending_up',
-    keywords: ['investment', 'advisor', 'portfolio', 'asset management', 'securities', 'hedge fund', 'mutual fund', 'brokerage', 'fiduciary'],
-  },
-  {
-    key: 'insurance',
-    label: 'Insurance',
-    icon: 'shield',
-    keywords: ['insurance', 'life insurance', 'health insurance', 'auto insurance', 'property insurance', 'underwriting'],
-  },
-  {
-    key: 'real-estate',
-    label: 'Real Estate',
-    icon: 'home_work',
-    keywords: ['real estate', 'property', 'realtor', 'housing', 'apartment', 'commercial real estate', 'land'],
-  },
-  {
-    key: 'health',
-    label: 'Health',
-    icon: 'local_hospital',
-    keywords: ['doctor', 'dentist', 'health', 'medical', 'chiropractic', 'optometrist', 'pharmacy', 'clinic', 'hospital', 'therapy', 'mental health', 'veterinar'],
-  },
-  {
-    key: 'legal',
-    label: 'Legal',
-    icon: 'gavel',
-    keywords: ['lawyer', 'legal', 'attorney', 'law firm', 'notary', 'immigration', 'divorce', 'criminal', 'estate planning'],
-  },
-  {
-    key: 'technology',
-    label: 'Tech',
-    icon: 'code',
-    keywords: ['it ', 'software', 'web design', 'technology', 'computer', 'internet', 'data', 'cloud', 'cyber', 'telecom'],
-  },
-  {
-    key: 'home-services',
-    label: 'Home',
-    icon: 'construction',
-    keywords: ['plumb', 'electric', 'contractor', 'landscap', 'roofing', 'paint', 'cleaning', 'handyman', 'hvac', 'pest', 'locksmith', 'moving'],
-  },
-  {
-    key: 'food',
-    label: 'Food',
-    icon: 'restaurant',
-    keywords: ['restaurant', 'cafe', 'coffee', 'bar', 'bakery', 'pizza', 'food', 'catering', 'grocery', 'deli', 'brewery'],
-  },
-  {
-    key: 'auto',
-    label: 'Auto',
-    icon: 'directions_car',
-    keywords: ['auto', 'car', 'vehicle', 'mechanic', 'tire', 'body shop', 'towing', 'oil change', 'transmission'],
-  },
-  {
-    key: 'education',
-    label: 'Education',
-    icon: 'school',
-    keywords: ['school', 'tutor', 'training', 'education', 'university', 'college', 'preschool', 'daycare', 'child care'],
-  },
-  {
-    key: 'beauty',
-    label: 'Beauty',
-    icon: 'spa',
-    keywords: ['salon', 'spa', 'massage', 'beauty', 'hair', 'nail', 'skin', 'barber', 'cosmetic', 'waxing'],
-  },
+  { key: 'finance', label: 'Finance', icon: 'account_balance', keywords: ['financial', 'accountant', 'tax', 'bank', 'credit union', 'bookkeeping', 'payroll', 'mortgage', 'loan', 'wealth'] },
+  { key: 'insurance', label: 'Insurance', icon: 'shield', keywords: ['insurance', 'life insurance', 'health insurance', 'auto insurance', 'property insurance', 'underwriting'] },
+  { key: 'real-estate', label: 'Real Est', icon: 'real_estate_agent', keywords: ['real estate', 'property', 'realtor', 'housing', 'apartment', 'commercial real estate', 'land'] },
+  { key: 'health', label: 'Health', icon: 'local_hospital', keywords: ['doctor', 'dentist', 'health', 'medical', 'chiropractic', 'optometrist', 'pharmacy', 'clinic', 'hospital', 'therapy', 'mental health', 'veterinar'] },
+  { key: 'legal', label: 'Legal', icon: 'gavel', keywords: ['lawyer', 'legal', 'attorney', 'law firm', 'notary', 'immigration', 'divorce', 'criminal', 'estate planning'] },
+  { key: 'technology', label: 'Tech', icon: 'code', keywords: ['it ', 'software', 'web design', 'technology', 'computer', 'internet', 'data', 'cloud', 'cyber', 'telecom'] },
+  { key: 'home-services', label: 'Home', icon: 'home_repair_service', keywords: ['plumb', 'electric', 'contractor', 'landscap', 'roofing', 'paint', 'cleaning', 'handyman', 'hvac', 'pest', 'locksmith', 'moving'] },
+  { key: 'food', label: 'Food', icon: 'restaurant', keywords: ['restaurant', 'cafe', 'coffee', 'bar', 'bakery', 'pizza', 'food', 'catering', 'grocery', 'deli', 'brewery'] },
+  { key: 'auto', label: 'Auto', icon: 'directions_car', keywords: ['auto', 'car', 'vehicle', 'mechanic', 'tire', 'body shop', 'towing', 'oil change', 'transmission'] },
+  { key: 'beauty', label: 'Beauty', icon: 'spa', keywords: ['salon', 'spa', 'massage', 'beauty', 'hair', 'nail', 'skin', 'barber', 'cosmetic', 'waxing'] },
 ];
 
 /** Check if an agent matches a major category */
@@ -124,97 +73,76 @@ interface KirklandAgent {
   photo_url: string | null;
 }
 
-/** Star rating row */
-const Stars: React.FC<{ rating: number | null }> = ({ rating }) => {
-  if (!rating) return <span className="text-[11px] text-gray-400">No rating</span>;
-  const full = Math.floor(rating);
+/* ── Rating display ── */
+const RatingText: React.FC<{ rating: number | null; count: number }> = ({ rating, count }) => {
+  if (!rating) return <span className="text-xs font-light" style={{ color: C.textSub }}>No rating{count > 0 ? ` (${count})` : ''}</span>;
   return (
-    <div className="flex items-center gap-0.5">
-      {[...Array(5)].map((_, i) => (
-        <span
-          key={i}
-          className={`material-symbols-outlined text-[14px] ${
-            i < full ? 'text-amber-400' : 'text-gray-200'
-          }`}
-          style={{ fontVariationSettings: i < full ? "'FILL' 1" : "'FILL' 0" }}
-        >
-          star
-        </span>
-      ))}
-      <span className="text-[11px] text-gray-500 ml-1 font-medium">{rating.toFixed(1)}</span>
+    <span className="text-xs font-light" style={{ color: C.textSub }}>
+      {rating.toFixed(1)} ★{count > 0 ? ` (${count})` : ''}
+    </span>
+  );
+};
+
+/* ── Avatar initials with color ── */
+const AVATAR_COLORS = ['#1e3a5f', '#1e40af', '#166534', '#7e22ce', '#374151', '#0f766e', '#9f1239', '#92400e'];
+const AvatarInitials: React.FC<{ name: string }> = ({ name }) => {
+  const initials = name.split(/\s+/).slice(0, 2).map(w => w[0]).join('').toUpperCase();
+  const colorIdx = name.split('').reduce((a, c) => a + c.charCodeAt(0), 0) % AVATAR_COLORS.length;
+  return (
+    <div
+      className="w-12 h-12 rounded-xl flex items-center justify-center text-white font-semibold text-lg shrink-0"
+      style={{ backgroundColor: AVATAR_COLORS[colorIdx] }}
+    >
+      {initials}
     </div>
   );
 };
 
-/** Individual agent card with MCP badge */
-const AgentCard: React.FC<{ agent: KirklandAgent; featured?: boolean }> = ({ agent, featured }) => {
+/* ── Agent Card ── */
+const AgentCard: React.FC<{ agent: KirklandAgent }> = ({ agent }) => {
   const navigate = useNavigate();
-
   return (
     <button
       onClick={() => navigate(`/hushh-agents/kirkland/${agent.id}`)}
-      className={`text-left w-full border rounded-2xl p-4 transition-all active:scale-[0.98] ${
-        featured
-          ? 'border-amber-200 bg-amber-50/40 hover:border-amber-300'
-          : 'border-gray-200/60 bg-white hover:border-gray-300'
-      }`}
+      className="w-full text-left border rounded-3xl p-5 shadow-sm flex flex-col relative group cursor-pointer transition-shadow hover:shadow-md active:scale-[0.99]"
+      style={{ borderColor: C.border, background: C.bg, ...sans }}
       aria-label={`View ${agent.name}`}
     >
-      {/* Top row: avatar + name + MCP badge */}
-      <div className="flex items-center gap-3">
-        <AgentAvatar name={agent.name} size="md" featured={featured} />
-        <div className="flex-1 min-w-0">
-          <p className="text-[13px] font-semibold text-gray-900 truncate leading-tight">
-            {agent.name}
-          </p>
-          {agent.city && (
-            <p className="text-[11px] text-gray-400 flex items-center gap-1 mt-0.5">
-              <span className="material-symbols-outlined text-[12px]">location_on</span>
-              {agent.city}{agent.state ? `, ${agent.state}` : ''}
-            </p>
-          )}
+      <div className="flex items-start justify-between w-full">
+        <div className="flex items-start gap-4">
+          <AvatarInitials name={agent.name} />
+          <div className="flex-1 min-w-0 pr-2">
+            <h3 className="font-semibold text-lg leading-tight mb-1 truncate" style={{ ...serif, color: C.primary }}>
+              {agent.name}
+            </h3>
+            {agent.city && (
+              <div className="flex items-center text-xs mb-2" style={{ color: C.textSub }}>
+                <span className="material-symbols-outlined text-[14px] mr-1">location_on</span>
+                {agent.city}{agent.state ? `, ${agent.state}` : ''}
+              </div>
+            )}
+            <RatingText rating={agent.avg_rating} count={agent.review_count} />
+          </div>
         </div>
-
-        {/* MCP Badge */}
-        <span className="px-2 py-0.5 bg-emerald-50 text-emerald-600 text-[8px] font-bold rounded-full uppercase tracking-wider border border-emerald-200/60">
-          MCP
-        </span>
-
-        {featured && (
-          <span className="px-2 py-0.5 bg-amber-100 text-amber-700 text-[9px] font-bold rounded-full uppercase tracking-wider">
-            Top
+        <div className="flex items-center gap-2 mt-1 shrink-0">
+          <span className="bg-emerald-50 text-emerald-600 border border-emerald-100 text-[10px] font-semibold px-2 py-1 rounded-full uppercase tracking-wider">
+            MCP
           </span>
-        )}
-        <span className="material-symbols-outlined text-gray-300 text-[18px]">
-          chevron_right
-        </span>
-      </div>
-
-      {/* Rating */}
-      <div className="mt-2.5">
-        <Stars rating={agent.avg_rating} />
-        {agent.review_count > 0 && (
-          <span className="text-[10px] text-gray-400 ml-0.5">
-            ({agent.review_count})
+          <span className="material-symbols-outlined text-lg transition-colors" style={{ color: C.border }}>
+            chevron_right
           </span>
-        )}
+        </div>
       </div>
-
-      {/* Categories */}
+      {/* Category pills */}
       {agent.categories?.length > 0 && (
-        <div className="mt-2.5 flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-2 mt-3">
           {agent.categories.slice(0, 2).map((cat) => (
-            <span
-              key={cat}
-              className="px-2 py-0.5 bg-gray-100 text-gray-500 text-[10px] rounded-full font-medium"
-            >
+            <span key={cat} className="bg-gray-100 text-[11px] px-3 py-1.5 rounded-full font-medium" style={{ color: C.textSub }}>
               {cat}
             </span>
           ))}
           {agent.categories.length > 2 && (
-            <span className="text-[10px] text-gray-300 font-medium">
-              +{agent.categories.length - 2}
-            </span>
+            <span className="text-[11px] py-1.5 font-medium" style={{ color: C.textSub }}>+{agent.categories.length - 2}</span>
           )}
         </div>
       )}
@@ -229,7 +157,7 @@ const KirklandAgentsPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedMajor, setSelectedMajor] = useState<string | null>(null);
 
-  // Fetch agents
+  /* Fetch agents from Supabase */
   useEffect(() => {
     const fetchAgents = async () => {
       setIsLoading(true);
@@ -238,14 +166,13 @@ const KirklandAgentsPage: React.FC = () => {
         .select('id, name, alias, phone, city, state, avg_rating, review_count, categories, is_closed, photo_url')
         .eq('is_closed', false)
         .order('avg_rating', { ascending: false, nullsFirst: false });
-
       if (!error && data) setAgents(data);
       setIsLoading(false);
     };
     fetchAgents();
   }, []);
 
-  // Count agents per major category
+  /* Category counts */
   const categoryCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     MAJOR_CATEGORIES.forEach((mc) => {
@@ -254,18 +181,9 @@ const KirklandAgentsPage: React.FC = () => {
     return counts;
   }, [agents]);
 
-  // Top 10
-  const topAgents = useMemo(() => {
-    return agents
-      .filter(a => a.avg_rating && a.avg_rating > 0 && a.review_count > 0)
-      .slice(0, 10);
-  }, [agents]);
-
-  // Filtered
+  /* Filtered agents */
   const filteredAgents = useMemo(() => {
     let result = agents;
-
-    // Search filter
     if (searchQuery) {
       const q = searchQuery.toLowerCase();
       result = result.filter(a =>
@@ -274,103 +192,102 @@ const KirklandAgentsPage: React.FC = () => {
         a.categories?.some(c => c.toLowerCase().includes(q))
       );
     }
-
-    // Major category filter
     if (selectedMajor) {
       const major = MAJOR_CATEGORIES.find((m) => m.key === selectedMajor);
-      if (major) {
-        result = result.filter((a) => agentMatchesMajor(a.categories, major));
-      }
+      if (major) result = result.filter((a) => agentMatchesMajor(a.categories, major));
     }
-
     return result;
   }, [agents, searchQuery, selectedMajor]);
 
-  // Loading
+  /* Loading state */
   if (isLoading) {
     return (
-      <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
-        <HushhTechBackHeader onBackClick={() => navigate('/hushh-agents')} rightLabel="FAQs" />
-        <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48 flex items-center justify-center">
-          <div className="text-center">
-            <div className="w-12 h-12 rounded-2xl bg-gray-100 flex items-center justify-center mx-auto mb-3 animate-pulse">
-              <span className="material-symbols-outlined text-gray-400">location_city</span>
-            </div>
-            <p className="text-[13px] text-gray-400 font-light">Loading agents...</p>
+      <div className="min-h-screen flex items-center justify-center" style={{ background: C.bg, ...sans }}>
+        <div className="text-center">
+          <div className="w-12 h-12 rounded-2xl bg-gray-100 flex items-center justify-center mx-auto mb-3 animate-pulse">
+            <span className="material-symbols-outlined" style={{ color: C.textSub }}>location_city</span>
           </div>
-        </main>
+          <p className="text-[13px] font-light" style={{ color: C.textSub }}>Loading agents...</p>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
-      <HushhTechBackHeader onBackClick={() => navigate('/hushh-agents')} rightLabel="FAQs" />
+    <div className="min-h-screen pb-10" style={{ background: C.bg, color: C.primary, ...sans }}>
 
-      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48">
+      {/* ═══ Header / Title ═══ */}
+      <header className="px-4 sm:px-6 md:px-8 pt-10 sm:pt-12 pb-6 max-w-md sm:max-w-lg md:max-w-3xl lg:max-w-5xl mx-auto">
+        {/* Back button */}
+        <button
+          onClick={() => navigate('/hushh-agents')}
+          className="flex items-center gap-1 mb-6 transition-opacity hover:opacity-70"
+          style={{ color: C.textSub }}
+        >
+          <span className="material-symbols-outlined text-lg">arrow_back</span>
+          <span className="text-xs font-medium uppercase tracking-wider">Back</span>
+        </button>
 
-        {/* ── Title Section ── */}
-        <section className="pt-8 pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-2 font-medium">
-            Agent Directory
-          </p>
-          <h1
-            className="text-[2rem] leading-[1.1] font-normal text-black tracking-tight font-serif"
-            style={playfair}
-          >
-            Kirkland <br />
-            <span className="text-gray-400 italic font-light">Agents</span>
-          </h1>
-          <p className="text-gray-500 text-[13px] font-light mt-3 leading-relaxed">
-            {agents.length} agents with MCP endpoints. Filter by category.
-          </p>
-        </section>
+        <p className="text-[10px] uppercase tracking-[0.2em] font-semibold mb-3" style={{ color: C.textSub }}>
+          Agent Directory
+        </p>
+        <h1 className="leading-tight" style={serif}>
+          <span className="text-4xl sm:text-5xl font-semibold block" style={{ color: C.primary }}>Kirkland</span>
+          <span className="text-4xl sm:text-5xl italic font-normal block mt-1" style={{ color: C.textSub }}>Agents</span>
+        </h1>
+        <p className="mt-4 text-sm font-light" style={{ color: C.textSub, ...sans }}>
+          {agents.length} agents with MCP endpoints. Filter by category.
+        </p>
+      </header>
 
-        {/* ── Search Bar ── */}
-        <section className="pb-4">
+      <main className="px-4 sm:px-6 md:px-8 max-w-md sm:max-w-lg md:max-w-3xl lg:max-w-5xl mx-auto">
+
+        {/* ═══ Search ═══ */}
+        <section className="mb-8">
           <div className="relative">
-            <span className="material-symbols-outlined absolute left-3.5 top-1/2 -translate-y-1/2 text-[18px] text-gray-400">
-              search
+            <span className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+              <span className="material-symbols-outlined text-[20px]" style={{ color: C.textSub }}>search</span>
             </span>
             <input
               type="text"
               placeholder="Search agents..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-3.5 bg-gray-50 border border-gray-200/60 rounded-2xl text-[13px] text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-hushh-blue/20 focus:border-hushh-blue/30 transition-all"
+              className="w-full rounded-full py-3.5 pl-11 pr-4 text-sm shadow-sm transition-colors focus:outline-none focus:ring-1"
+              style={{
+                background: C.bg,
+                border: `1px solid ${C.border}`,
+                color: C.primary,
+                ...sans,
+              }}
             />
             {searchQuery && (
-              <button
-                onClick={() => setSearchQuery('')}
-                className="absolute right-3.5 top-1/2 -translate-y-1/2"
-                aria-label="Clear search"
-              >
-                <span className="material-symbols-outlined text-[18px] text-gray-400">close</span>
+              <button onClick={() => setSearchQuery('')} className="absolute right-3.5 top-1/2 -translate-y-1/2" aria-label="Clear search">
+                <span className="material-symbols-outlined text-[18px]" style={{ color: C.textSub }}>close</span>
               </button>
             )}
           </div>
         </section>
 
-        {/* ── Major Category Filter Grid ── */}
-        <section className="pb-6">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
+        {/* ═══ Category Filter Grid ═══ */}
+        <section className="mb-10">
+          <p className="text-[10px] uppercase tracking-[0.15em] font-medium mb-4" style={{ color: C.textSub }}>
             Filter by Category
           </p>
-          <div className="grid grid-cols-4 gap-2">
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-2 sm:gap-3">
             {/* All button */}
             <button
               onClick={() => setSelectedMajor(null)}
-              className={`flex flex-col items-center justify-center gap-1 p-3 rounded-2xl border transition-all ${
-                !selectedMajor
-                  ? 'bg-gray-900 text-white border-gray-900'
-                  : 'bg-white text-gray-500 border-gray-200/60 hover:border-gray-300'
-              }`}
+              className="rounded-2xl p-3 sm:p-4 flex flex-col items-center justify-center aspect-square shadow-md transition-transform active:scale-95"
+              style={{
+                background: !selectedMajor ? C.primary : C.bg,
+                color: !selectedMajor ? '#FFFFFF' : C.textSub,
+                border: `1px solid ${!selectedMajor ? C.primary : C.border}`,
+              }}
             >
-              <span className="material-symbols-outlined text-[20px]">apps</span>
-              <span className="text-[9px] font-semibold uppercase tracking-wider">All</span>
-              <span className={`text-[8px] font-medium ${!selectedMajor ? 'text-gray-300' : 'text-gray-400'}`}>
-                {agents.length}
-              </span>
+              <span className="material-symbols-outlined mb-2 text-xl">apps</span>
+              <span className="text-[10px] font-semibold tracking-wide uppercase mb-1">All</span>
+              <span className="text-[10px] font-light" style={{ opacity: 0.7 }}>{agents.length}</span>
             </button>
 
             {MAJOR_CATEGORIES.map((mc) => {
@@ -381,43 +298,25 @@ const KirklandAgentsPage: React.FC = () => {
                 <button
                   key={mc.key}
                   onClick={() => setSelectedMajor(isActive ? null : mc.key)}
-                  className={`flex flex-col items-center justify-center gap-1 p-3 rounded-2xl border transition-all ${
-                    isActive
-                      ? 'bg-gray-900 text-white border-gray-900'
-                      : 'bg-white text-gray-500 border-gray-200/60 hover:border-gray-300'
-                  }`}
+                  className="rounded-2xl p-3 sm:p-4 flex flex-col items-center justify-center aspect-square transition-all active:scale-95"
+                  style={{
+                    background: isActive ? C.primary : C.bg,
+                    color: isActive ? '#FFFFFF' : C.textSub,
+                    border: `1px solid ${isActive ? C.primary : C.border}`,
+                  }}
                 >
-                  <span className="material-symbols-outlined text-[20px]">{mc.icon}</span>
-                  <span className="text-[9px] font-semibold uppercase tracking-wider">{mc.label}</span>
-                  <span className={`text-[8px] font-medium ${isActive ? 'text-gray-300' : 'text-gray-400'}`}>
-                    {count}
-                  </span>
+                  <span className="material-symbols-outlined mb-2 text-xl">{mc.icon}</span>
+                  <span className="text-[10px] font-semibold tracking-wide uppercase mb-1 truncate w-full text-center">{mc.label}</span>
+                  <span className="text-[10px] font-light" style={{ opacity: 0.7 }}>{count}</span>
                 </button>
               );
             })}
           </div>
         </section>
 
-        {/* ── Top Recommended ── */}
-        {!searchQuery && !selectedMajor && topAgents.length > 0 && (
-          <section className="pb-8">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium flex items-center gap-1.5">
-              <span className="material-symbols-outlined text-amber-400 text-[14px]" style={{ fontVariationSettings: "'FILL' 1" }}>
-                star
-              </span>
-              Top Recommended
-            </p>
-            <div className="space-y-3">
-              {topAgents.map((agent) => (
-                <AgentCard key={agent.id} agent={agent} featured />
-              ))}
-            </div>
-          </section>
-        )}
-
-        {/* ── All Agents / Search Results ── */}
+        {/* ═══ Agent List ═══ */}
         <section className="pb-8">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-3 font-medium">
+          <p className="text-[10px] uppercase tracking-[0.15em] font-medium mb-4" style={{ color: C.textSub }}>
             {searchQuery || selectedMajor
               ? `Results · ${filteredAgents.length}`
               : `All Agents · ${agents.length}`}
@@ -425,14 +324,12 @@ const KirklandAgentsPage: React.FC = () => {
 
           {filteredAgents.length === 0 ? (
             <div className="text-center py-16">
-              <span className="material-symbols-outlined text-gray-200 text-[40px] mb-3 block">
-                search_off
-              </span>
-              <p className="text-gray-500 text-[13px] font-light">No agents found</p>
-              <p className="text-gray-400 text-[11px] font-light mt-1">Try a different category or search</p>
+              <span className="material-symbols-outlined text-[40px] mb-3 block" style={{ color: C.border }}>search_off</span>
+              <p className="text-[13px] font-light" style={{ color: C.textSub }}>No agents found</p>
+              <p className="text-[11px] font-light mt-1" style={{ color: C.textSub }}>Try a different category or search</p>
             </div>
           ) : (
-            <div className="space-y-3">
+            <div className="space-y-4 md:grid md:grid-cols-2 md:gap-4 md:space-y-0">
               {filteredAgents.map((agent) => (
                 <AgentCard key={agent.id} agent={agent} />
               ))}

--- a/src/hushh-agents/pages/LoginPage.tsx
+++ b/src/hushh-agents/pages/LoginPage.tsx
@@ -1,0 +1,215 @@
+/**
+ * Hushh Agents — Dedicated Login Page
+ *
+ * Self-contained login for Hushh Agents (separate from HushhTech main app).
+ * After OAuth, redirects back to /hushh-agents — never to the main app home.
+ * Uses same Supabase auth, but all flows stay within /hushh-agents/*.
+ */
+import { useEffect } from 'react';
+import { useNavigate, Link, useSearchParams } from 'react-router-dom';
+import { FaApple } from 'react-icons/fa';
+import { FcGoogle } from 'react-icons/fc';
+import { useAuth } from '../hooks/useAuth';
+import HushhLogo from '../assets/Hushhogo.png';
+
+const playfair = { fontFamily: "'Playfair Display', serif" };
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { isAuthenticated, isLoading, signIn, error } = useAuth();
+
+  // Where to go after login (default: /hushh-agents)
+  const redirectTo = searchParams.get('redirectTo') || '/hushh-agents';
+
+  // If already logged in, redirect immediately
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate(redirectTo, { replace: true });
+    }
+  }, [isAuthenticated, isLoading, navigate, redirectTo]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-white flex items-center justify-center">
+        <div className="animate-pulse flex flex-col items-center gap-4">
+          <div className="w-16 h-16 rounded-2xl bg-gray-100" />
+          <div className="w-32 h-4 bg-gray-100 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-white text-gray-900 antialiased flex flex-col">
+      <div className="flex-grow flex flex-col lg:flex-row">
+
+        {/* ═══ Left Panel — Branding (Desktop only) ═══ */}
+        <div className="hidden lg:flex lg:w-1/2 bg-gradient-to-br from-gray-900 via-gray-800 to-black p-12 flex-col justify-between">
+          <Link to="/hushh-agents" className="inline-flex items-center gap-3">
+            <div className="w-12 h-12 rounded-xl bg-white/10 flex items-center justify-center overflow-hidden backdrop-blur-sm">
+              <img src={HushhLogo} alt="Hushh" className="w-8 h-8 object-contain" />
+            </div>
+            <span className="text-white text-xl font-medium" style={playfair}>
+              Hushh Agents
+            </span>
+          </Link>
+
+          <div className="space-y-8">
+            <h1
+              className="text-5xl xl:text-6xl text-white font-normal leading-tight"
+              style={playfair}
+            >
+              Your Private
+              <br />
+              <span className="text-gray-400 italic">AI Companions</span>
+            </h1>
+            <p className="text-gray-400 text-lg max-w-md leading-relaxed">
+              Intelligent conversations in Hindi, English, and Tamil.
+              Powered by advanced AI, designed for you.
+            </p>
+
+            {/* Feature List */}
+            <div className="space-y-4 pt-4">
+              {[
+                { icon: 'chat', title: 'Natural Conversations', desc: 'Text chat that understands context' },
+                { icon: 'mic', title: 'Voice Chat', desc: 'Speak naturally with Hushh', badge: 'Pro' },
+                { icon: 'translate', title: 'Multi-lingual', desc: 'English, हिंदी, தமிழ் supported' },
+              ].map((f) => (
+                <div key={f.icon} className="flex items-center gap-4">
+                  <div className="w-10 h-10 rounded-lg bg-white/10 flex items-center justify-center">
+                    <span className="material-symbols-outlined text-white text-xl">{f.icon}</span>
+                  </div>
+                  <div>
+                    <p className="text-white font-medium">
+                      {f.title}
+                      {f.badge && (
+                        <span className="text-xs text-gray-500 ml-1">{f.badge}</span>
+                      )}
+                    </p>
+                    <p className="text-gray-500 text-sm">{f.desc}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 text-gray-500 text-sm">
+            <span className="material-symbols-outlined text-base">shield</span>
+            <span>Your data stays private and secure</span>
+          </div>
+        </div>
+
+        {/* ═══ Right Panel — Login Form ═══ */}
+        <main className="flex-grow lg:w-1/2 px-6 lg:px-12 xl:px-20 flex flex-col justify-center py-12 lg:py-0">
+          <div className="max-w-md mx-auto w-full">
+
+            {/* Logo — Mobile only */}
+            <section className="flex justify-center pt-8 pb-6 lg:hidden">
+              <Link to="/hushh-agents">
+                <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#1400FF] to-blue-600 flex items-center justify-center overflow-hidden border border-black/5">
+                  <img src={HushhLogo} alt="Hushh" className="w-10 h-10 object-contain" />
+                </div>
+              </Link>
+            </section>
+
+            {/* Title */}
+            <section className="pb-8 lg:pb-10">
+              <h1
+                className="text-3xl lg:text-4xl leading-[1.1] font-normal text-black tracking-tight text-center lg:text-left"
+                style={playfair}
+              >
+                Hushh Agents
+              </h1>
+              <p className="text-gray-500 text-sm lg:text-base font-light mt-3 text-center lg:text-left leading-relaxed">
+                Sign in to access your AI agents, chat history, and preferences.
+              </p>
+            </section>
+
+            {/* Error */}
+            {error && (
+              <div className="mb-6 p-4 bg-red-50 border border-red-100 rounded-xl">
+                <p className="text-red-600 text-sm text-center lg:text-left">{error}</p>
+              </div>
+            )}
+
+            {/* Sign-in Buttons */}
+            <section className="space-y-3 mb-8">
+              <button
+                onClick={() => signIn('apple')}
+                className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-black text-white rounded-2xl font-medium text-sm hover:bg-gray-900 transition-colors"
+              >
+                <FaApple className="text-xl" />
+                <span>Continue with Apple</span>
+              </button>
+
+              <button
+                onClick={() => signIn('google')}
+                className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-white text-gray-900 rounded-2xl font-medium text-sm border border-gray-200 hover:bg-gray-50 transition-colors"
+              >
+                <FcGoogle className="text-xl" />
+                <span>Continue with Google</span>
+              </button>
+            </section>
+
+            {/* Features — Mobile only */}
+            <section className="space-y-4 mb-8 lg:hidden">
+              <h2 className="text-center text-xs font-medium text-gray-400 uppercase tracking-wider">
+                What You Get
+              </h2>
+              <div className="grid grid-cols-3 gap-3 text-center">
+                {[
+                  { icon: 'chat', label: 'Text Chat' },
+                  { icon: 'mic', label: 'Voice (Pro)' },
+                  { icon: 'translate', label: 'Multi-lingual' },
+                ].map((f) => (
+                  <div key={f.icon} className="p-3 rounded-xl bg-gray-50">
+                    <div className="flex justify-center mb-2">
+                      <span className="material-symbols-outlined text-xl text-gray-600">
+                        {f.icon}
+                      </span>
+                    </div>
+                    <p className="text-xs text-gray-600">{f.label}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Trust */}
+            <section className="flex flex-col items-center lg:items-start gap-2 pt-4 pb-4">
+              <div className="flex items-center gap-2">
+                <span className="material-symbols-outlined text-base text-gray-400">lock</span>
+                <span className="text-xs text-gray-400 tracking-wide uppercase font-medium">
+                  Private & Secure
+                </span>
+              </div>
+            </section>
+
+            {/* Back to agents link */}
+            <div className="text-center lg:text-left mt-4">
+              <Link
+                to="/hushh-agents"
+                className="text-sm text-gray-400 hover:text-gray-600 transition-colors inline-flex items-center gap-1"
+              >
+                <span className="material-symbols-outlined text-sm">arrow_back</span>
+                Back to Hushh Agents
+              </Link>
+            </div>
+
+            {/* Terms */}
+            <p className="text-[11px] leading-[16px] text-gray-400 text-center lg:text-left font-light mt-6">
+              By continuing, you agree to our{' '}
+              <Link to="/terms" className="underline underline-offset-2 hover:text-gray-600">
+                Terms
+              </Link>{' '}
+              and{' '}
+              <Link to="/privacy" className="underline underline-offset-2 hover:text-gray-600">
+                Privacy Policy
+              </Link>
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/hushh-agents/pages/VoicePage.tsx
+++ b/src/hushh-agents/pages/VoicePage.tsx
@@ -80,12 +80,7 @@ export default function VoicePage() {
     setMounted(true);
   }, []);
 
-  // Redirect if not authenticated
-  useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
-      navigate('/login', { state: { redirectTo: `/hushh-agents/voice?lang=${langParam}` } });
-    }
-  }, [isAuthenticated, isLoading, navigate, langParam]);
+  // Auth is optional — voice works without login
 
   // Cleanup on unmount
   useEffect(() => {
@@ -361,8 +356,6 @@ export default function VoicePage() {
     );
   }
 
-  if (!isAuthenticated) return null;
-
   // Status text
   const getStatusText = () => {
     switch (status) {
@@ -393,7 +386,7 @@ export default function VoicePage() {
       }}
     >
       {/* ═══ Header ═══ */}
-      <header className="px-6 py-5 flex justify-between items-center">
+      <header className="px-4 sm:px-6 py-4 sm:py-5 flex justify-between items-center">
         <Link to="/hushh-agents" className="flex items-center gap-3">
           <div className="w-10 h-10 rounded-xl bg-white/20 backdrop-blur-md flex items-center justify-center">
             <img src={HushhLogo} alt="Hushh" className="w-6 h-6 object-contain" />
@@ -416,11 +409,11 @@ export default function VoicePage() {
       </header>
 
       {/* ═══ Main Content ═══ */}
-      <main className="flex-1 flex flex-col items-center justify-center px-6 pb-8">
+      <main className="flex-1 flex flex-col items-center justify-center px-4 sm:px-6 pb-8">
         
         {/* Response Text */}
-        <div className="max-w-md text-center mb-8 min-h-[120px] flex items-center justify-center">
-          <p className="text-xl md:text-2xl font-light leading-relaxed">
+        <div className="max-w-md text-center mb-6 sm:mb-8 min-h-[100px] sm:min-h-[120px] flex items-center justify-center px-2">
+          <p className="text-base sm:text-xl md:text-2xl font-light leading-relaxed">
             {response || langConfig.greeting}
           </p>
         </div>


### PR DESCRIPTION
## Changes
- Hamburger menu: Home + Chat + Voice + Code (removed generic links)
- Dedicated login at /hushh-agents/login (Apple + Google OAuth)
- Post-login redirects to /hushh-agents home (not main app)
- Get Started buttons go to /hushh-agents/kirkland
- Removed auth gates from Chat, Voice, Code pages
- All navigation stays within /hushh-agents/*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated login page with Apple and Google sign-in options
  * Launched redesigned public home page featuring hero section, feature showcase, KPIs, and security badges
  * Made chat, code, and voice features publicly accessible
  * Introduced agent cards and step indicators for improved visual presentation

* **Refactor**
  * Redesigned agent detail page with unified color and typography system
  * Updated Kirkland Agents Directory with improved search, filtering, and responsive layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->