### PR TITLE
fix: make recurring investment compulsory on Step 1

### DIFF
--- a/src/pages/onboarding/step-1/logic.ts
+++ b/src/pages/onboarding/step-1/logic.ts
@@ -70,7 +70,6 @@ export interface Step1Logic {
   totalInvestment: number;
   hasSelection: boolean;
   recurringEnabled: boolean;
-  setRecurringEnabled: (enabled: boolean) => void;
   handleUnitChange: (classId: string, delta: number) => void;
   handleAmountClick: (amount: number) => void;
   handleCustomAmountChange: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -93,18 +92,8 @@ export const useStep1Logic = (): Step1Logic => {
   const [selectedAmount, setSelectedAmount] = useState<number | null>(null);
   const [customAmount, setCustomAmount] = useState('');
   const [customAmountError, setCustomAmountError] = useState<string | null>(null);
-  const [recurringEnabled, setRecurringEnabledRaw] = useState(false);
-
-  /* When recurring is toggled OFF, clear recurring-related state */
-  const setRecurringEnabled = (enabled: boolean) => {
-    setRecurringEnabledRaw(enabled);
-    if (!enabled) {
-      setSelectedAmount(null);
-      setCustomAmount('');
-      setCustomAmountError(null);
-      setError(null);
-    }
-  };
+  /* Recurring investment is compulsory — always enabled */
+  const recurringEnabled = true;
 
   const totalInvestment = SHARE_CLASSES.reduce((t, sc) => t + units[sc.id] * sc.unitPrice, 0);
   const hasSelection = Object.values(units).some((c) => c > 0);
@@ -249,7 +238,7 @@ export const useStep1Logic = (): Step1Logic => {
   return {
     units, frequency, investmentDay, selectedAmount, customAmount, customAmountError,
     error, isLoading, isFooterVisible, totalInvestment, hasSelection,
-    recurringEnabled, setRecurringEnabled,
+    recurringEnabled,
     handleUnitChange, handleAmountClick, handleCustomAmountChange,
     setFrequency, setInvestmentDay, handleNext, handleBack,
   };

--- a/src/pages/onboarding/step-1/ui.tsx
+++ b/src/pages/onboarding/step-1/ui.tsx
@@ -56,8 +56,6 @@ export default function OnboardingStep1() {
     handleCustomAmountChange,
     setFrequency,
     setInvestmentDay,
-    recurringEnabled,
-    setRecurringEnabled,
     handleNext,
     handleBack,
   } = useStep1Logic();
@@ -201,22 +199,11 @@ export default function OnboardingStep1() {
             >
               Recurring Investment
             </h3>
-            <div className="relative inline-block w-10 align-middle select-none transition duration-200 ease-in">
-              <input
-                    className="toggle-checkbox absolute block w-5 h-5 rounded-full bg-white border-4 appearance-none cursor-pointer border-gray-300 checked:right-0 checked:border-hushh-blue transition-all duration-300"
-                id="recurring-toggle"
-                type="checkbox"
-                checked={recurringEnabled}
-                onChange={(e) => setRecurringEnabled(e.target.checked)}
-              />
-              <label
-                className="toggle-label block overflow-hidden h-5 rounded-full bg-gray-200 cursor-pointer transition-colors duration-300"
-                htmlFor="recurring-toggle"
-              />
-            </div>
+            <span className="px-2.5 py-1 bg-red-50 text-red-600 text-[10px] font-semibold rounded-full border border-red-200 uppercase tracking-wide">
+              Required
+            </span>
           </div>
 
-          {recurringEnabled && (
           <div className="space-y-0">
             {/* ── Frequency: selectable pills ── */}
             <div className="py-5 border-b border-gray-100">
@@ -357,7 +344,6 @@ export default function OnboardingStep1() {
               </div>
             </div>
           </div>
-          )}
         </section>
 
         {/* ── Error message ── */}


### PR DESCRIPTION
## Changes
- **logic.ts**: Changed `recurringEnabled` from `useState(false)` to const `true` — recurring is always on
- **logic.ts**: Removed `setRecurringEnabled` from interface and return object
- **ui.tsx**: Removed toggle checkbox UI, replaced with 'Required' badge
- **ui.tsx**: Removed conditional wrapper — recurring section always visible
- **ui.tsx**: Cleaned up unused destructured props

## Behavior
- User MUST select a recurring investment amount before proceeding to Step 2
- Validation enforces minimum amount of $100
- No way to skip or disable recurring investment