### PR TITLE
fix: add --clear-base-image flag for Cloud Run Dockerfile deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -39,4 +39,5 @@ jobs:
             --min-instances=1 \
             --max-instances=10 \
             --port=8080 \
+            --clear-base-image \
             --quiet

--- a/.github/workflows/deploy-uat.yml
+++ b/.github/workflows/deploy-uat.yml
@@ -39,4 +39,5 @@ jobs:
             --min-instances=0 \
             --max-instances=3 \
             --port=8080 \
+            --clear-base-image \
             --quiet


### PR DESCRIPTION
Fixes Cloud Run PROD deploy failure: gcloud requires --clear-base-image when deploying from source with a Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment pipeline configurations for both production and staging environments to optimize the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->