### PR TITLE
fix: remove top margin on /profile page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,9 +114,10 @@ const ContentWrapper = ({ children }: { children: ReactNode }) => {
   const isDeleteAccount = location.pathname === '/delete-account';
   const isLogin = location.pathname.toLowerCase() === '/login';
   const isSignup = location.pathname.toLowerCase() === '/signup';
+  const isProfile = location.pathname === '/profile';
 
   return (
-    <div className={`${isHomePage || isAuthCallback || isUserRegistration || isOnboarding || isKycFlow || isKycDemo || isA2APlayground || isInvestorGuide || isHushhAI || isHushhAgent || isHushhAgents || isKai || isStudio || isHushhUserProfile || isSignNda || isInvestorProfile || isDiscoverFundA || isCommunity || isDeleteAccount || isLogin || isSignup ? '' : 'mt-20'}`}>
+    <div className={`${isHomePage || isAuthCallback || isUserRegistration || isOnboarding || isKycFlow || isKycDemo || isA2APlayground || isInvestorGuide || isHushhAI || isHushhAgent || isHushhAgents || isKai || isStudio || isHushhUserProfile || isSignNda || isInvestorProfile || isDiscoverFundA || isCommunity || isDeleteAccount || isLogin || isSignup || isProfile ? '' : 'mt-20'}`}>
       {children}
     </div>
   );


### PR DESCRIPTION
The /profile page had an 80px top gap because it was missing from ContentWrapper's exclusion list in App.tsx. Added isProfile check so the mt-20 class is not applied on /profile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Adjusted layout spacing for the profile route to maintain consistent page margins.
  * Modified navigation element visibility behavior to properly display/hide the navbar, footer, and mobile navigation on the profile page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->