### PR TITLE
fix: Fund A card typography — Playfair for title+numbers, Manrope for labels

### DIFF
--- a/src/pages/home/ui.tsx
+++ b/src/pages/home/ui.tsx
@@ -194,13 +194,13 @@ export default function HomePage() {
               <div className="space-y-4 my-2">
                 <div>
                   <span className="text-xs text-white/50 block mb-1">Target Net IRR</span>
-                  <span className="text-4xl font-mono font-light tracking-tighter text-ios-green">
+                  <span className="text-4xl font-serif font-light tracking-tighter text-ios-green" style={playfair}>
                     18-23%
                   </span>
                 </div>
                 <div>
                   <span className="text-xs text-white/50 block mb-1">Inception Year</span>
-                  <span className="font-mono text-xl">2024</span>
+                  <span className="font-serif text-xl" style={playfair}>2024</span>
                 </div>
               </div>
 


### PR DESCRIPTION
Updated the Fund A card on the home page:

- **Title ('Fund A')**: Already had Playfair Display ✅
- **Numbers ('18-23%', '2024')**: Changed from `font-mono` → `font-serif` with `style={playfair}` (Playfair Display)
- **Labels ('Target Net IRR', 'Inception Year', 'FLAGSHIP PRODUCT', etc.)**: Already use Manrope via `data-page=home` CSS rule ✅
- **'PERFORMANCE DETAILS'**: Already uses Manrope (no font override) ✅