### PR TITLE
fix: use common HushhTechHeader with stock ticker on Investor Profile

### DIFF
--- a/src/pages/hushh-user-profile/ui.tsx
+++ b/src/pages/hushh-user-profile/ui.tsx
@@ -9,7 +9,7 @@ import { useHushhUserProfileLogic } from "./logic";
 import { Copy, Check } from "lucide-react";
 import { FaApple } from "react-icons/fa";
 import { SiGooglepay } from "react-icons/si";
-import HushhTechBackHeader from "../../components/hushh-tech-back-header/HushhTechBackHeader";
+import HushhTechHeader from "../../components/hushh-tech-header/HushhTechHeader";
 import HushhTechCta, { HushhTechCtaVariant } from "../../components/hushh-tech-cta/HushhTechCta";
 import HushhTechFooter, { HushhFooterTab } from "../../components/hushh-tech-footer/HushhTechFooter";
 import NWSScoreBadge from "../../components/profile/NWSScoreBadge";
@@ -47,7 +47,7 @@ const HushhUserProfilePage: React.FC = () => {
   return (
     <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
       {/* ═══ Header ═══ */}
-      <HushhTechBackHeader onBackClick={handleBack} rightType="hamburger" />
+      <HushhTechHeader />
 
       <main className="px-6 flex-grow max-w-md mx-auto w-full pb-48">
         {/* ── Hero ── */}


### PR DESCRIPTION
Replaces outdated `HushhTechBackHeader` (back arrow + hamburger) with the common `HushhTechHeader` (hushh logo + brand + hamburger + live stock ticker marquee). Now matches the header used on Home, Fund A, Community, and Profile pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the header component on the user profile page for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->