### PR TITLE
fix: make recurring investment optional on step 1 onboarding

### DIFF
--- a/src/pages/onboarding/step-1/logic.ts
+++ b/src/pages/onboarding/step-1/logic.ts
@@ -93,7 +93,18 @@ export const useStep1Logic = (): Step1Logic => {
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
   const [customAmount, setCustomAmount] = useState('');
   const [customAmountError, setCustomAmountError] = useState<string | null>(null);
-  const [recurringEnabled, setRecurringEnabled] = useState(false);
+  const [recurringEnabled, setRecurringEnabledRaw] = useState(false);
+
+  /* When recurring is toggled OFF, clear recurring-related state */
+  const setRecurringEnabled = (enabled: boolean) => {
+    setRecurringEnabledRaw(enabled);
+    if (!enabled) {
+      setSelectedAmount(null);
+      setCustomAmount('');
+      setCustomAmountError(null);
+      setError(null);
+    }
+  };
 
   const totalInvestment = SHARE_CLASSES.reduce((t, sc) => t + units[sc.id] * sc.unitPrice, 0);
   const hasSelection = Object.values(units).some((c) => c > 0);
@@ -187,7 +198,8 @@ export const useStep1Logic = (): Step1Logic => {
 
   const handleNext = async () => {
     if (!userId || !config.supabaseClient || !hasSelection) return;
-    if (customAmountError) { setError(customAmountError); return; }
+    /* Only block on custom amount error when recurring is active */
+    if (recurringEnabled && customAmountError) { setError(customAmountError); return; }
 
     /* When recurring is ON, validate that user picked a valid amount */
     if (recurringEnabled) {


### PR DESCRIPTION
## Problem
Users could not proceed from Step 1 to Step 2 without toggling the Recurring Investment toggle. The recurring investment should be optional.

## Root Cause
- `customAmountError` validation in `handleNext` ran unconditionally, so stale error state from a previous toggle-on could block submission even after toggling off.
- Recurring-related state (selectedAmount, customAmount, customAmountError) was not being cleared when the toggle was turned off.

## Fix
1. Wrapped `setRecurringEnabled` to clear all recurring state (selectedAmount, customAmount, customAmountError, error) when toggled OFF.
2. Made `customAmountError` check conditional on `recurringEnabled` in `handleNext`.

## Testing
- Select share classes → Continue without toggling recurring → should navigate to Step 2 ✅
- Toggle recurring ON → select amount → Continue → should work ✅  
- Toggle recurring ON → toggle OFF → Continue → should work (no stale errors) ✅