### PR TITLE
fix: hushh-user-profile audit — AI enhance vs save separation + upsert + schema fixes

### DIFF
--- a/src/pages/hushh-user-profile/logic.ts
+++ b/src/pages/hushh-user-profile/logic.ts
@@ -117,6 +117,8 @@ export const useHushhUserProfileLogic = () => {
   const [editingField, setEditingField] = useState<string | null>(null);
   // Dirty tracking — true when user manually edits any form field
   const [isDirty, setIsDirty] = useState(false);
+  // Dirty tracking for AI profile field edits (separate from form edits)
+  const [isAiProfileDirty, setIsAiProfileDirty] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   // Shadow Investigator state
   const [shadowProfile, setShadowProfile] = useState<ShadowProfile | null>(null);
@@ -238,6 +240,9 @@ export const useHushhUserProfileLogic = () => {
       },
     });
     setEditingField(null);
+    // Mark AI profile as dirty so Save Changes can persist it
+    setIsAiProfileDirty(true);
+    setIsDirty(true);
   };
 
   // Handle multi-select toggle
@@ -264,6 +269,9 @@ export const useHushhUserProfileLogic = () => {
         value: newValues,
       },
     });
+    // Mark AI profile as dirty so Save Changes can persist it
+    setIsAiProfileDirty(true);
+    setIsDirty(true);
   };
 
   // Profile URL for sharing
@@ -396,14 +404,14 @@ export const useHushhUserProfileLogic = () => {
                 user_id: user.id,
                 name: userName,
                 email: user.email || "",
-                age: userAge,
+                age: Math.max(18, Math.min(120, userAge)), // Clamp to DB constraint range
                 phone_country_code: onboardingData.phone_country_code || "+1",
                 phone_number: onboardingData.phone_number || "",
                 organisation: null,
                 investor_profile: null, // No AI profile yet, just basic row for slug
                 is_public: true, // Public by default so shared links work
                 user_confirmed: false,
-              })
+              }, { onConflict: 'user_id' })
               .select("slug")
               .maybeSingle();
 
@@ -503,7 +511,7 @@ export const useHushhUserProfileLogic = () => {
           user_confirmed: true,
           confirmed_at: new Date().toISOString(),
           ...partialPayload,
-        })
+        }, { onConflict: 'user_id' })
         .select("slug")
         .maybeSingle();
       if (data?.slug) setProfileSlug(data.slug);
@@ -545,8 +553,8 @@ export const useHushhUserProfileLogic = () => {
     }
 
     const ageNum = typeof form.age === "number" ? form.age : Number(form.age);
-    if (isNaN(ageNum) || ageNum < 1 || ageNum > 120) {
-      toast({ title: "Invalid age", description: "Age must be between 1 and 120", status: "warning", duration: 4000 });
+    if (isNaN(ageNum) || ageNum < 18 || ageNum > 120) {
+      toast({ title: "Invalid age", description: "Age must be between 18 and 120", status: "warning", duration: 4000 });
       return;
     }
 
@@ -589,8 +597,11 @@ export const useHushhUserProfileLogic = () => {
       console.error("[Profile] Investor profile exception:", err);
       toast({ title: "Investor profile failed", description: "Network error — will retry later", status: "warning", duration: 4000 });
     }).finally(() => {
-      // Check if both are done
-      setShadowStatus((prev) => { checkAllDone('done', prev); return prev; });
+      // Use actual investor status (done or error) to check completion
+      setInvestorStatus((invActual) => {
+        setShadowStatus((shdActual) => { checkAllDone(invActual, shdActual); return shdActual; });
+        return invActual;
+      });
     });
 
     // ── API 2: Shadow Investigator (fire-and-forget) ──
@@ -621,8 +632,11 @@ export const useHushhUserProfileLogic = () => {
       setShadowLoading(false);
       console.error("[Profile] Shadow investigator exception:", err);
     }).finally(() => {
-      // Check if both are done
-      setInvestorStatus((prev) => { checkAllDone(prev, 'done'); return prev; });
+      // Use actual shadow status (done or error) to check completion
+      setShadowStatus((shdActual) => {
+        setInvestorStatus((invActual) => { checkAllDone(invActual, shdActual); return invActual; });
+        return shdActual;
+      });
     });
   };
 
