### PR TITLE
fix: Profile page - uppercase PERSON icon + Title Case CTA text

### DIFF
--- a/src/pages/profile/logic.ts
+++ b/src/pages/profile/logic.ts
@@ -111,23 +111,23 @@ export function useProfileLogic() {
   /* primary CTA content based on onboarding status */
   const getPrimaryCTAContent = () => {
     if (onboardingStatus.loading) {
-      return { text: 'loading...', action: () => {} };
+      return { text: 'Loading...', action: () => {} };
     }
     if (onboardingStatus.hasProfile || onboardingStatus.isCompleted) {
       return {
-        text: 'view your profile',
+        text: 'View Your Profile',
         action: () => navigate('/hushh-user-profile'),
       };
     }
     if (onboardingStatus.currentStep > 1) {
       return {
-        text: `continue onboarding (step ${onboardingStatus.currentStep})`,
+        text: `Continue Onboarding (Step ${onboardingStatus.currentStep})`,
         action: () =>
           navigate(`/onboarding/step-${onboardingStatus.currentStep}`),
       };
     }
     return {
-      text: 'complete your hushh profile',
+      text: 'Complete Your Hushh Profile',
       action: () => navigate('/onboarding/financial-link'),
     };
   };

--- a/src/pages/profile/ui.tsx
+++ b/src/pages/profile/ui.tsx
@@ -34,7 +34,7 @@ const ProfilePage: React.FC = () => {
 
           {/* pill badge */}
           <span className="inline-flex items-center gap-1.5 rounded-full border border-hushh-blue/20 bg-hushh-blue/5 px-4 py-1">
-            <span className="material-symbols-rounded text-[16px] text-hushh-blue">person</span>
+            <span className="material-symbols-rounded text-[16px] text-hushh-blue uppercase">person</span>
             <span className="text-[11px] tracking-[0.14em] uppercase text-hushh-blue font-medium">
               Profile
             </span>


### PR DESCRIPTION
## Changes

### 1. Pill badge icon fallback — uppercase
- Added `uppercase` class to the Material Symbol `person` icon span in `ui.tsx`
- When the Material Symbols font doesn't load, the fallback text now shows as **PERSON** instead of lowercase **person**

### 2. CTA button text — Title Case
- Fixed all CTA text values in `logic.ts` to use proper Title Case:
  - `complete your hushh profile` → **Complete Your Hushh Profile**
  - `view your profile` → **View Your Profile**
  - `continue onboarding (step N)` → **Continue Onboarding (Step N)**
  - `loading...` → **Loading...**

### Files Changed
- `src/pages/profile/ui.tsx` — added `uppercase` class to person icon span
- `src/pages/profile/logic.ts` — Title Case for all CTA text values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text capitalization and phrasing in profile-related UI elements for improved consistency
  * Applied uppercase styling to the profile icon badge

<!-- end of auto-generated comment: release notes by coderabbit.ai -->