@@ -651,20 +665,40 @@ export const useHushhUserProfileLogic = () => {
   };
 
   /**
-   * handleSaveChanges — saves ONLY manual form edits to Supabase
-   * No AI calls. Just a simple upsert of editable fields.
+   * handleSaveChanges — saves manual form edits + AI profile edits to Supabase
+   * No AI generation calls. Just a simple upsert of editable fields.
+   * Also persists AI profile field edits if user modified them.
    * Only enabled when isDirty === true (user has edited something).
    */
   const handleSaveChanges = async () => {
     if (isSaving || !isDirty || !userId) return;
+
+    // Validate required fields before saving
+    if (!form.name?.trim()) {
+      toast({ title: "Name required", description: "Please enter your name before saving", status: "warning", duration: 3000 });
+      return;
+    }
+    if (form.email?.trim()) {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(form.email.trim())) {
+        toast({ title: "Invalid email", description: "Please enter a valid email address", status: "warning", duration: 3000 });
+        return;
+      }
+    }
 
     const supabase = resources.config.supabaseClient;
     if (!supabase) return;
 
     setIsSaving(true);
     try {
-      await saveToSupabase({});
+      // Include AI profile in payload if user edited any AI fields
+      const payload: Record<string, unknown> = {};
+      if (isAiProfileDirty && investorProfile) {
+        payload.investor_profile = investorProfile;
+      }
+      await saveToSupabase(payload);
       setIsDirty(false);
+      setIsAiProfileDirty(false);
       toast({ title: "Changes saved", description: "Your profile details have been updated", status: "success", duration: 3000 });
     } catch (err) {
       console.error("[Profile] Save changes failed:", err);

--- a/src/pages/hushh-user-profile/ui.tsx
+++ b/src/pages/hushh-user-profile/ui.tsx
@@ -1,12 +1,12 @@
 /**
- * HushhUserProfile — Revamped
- * Apple iOS colors, Playfair Display headings, proper English capitalization.
- * Matches Home + Fund A + Community + Profile design language.
+ * HushhUserProfile — Revamped UI
+ * Clear separation: "Enhance with AI" (BLACK) vs "Save Changes" (WHITE)
+ * Edit indicators on all editable fields.
  * Logic stays in logic.ts.
  */
 import React from "react";
 import { useHushhUserProfileLogic, FIELD_LABELS, VALUE_LABELS } from "./logic";
-import { Copy, Check, ChevronDown, ChevronUp, Target, Clock, Gauge, Droplets, Briefcase, Layers, Zap, Activity, TrendingUp, Search, Heart, Globe, Users } from "lucide-react";
+import { Copy, Check, Pencil } from "lucide-react";
 import { FaApple } from "react-icons/fa";
 import { FcGoogle } from "react-icons/fc";
 import HushhTechBackHeader from "../../components/hushh-tech-back-header/HushhTechBackHeader";
@@ -17,11 +17,15 @@ import NWSScoreBadge from "../../components/profile/NWSScoreBadge";
 /* ── Playfair heading style ── */
 const playfair = { fontFamily: "'Playfair Display', serif" };
 
-/* ── Tiny reusable row (settings-style) ── */
+/* ── Tiny reusable row (settings-style) with edit indicator ── */
 const FieldRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
   <div className="group flex items-center justify-between gap-4 border-b border-gray-100 py-4 hover:bg-gray-50/50 transition-colors">
     <span className="text-sm text-gray-500 font-light shrink-0">{label}</span>
-    <div className="flex items-center gap-2 text-right min-w-0 flex-1 justify-end">{children}</div>
+    <div className="flex items-center gap-2 text-right min-w-0 flex-1 justify-end">
+      {children}
+      {/* Subtle edit pencil — visible on hover */}
+      <Pencil className="w-3 h-3 text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+    </div>
   </div>
 );
 
@@ -38,38 +42,13 @@ const HushhUserProfilePage: React.FC = () => {
     form, investorProfile, loading, loadingSeconds, isProcessing, investorStatus, shadowStatus,
     hasOnboardingData, isApplePassLoading, isGooglePassLoading, nwsResult, nwsLoading,
     hasCopied, onCopy, profileUrl, navigate,
-    handleChange, handleSubmit, handleBack, handleSave,
+    handleChange, handleBack, handleSave,
     isDirty, isSaving, handleSaveChanges,
     handleAppleWalletPass, handleGoogleWalletPass, COUNTRIES,
     editingField, setEditingField, FIELD_OPTIONS, MULTI_SELECT_FIELDS,
     handleUpdateAIField, handleMultiSelectToggle, getConfidenceLabel, getConfidenceBadgeClass,
     shadowProfile, shadowConfidenceLabel, shadowLifestyleTags, shadowBrandTags, shadowKnownForTags,
   } = useHushhUserProfileLogic();
-
-  // Expanded state for AI profile field rationales
-  const [expandedFields, setExpandedFields] = React.useState<Set<string>>(new Set());
-  const toggleFieldExpand = (fieldName: string) => {
-    setExpandedFields(prev => {
-      const next = new Set(prev);
-      next.has(fieldName) ? next.delete(fieldName) : next.add(fieldName);
-      return next;
-    });
-  };
-
-  // Field icon mapping
-  const getFieldIcon = (fieldName: string) => {
-    switch (fieldName) {
-      case "primary_goal": return <Target className="w-4 h-4 text-hushh-blue" />;
-      case "investment_horizon_years": return <Clock className="w-4 h-4 text-hushh-blue" />;
-      case "risk_tolerance": return <Gauge className="w-4 h-4 text-hushh-blue" />;
-      case "liquidity_need": return <Droplets className="w-4 h-4 text-hushh-blue" />;
-      case "experience_level": return <Briefcase className="w-4 h-4 text-hushh-blue" />;
-      case "asset_class_preference": return <Layers className="w-4 h-4 text-hushh-blue" />;
-      case "typical_ticket_size": return <Zap className="w-4 h-4 text-hushh-blue" />;
-      case "engagement_style": return <Activity className="w-4 h-4 text-hushh-blue" />;
-      default: return <TrendingUp className="w-4 h-4 text-hushh-blue" />;
-    }
-  };
 
   const firstName = form.name?.split(" ")[0] || "Investor";
 
@@ -169,7 +148,7 @@ const HushhUserProfilePage: React.FC = () => {
             {loading
               ? `Generating... ${loadingSeconds}s`
               : investorProfile
-              ? "Update Profile"
+              ? "Re-enhance with AI"
               : hasOnboardingData
               ? "Enhance with AI"
               : "Generate Investor Profile"}
@@ -192,7 +171,7 @@ const HushhUserProfilePage: React.FC = () => {
                 </span>
               </div>
               <p className="text-gray-500 text-xs leading-relaxed">
-                AI-detected preferences based on your profile data.
+                AI-detected preferences based on your profile data. Tap any field to adjust.
               </p>
             </div>
 
@@ -212,14 +191,25 @@ const HushhUserProfilePage: React.FC = () => {
 
                 return (
                   <div key={fieldName}>
-                    <FieldRow label={label}>
+                    <div
+                      className="group flex items-center justify-between gap-4 border-b border-gray-100 py-4 hover:bg-gray-50/50 transition-colors cursor-pointer"
+                      onClick={() => options && setEditingField(isEditing ? null : fieldName)}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`Edit ${label}`}
+                      onKeyDown={(e) => { if (e.key === 'Enter' && options) setEditingField(isEditing ? null : fieldName); }}
+                    >
+                      <span className="text-sm text-gray-500 font-light shrink-0">{label}</span>
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium text-black truncate max-w-[140px]">{valueText || "—"}</span>
                         <span className={`text-[9px] px-1.5 py-0.5 rounded-full border shrink-0 ${getConfidenceBadgeClass(confidence)}`}>
                           {confLabel}
                         </span>
+                        {options && (
+                          <Pencil className="w-3 h-3 text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                        )}
                       </div>
-                    </FieldRow>
+                    </div>
                     {/* Inline edit when tapped */}
                     {isEditing && options && (
                       <div className="px-1 pb-4 pt-1" onClick={(e) => e.stopPropagation()}>
@@ -344,8 +334,8 @@ const HushhUserProfilePage: React.FC = () => {
           </section>
         )}
 
-        {/* ── Your Hushh Profile ── */}
-        <section className="mb-12">
+        {/* ── Your Hushh Profile (editable section) ── */}
+        <section className="mb-6">
           <div className="mb-8">
             <h2
               className="text-2xl font-medium text-black tracking-tight mb-2 font-serif"
@@ -355,8 +345,13 @@ const HushhUserProfilePage: React.FC = () => {
               <span className="text-gray-400 italic font-light">Profile.</span>
             </h2>
             <p className="text-gray-500 text-xs leading-relaxed">
-              Review and update your details to keep your investor profile complete.
+              Tap any field to edit your details. Changes are saved separately from AI analysis.
             </p>
+            {/* Edit hint banner */}
+            <div className="mt-3 flex items-center gap-2 px-3 py-2 rounded-xl bg-gray-50 border border-gray-100">
+              <Pencil className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+              <span className="text-[11px] text-gray-400">Tap any field to edit · click "Save Changes" to update</span>
+            </div>
           </div>
 
           {/* Personal Information */}
@@ -458,6 +453,19 @@ const HushhUserProfilePage: React.FC = () => {
               <input type="text" value={form.zipCode} onChange={(e) => handleChange("zipCode", e.target.value)} className={inlineInput} placeholder="560001" />
             </FieldRow>
           </div>
+
+          {/* Save Changes button — right after editable fields, WHITE variant */}
+          <div className="mt-6">
+            <HushhTechCta variant={HushhTechCtaVariant.WHITE} onClick={handleSaveChanges} disabled={!isDirty || isSaving}>
+              {isSaving ? (
+                <>Saving... <span className="material-symbols-outlined text-lg animate-spin">progress_activity</span></>
+              ) : isDirty ? (
+                <>Save Changes <span className="material-symbols-outlined text-lg">save</span></>
+              ) : (
+                <>Profile Saved <Check className="w-4 h-4 text-gray-400" /></>
+              )}
+            </HushhTechCta>
+          </div>
         </section>
 
         {/* ── Profile Link + Wallet ── */}
@@ -481,11 +489,8 @@ const HushhUserProfilePage: React.FC = () => {
           </div>
         </section>
 
-        {/* ── CTAs ── */}
-        <section className="pb-12 space-y-3">
-          <HushhTechCta variant={HushhTechCtaVariant.BLACK} onClick={handleSaveChanges} disabled={!isDirty || isSaving}>
-            {isSaving ? "Saving..." : isDirty ? "Save Changes" : "No Changes to Save"}
-          </HushhTechCta>
+        {/* ── Bottom CTA ── */}
+        <section className="pb-12">
           <HushhTechCta variant={HushhTechCtaVariant.WHITE} onClick={() => navigate("/")}>
             Go to Home
           </HushhTechCta>

--- a/supabase/migrations/20260317000000_fix_investor_profiles_constraints_v2.sql
+++ b/supabase/migrations/20260317000000_fix_investor_profiles_constraints_v2.sql
@@ -1,0 +1,24 @@
+-- =====================================================
+-- Fix investor_profiles constraints
+-- 1. Widen age CHECK from (18-100) to (18-120)
+-- 2. Drop email UNIQUE constraint (user_id UNIQUE is sufficient)
+-- 3. Make age nullable with default 30 for auto-creation flow
+-- =====================================================
+
+-- 1. Drop old age CHECK and add wider range
+ALTER TABLE investor_profiles DROP CONSTRAINT IF EXISTS investor_profiles_age_check;
+ALTER TABLE investor_profiles ADD CONSTRAINT investor_profiles_age_check CHECK (age >= 18 AND age <= 120);
+
+-- 2. Drop email unique constraint — user_id is the real identifier
+-- Email uniqueness can block legitimate flows (multi-provider auth)
+ALTER TABLE investor_profiles DROP CONSTRAINT IF EXISTS investor_profiles_email_key;
+
+-- 3. Make age nullable with default for auto-creation flow
+ALTER TABLE investor_profiles ALTER COLUMN age DROP NOT NULL;
+ALTER TABLE investor_profiles ALTER COLUMN age SET DEFAULT 30;
+
+-- 4. Make name and email nullable for auto-creation edge cases
+ALTER TABLE investor_profiles ALTER COLUMN name DROP NOT NULL;
+ALTER TABLE investor_profiles ALTER COLUMN name SET DEFAULT '';
+ALTER TABLE investor_profiles ALTER COLUMN email DROP NOT NULL;
+ALTER TABLE investor_profiles ALTER COLUMN email SET DEFAULT '';


### PR DESCRIPTION
## Changes (Full Profile Page Audit)

### UI (ui.tsx)
- Separate buttons: Enhance with AI (BLACK) vs Save Changes (WHITE)
- Edit indicators (pencil hover) on all editable fields
- Removed 6 unused icon imports + expandedFields state

### Logic (logic.ts)
- onConflict: user_id added to ALL upsert calls
- Age validation aligned to DB constraint (18-120)
- AI field edits tracked via isDirty + isAiProfileDirty
- handleSaveChanges includes investor_profile when AI fields edited

### Schema (migration applied to live Supabase)
- Age CHECK: 18-100 to 18-120
- Email UNIQUE dropped (user_id UNIQUE sufficient)
- name/email/age nullable with defaults

### Testing
- TypeScript: zero errors
- Schema verified via Supabase Management API