### PR TITLE
Add RIA intelligence dossier API

### DIFF
--- a/cloud-run/ria-intelligence-api/Dockerfile
+++ b/cloud-run/ria-intelligence-api/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PORT=8080
+ENV GOOGLE_GENAI_USE_VERTEXAI=True
+ENV GOOGLE_CLOUD_LOCATION=global
+ENV FORWARDED_ALLOW_IPS=*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+EXPOSE 8080
+
+CMD ["gunicorn", "-k", "uvicorn.workers.UvicornWorker", "-w", "1", "--threads", "8", "--timeout", "0", "--bind", "0.0.0.0:8080", "app.main:app"]

--- a/cloud-run/ria-intelligence-api/README.md
+++ b/cloud-run/ria-intelligence-api/README.md
@@ -1,0 +1,256 @@
+# Hushh RIA Intelligence API
+
+Standalone Python API for advisor lookup and public-web dossier generation.
+
+## Quick Start
+
+Public API me **sirf name/query dena hota hai**.
+
+Example:
+
+```json
+{
+  "query": "ANA ROUMENOVA CARTER"
+}
+```
+
+You do **not** send:
+
+- Phase 1 seed JSON
+- FINRA details manually
+- CRD number manually
+- any image/document payload
+
+Current public flow:
+
+1. caller sends a name query
+2. Phase 1 verifies the advisor or firm via Gemini on Vertex AI against FINRA/SEC sources
+3. the verified Phase 1 profile is passed as seed JSON into OpenAI Responses API
+4. backend scrapes and ranks public image candidates
+5. API returns the final dossier JSON
+
+## Base URL
+
+Production:
+
+```text
+https://hushh-ria-intelligence-api-53407187172.us-central1.run.app
+```
+
+Local:
+
+```text
+http://127.0.0.1:8000
+```
+
+## Endpoints
+
+| Method | Endpoint | Use |
+|---|---|---|
+| `GET` | `/` | Basic liveness check |
+| `GET` | `/health` | Health check for Cloud Run and external monitors |
+| `GET` | `/healthz` | Legacy compatibility alias; avoid using this path on Cloud Run |
+| `POST` | `/v1/ria/profile` | Main query-based advisor dossier API |
+
+## `POST /v1/ria/profile`
+
+### Input
+
+```json
+{
+  "query": "ANA ROUMENOVA CARTER"
+}
+```
+
+### Input rules
+
+- `query` is required
+- `query` must not be blank
+- this route does not accept a Phase 1 seed payload directly
+- the backend itself builds the Phase 1 verified profile internally
+- client only sends the advisor or firm name
+
+## Output
+
+### Success response shape
+
+```json
+{
+  "subject": {
+    "full_name": "ANA ROUMENOVA CARTER",
+    "crd_number": "4424794",
+    "current_firm": "LCG CAPITAL ADVISORS, LLC",
+    "location": "Tampa, Florida"
+  },
+  "executive_summary": "Ana Carter is a finance executive and outsourced FINOP.",
+  "verified_profiles": [
+    {
+      "platform": "FINRA BrokerCheck",
+      "label": "BrokerCheck Report - ANA ROUMENOVA CARTER",
+      "url": "https://files.brokercheck.finra.org/individual/individual_4424794.pdf",
+      "handle": null,
+      "source_title": "BrokerCheck Report - ANA ROUMENOVA CARTER",
+      "source_url": "https://files.brokercheck.finra.org/individual/individual_4424794.pdf",
+      "evidence_note": "Official regulatory source captured during Phase 1 verification."
+    }
+  ],
+  "public_images": [
+    {
+      "kind": "headshot",
+      "image_url": "https://images.example/ana-final.jpg",
+      "source_page_url": "https://cartanaconsulting.com/about-cartana/",
+      "source_title": "About Cartana",
+      "confidence_note": "Best public headshot among validated candidates."
+    }
+  ],
+  "key_facts": [
+    {
+      "fact": "Founder of Cartana Consulting Solutions.",
+      "source_title": "About Cartana",
+      "source_url": "https://cartanaconsulting.com/about-cartana/",
+      "evidence_note": "Official company biography."
+    }
+  ],
+  "unverified_or_not_found": [],
+  "prompts_used": [
+    "Ana Roumenova Carter LinkedIn"
+  ]
+}
+```
+
+## Runtime Behavior
+
+- Public request contract is always:
+  - input: `{ "query": "<name>" }`
+  - output: final dossier JSON
+- Phase 1 no confident FINRA/SEC match:
+  - returns `200`
+  - `subject.full_name` is filled from the query
+  - `subject.crd_number/current_firm/location = null`
+  - `verified_profiles`, `public_images`, `key_facts` are empty
+  - `unverified_or_not_found` contains the not-found reason
+- Phase 1 verified + OpenAI dossier success:
+  - returns `200`
+  - final dossier JSON
+- Phase 1 verified + image-ranking fallback:
+  - returns `200`
+  - final dossier JSON with validated fallback public image candidates
+- full Phase 1 upstream failure:
+  - returns `502`
+- blank query:
+  - returns `400`
+
+## Image Behavior
+
+- OpenAI dossier research returns profile/page/image evidence
+- backend then fetches candidate/source pages and extracts images from:
+  - `og:image`
+  - `twitter:image`
+  - `<img>`
+- shortlisted images are ranked with a second OpenAI pass
+- if that ranking step fails, the API falls back to locally validated public image candidates
+- final `public_images` contains public source URLs only
+- no DOCX is generated
+- no image is uploaded to GCS by this endpoint
+
+## Example curl
+
+### Production
+
+```bash
+curl https://hushh-ria-intelligence-api-53407187172.us-central1.run.app/health
+
+curl -X POST https://hushh-ria-intelligence-api-53407187172.us-central1.run.app/v1/ria/profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "ANA ROUMENOVA CARTER"
+  }'
+```
+
+Minimal one-line request:
+
+```bash
+curl -X POST https://hushh-ria-intelligence-api-53407187172.us-central1.run.app/v1/ria/profile -H "Content-Type: application/json" -d '{"query":"ANA ROUMENOVA CARTER"}'
+```
+
+### Local
+
+```bash
+curl http://127.0.0.1:8000/health
+
+curl -X POST http://127.0.0.1:8000/v1/ria/profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "ANA ROUMENOVA CARTER"
+  }'
+```
+
+## Environment
+
+Required:
+
+- `GOOGLE_CLOUD_PROJECT`
+- `OPENAI_API_KEY`
+
+Optional:
+
+- `GOOGLE_CLOUD_LOCATION=global`
+- `RIA_PRIMARY_MODEL=gemini-3.1-pro-preview`
+- `RIA_FALLBACK_MODEL=gemini-2.5-pro`
+- `OPENAI_MODEL=gpt-5.4`
+- `OPENAI_IMAGE_RANK_MODEL=gpt-5.4-mini`
+- `OPENAI_TIMEOUT_SECONDS=90`
+- `PORT=8080`
+
+## Local Run
+
+```bash
+cd cloud-run/ria-intelligence-api
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID
+export GOOGLE_CLOUD_LOCATION=global
+export OPENAI_API_KEY=YOUR_OPENAI_KEY
+export RIA_PRIMARY_MODEL=gemini-3.1-pro-preview
+export RIA_FALLBACK_MODEL=gemini-2.5-pro
+export OPENAI_MODEL=gpt-5.4
+export OPENAI_IMAGE_RANK_MODEL=gpt-5.4-mini
+uvicorn app.main:app --reload
+```
+
+## Deploy
+
+```bash
+./scripts/deploy-ria-intelligence-api.sh \
+  --project YOUR_PROJECT_ID \
+  --region us-central1 \
+  --openai-api-key-secret YOUR_SECRET_NAME
+```
+
+## Server-Side OpenAI Key
+
+Keep the OpenAI key on the server side only.
+
+Recommended production setup:
+
+1. store the key in GCP Secret Manager
+2. grant the Cloud Run service account `roles/secretmanager.secretAccessor`
+3. deploy with `--openai-api-key-secret YOUR_SECRET_NAME`
+
+Example:
+
+```bash
+./scripts/deploy-ria-intelligence-api.sh \
+  --project hushone-app \
+  --region us-central1 \
+  --openai-api-key-secret ria-intelligence-openai-api-key
+```
+
+The live service is currently configured this way, so `OPENAI_API_KEY` is injected into Cloud Run from Secret Manager instead of being kept in source code or frontend code.
+
+## Security Note
+
+Do not hardcode OpenAI keys in source, docs, or scripts.
+
+If an OpenAI key was shared in chat on **March 21, 2026**, rotate it before production use and move it into Secret Manager.

--- a/cloud-run/ria-intelligence-api/app/__init__.py
+++ b/cloud-run/ria-intelligence-api/app/__init__.py
@@ -1,0 +1,2 @@
+"""RIA Intelligence Cloud Run service package."""
+

--- a/cloud-run/ria-intelligence-api/app/image_pipeline.py
+++ b/cloud-run/ria-intelligence-api/app/image_pipeline.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import io
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable
+from urllib.parse import quote, urlparse
+
+import httpx
+from PIL import Image, UnidentifiedImageError
+
+from .models import ImageCandidate, RIAProfile
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_IMAGE_REFRESH_DAYS = 30
+DEFAULT_IMAGE_MAX_BYTES = 5 * 1024 * 1024
+DEFAULT_IMAGE_BUCKET = ""
+DEFAULT_FETCH_TIMEOUT_SECONDS = 20.0
+MIN_HEADSHOT_DIMENSION = 200
+MIN_LOGO_DIMENSION = 120
+ALLOWED_CONTENT_TYPES = {
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+}
+TEAM_PAGE_KEYWORDS = (
+    "advisor",
+    "advisors",
+    "bio",
+    "leadership",
+    "our-team",
+    "people",
+    "professional",
+    "professionals",
+    "staff",
+    "team",
+)
+ABOUT_PAGE_KEYWORDS = ("about", "company", "firm", "leadership")
+TWITTER_DOMAINS = {"twitter.com", "www.twitter.com", "x.com", "www.x.com"}
+LINKEDIN_DOMAINS = {"linkedin.com", "www.linkedin.com"}
+
+
+@dataclass(frozen=True)
+class FetchedImage:
+    data: bytes
+    content_type: str
+    extension: str
+    width: int
+    height: int
+    final_url: str
+
+
+@dataclass(frozen=True)
+class ImageResolutionResult:
+    public_url: str | None
+    warnings: list[str]
+
+
+class HTTPImageFetcher:
+    def __init__(self, client: httpx.Client | None = None) -> None:
+        self._client = client or httpx.Client(
+            follow_redirects=True,
+            max_redirects=3,
+            timeout=DEFAULT_FETCH_TIMEOUT_SECONDS,
+            headers={"User-Agent": "hushh-ria-intelligence-api/1.0"},
+        )
+
+    def fetch(self, url: str, max_bytes: int) -> FetchedImage:
+        if not _is_https_url(url):
+            raise ValueError("candidate image URL must use https")
+
+        with self._client.stream("GET", url) as response:
+            response.raise_for_status()
+            final_url = str(response.url)
+            if not _is_https_url(final_url):
+                raise ValueError("image redirect chain ended on a non-https URL")
+
+            content_type = _normalize_content_type(response.headers.get("content-type"))
+            if content_type not in ALLOWED_CONTENT_TYPES:
+                raise ValueError(f"unsupported content type: {content_type or 'unknown'}")
+
+            size_header = response.headers.get("content-length")
+            if size_header and int(size_header) > max_bytes:
+                raise ValueError("image exceeds maximum allowed size")
+
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in response.iter_bytes():
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError("image exceeds maximum allowed size")
+                chunks.append(chunk)
+
+        data = b"".join(chunks)
+        width, height = _inspect_image_dimensions(data, content_type)
+        return FetchedImage(
+            data=data,
+            content_type=content_type,
+            extension=ALLOWED_CONTENT_TYPES[content_type],
+            width=width,
+            height=height,
+            final_url=final_url,
+        )
+
+    def is_publicly_accessible(self, url: str) -> bool:
+        if not _is_https_url(url):
+            return False
+
+        try:
+            with self._client.stream("GET", url, headers={"Range": "bytes=0-0"}) as response:
+                if response.status_code not in (200, 206):
+                    return False
+                content_type = _normalize_content_type(response.headers.get("content-type"))
+                return content_type in ALLOWED_CONTENT_TYPES
+        except Exception:  # noqa: BLE001 - non-critical validation path
+            return False
+
+
+class GCSImageStore:
+    def __init__(
+        self,
+        bucket_name: str,
+        *,
+        client: object | None = None,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        if not bucket_name:
+            raise ValueError("bucket_name is required")
+
+        self._now_fn = now_fn or (lambda: datetime.now(timezone.utc))
+        self.bucket_name = bucket_name
+
+        if client is None:
+            try:
+                from google.cloud import storage
+            except ImportError as exc:
+                raise RuntimeError(
+                    "google-cloud-storage is not installed. Install requirements before starting the service."
+                ) from exc
+            client = storage.Client()
+
+        self._client = client
+        self._bucket = self._client.bucket(bucket_name)
+
+    def get_fresh_public_url(self, base_object_key: str, refresh_days: int) -> str | None:
+        cutoff = self._now_fn() - timedelta(days=refresh_days)
+        freshest: tuple[datetime, str] | None = None
+
+        for extension in ALLOWED_CONTENT_TYPES.values():
+            object_name = f"{base_object_key}.{extension}"
+            blob = self._bucket.blob(object_name)
+            if not blob.exists(client=self._client):
+                continue
+            blob.reload(client=self._client)
+            updated = blob.updated
+            if updated is None:
+                continue
+            if updated.tzinfo is None:
+                updated = updated.replace(tzinfo=timezone.utc)
+            if updated < cutoff:
+                continue
+            if freshest is None or updated > freshest[0]:
+                freshest = (updated, object_name)
+
+        if freshest is None:
+            return None
+
+        return self.public_url(freshest[1])
+
+    def upload_image(
+        self,
+        *,
+        base_object_key: str,
+        extension: str,
+        data: bytes,
+        content_type: str,
+    ) -> str:
+        object_name = f"{base_object_key}.{extension}"
+        blob = self._bucket.blob(object_name)
+        blob.cache_control = "public, max-age=86400"
+        blob.upload_from_string(data, content_type=content_type)
+
+        for other_extension in ALLOWED_CONTENT_TYPES.values():
+            if other_extension == extension:
+                continue
+            stale_blob = self._bucket.blob(f"{base_object_key}.{other_extension}")
+            if stale_blob.exists(client=self._client):
+                stale_blob.delete(client=self._client)
+
+        return self.public_url(object_name)
+
+    def public_url(self, object_name: str) -> str:
+        quoted_name = quote(object_name, safe="/")
+        return f"https://storage.googleapis.com/{self.bucket_name}/{quoted_name}"
+
+
+class ImagePipeline:
+    def __init__(
+        self,
+        *,
+        bucket_name: str | None = None,
+        refresh_days: int | None = None,
+        max_bytes: int | None = None,
+        store: GCSImageStore | None = None,
+        storage_client: object | None = None,
+        fetcher: HTTPImageFetcher | None = None,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.bucket_name = bucket_name or os.getenv("RIA_IMAGE_BUCKET", DEFAULT_IMAGE_BUCKET)
+        self.refresh_days = int(
+            refresh_days
+            if refresh_days is not None
+            else os.getenv("RIA_IMAGE_REFRESH_DAYS", DEFAULT_IMAGE_REFRESH_DAYS)
+        )
+        self.max_bytes = int(
+            max_bytes
+            if max_bytes is not None
+            else os.getenv("RIA_IMAGE_MAX_BYTES", DEFAULT_IMAGE_MAX_BYTES)
+        )
+        self._fetcher = fetcher or HTTPImageFetcher()
+        self._store_error: str | None = None
+        self._store: GCSImageStore | None = store
+
+        if self._store is None and self.bucket_name:
+            try:
+                self._store = GCSImageStore(
+                    self.bucket_name,
+                    client=storage_client,
+                    now_fn=now_fn,
+                )
+            except Exception as exc:  # noqa: BLE001 - defer to runtime warning path
+                logger.warning("Image store initialization failed: %s", exc)
+                self._store_error = str(exc)
+
+    def resolve_image(
+        self,
+        *,
+        profile: RIAProfile,
+        image_candidates: list[ImageCandidate] | None,
+    ) -> ImageResolutionResult:
+        if not image_candidates:
+            return ImageResolutionResult(public_url=None, warnings=[])
+
+        if not self.bucket_name:
+            return ImageResolutionResult(
+                public_url=None,
+                warnings=["Image enrichment skipped because RIA_IMAGE_BUCKET is not configured."],
+            )
+
+        if self._store is None:
+            return ImageResolutionResult(
+                public_url=None,
+                warnings=[f"Image enrichment skipped because storage is unavailable. {self._store_error}"],
+            )
+
+        ranked_candidates = _rank_candidates(image_candidates)
+        if not ranked_candidates:
+            return ImageResolutionResult(
+                public_url=None,
+                warnings=["No valid public image candidate passed deterministic validation."],
+            )
+
+        for candidate in ranked_candidates:
+            base_object_key = _build_base_object_key(profile, candidate)
+            if base_object_key is None:
+                logger.info("Skipping image candidate because no stable object key could be derived.")
+                continue
+
+            fresh_public_url = self._store.get_fresh_public_url(base_object_key, self.refresh_days)
+            if fresh_public_url:
+                if self._fetcher.is_publicly_accessible(fresh_public_url):
+                    return ImageResolutionResult(public_url=fresh_public_url, warnings=[])
+                logger.warning("Stored image exists but is not publicly accessible: %s", fresh_public_url)
+                return ImageResolutionResult(
+                    public_url=None,
+                    warnings=["Stored image exists but is not publicly accessible from GCS."],
+                )
+
+            try:
+                fetched = self._fetcher.fetch(candidate.imageUrl or "", self.max_bytes)
+                _validate_dimensions(candidate, fetched)
+                public_url = self._store.upload_image(
+                    base_object_key=base_object_key,
+                    extension=fetched.extension,
+                    data=fetched.data,
+                    content_type=fetched.content_type,
+                )
+            except Exception as exc:  # noqa: BLE001 - keep trying lower-priority candidates
+                logger.info(
+                    "Image candidate rejected for profile=%s source=%s reason=%s",
+                    profile.fullName or profile.currentFirm or profile.crdNumber,
+                    candidate.sourcePageUrl,
+                    exc,
+                )
+                continue
+
+            if not self._fetcher.is_publicly_accessible(public_url):
+                logger.warning("Uploaded image is not publicly accessible from GCS: %s", public_url)
+                return ImageResolutionResult(
+                    public_url=None,
+                    warnings=["Image uploaded to GCS but public delivery is blocked by bucket or org policy."],
+                )
+
+            logger.info(
+                "Selected image for profile=%s candidateType=%s sourcePage=%s publicUrl=%s",
+                profile.fullName or profile.currentFirm or profile.crdNumber,
+                candidate.candidateType,
+                candidate.sourcePageUrl,
+                public_url,
+            )
+            return ImageResolutionResult(public_url=public_url, warnings=[])
+
+        return ImageResolutionResult(
+            public_url=None,
+            warnings=["No valid public image candidate passed deterministic validation."],
+        )
+
+
+def _build_base_object_key(profile: RIAProfile, candidate: ImageCandidate) -> str | None:
+    if candidate.candidateType == "logo":
+        firm_name = profile.currentFirm or profile.fullName
+        if not firm_name:
+            return None
+        return f"ria-images/firms/{_slugify(firm_name)}/logo"
+
+    advisor_id = profile.crdNumber or profile.fullName
+    if not advisor_id:
+        return None
+    return f"ria-images/advisors/{_slugify(advisor_id)}/profile"
+
+
+def _rank_candidates(candidates: list[ImageCandidate]) -> list[ImageCandidate]:
+    deduped: dict[str, ImageCandidate] = {}
+    for candidate in candidates:
+        image_url = (candidate.imageUrl or "").strip()
+        source_page_url = (candidate.sourcePageUrl or "").strip()
+        if not image_url or not source_page_url:
+            continue
+        if not _is_https_url(image_url) or not _is_https_url(source_page_url):
+            continue
+        if candidate.candidateType not in {"headshot", "logo"}:
+            continue
+        if candidate.confidence is not None and candidate.confidence < 90:
+            continue
+        deduped.setdefault(image_url, candidate)
+
+    return sorted(deduped.values(), key=_candidate_sort_key)
+
+
+def _candidate_sort_key(candidate: ImageCandidate) -> tuple[int, int, str]:
+    priority = 99
+    platform = (candidate.platform or "").strip().lower()
+    source = urlparse(candidate.sourcePageUrl or "")
+    domain = (source.netloc or "").lower()
+    path = (source.path or "").lower()
+
+    if candidate.candidateType == "headshot":
+        if platform == "linkedin" or _domain_matches(domain, LINKEDIN_DOMAINS):
+            priority = 0
+        elif platform in {"twitter", "x"} or _domain_matches(domain, TWITTER_DOMAINS):
+            priority = 1
+        elif any(keyword in path for keyword in TEAM_PAGE_KEYWORDS):
+            priority = 2
+        elif any(keyword in path for keyword in ABOUT_PAGE_KEYWORDS + TEAM_PAGE_KEYWORDS):
+            priority = 3
+        else:
+            priority = 3
+    elif candidate.candidateType == "logo":
+        priority = 4
+
+    confidence_rank = -(candidate.confidence or 0)
+    return (priority, confidence_rank, candidate.imageUrl or "")
+
+
+def _validate_dimensions(candidate: ImageCandidate, fetched: FetchedImage) -> None:
+    minimum = MIN_LOGO_DIMENSION if candidate.candidateType == "logo" else MIN_HEADSHOT_DIMENSION
+    if fetched.width < minimum or fetched.height < minimum:
+        raise ValueError(
+            f"image dimensions {fetched.width}x{fetched.height} are below the minimum {minimum}x{minimum}"
+        )
+
+
+def _inspect_image_dimensions(data: bytes, content_type: str) -> tuple[int, int]:
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            image.load()
+            if image.format not in {"JPEG", "PNG", "WEBP"}:
+                raise ValueError(f"decoded image format is not supported: {image.format}")
+            width, height = image.size
+    except UnidentifiedImageError as exc:
+        raise ValueError(f"response body was not a valid raster image for {content_type}") from exc
+    return width, height
+
+
+def _normalize_content_type(value: str | None) -> str:
+    if not value:
+        return ""
+    return value.split(";", 1)[0].strip().lower()
+
+
+def _is_https_url(value: str) -> bool:
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def _domain_matches(domain: str, options: set[str]) -> bool:
+    if domain in options:
+        return True
+    return any(domain.endswith(f".{option}") for option in options)
+
+
+def _slugify(value: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return normalized or "unknown"

--- a/cloud-run/ria-intelligence-api/app/image_scraper.py
+++ b/cloud-run/ria-intelligence-api/app/image_scraper.py
@@ -1,0 +1,1229 @@
+"""Deterministic web scraper for advisor/firm profile images.
+
+Production-grade module that:
+1. Takes verified profile data, model-discovered candidate pages, AND grounded source URLs
+2. Filters source URLs for relevance (person/firm name match, team/about pages)
+3. Crawls actual pages: LinkedIn, firm website, FINRA BrokerCheck, grounded sources
+4. Parses HTML with rich extraction: <img>, srcset, data-src, <picture><source>,
+   og:image, twitter:image, JSON-LD image, CSS background-image
+5. Scores and ranks images using page-level + image-level heuristics
+6. Returns ImageCandidate objects for the existing image pipeline
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from urllib.parse import urljoin, urlparse
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+
+from .models import ImageCandidate, RIAProfile
+
+logger = logging.getLogger(__name__)
+
+SCRAPE_TIMEOUT = 15.0
+MAX_CANDIDATES_PER_SOURCE = 4
+MAX_TOTAL_CANDIDATES = 10
+MAX_GROUNDED_PAGES = 6
+
+# CDN patterns for known platforms
+LINKEDIN_IMAGE_PATTERNS = (
+    "media.licdn.com",
+    "media-exp1.licdn.com",
+    "media-exp2.licdn.com",
+    "static.licdn.com",
+)
+TWITTER_IMAGE_PATTERNS = (
+    "pbs.twimg.com/profile_images",
+    "pbs.twimg.com/media",
+)
+
+# Low-value assets to reject before fetching
+EXCLUDE_PATTERNS = (
+    "favicon", "sprite", "badge", "arrow", "button",
+    "spacer", "pixel", "tracking", "analytics",
+    "ad-", "ads/", "1x1", "placeholder", "loading",
+    "spinner", "social-", "share-",
+    ".svg", ".gif", "data:image",
+)
+
+# Tiny-asset patterns to reject specifically (favicons, icon fonts, etc.)
+TINY_ASSET_PATTERNS = (
+    "favicon", "apple-touch-icon", "/ico/", "/icons/",
+    "icon-", "-icon.", "16x16", "32x32", "48x48",
+    "shortcut icon",
+)
+
+# Keywords that suggest a headshot image
+HEADSHOT_INDICATORS = (
+    "headshot", "portrait", "profile", "photo", "team",
+    "advisor", "staff", "bio", "about", "people",
+    "professional", "executive", "officer", "director",
+    "member", "principal", "founder", "ceo", "president",
+)
+
+# Team/about page path segments
+TEAM_PAGE_SEGMENTS = (
+    "team", "our-team", "about", "people", "staff",
+    "advisors", "professionals", "leadership", "bio",
+    "about-us", "our-people", "our-advisors", "meet",
+    "team-member", "contact",
+)
+
+# Page keywords that indicate a person/team page (scores higher)
+PERSON_PAGE_KEYWORDS = (
+    "team", "advisor", "bio", "profile", "staff",
+    "people", "leadership", "professional", "member",
+    "about", "meet",
+)
+
+# Patterns to filter irrelevant grounded source URLs
+IRRELEVANT_DOMAIN_PATTERNS = (
+    "wikipedia.org", "youtube.com", "facebook.com",
+    "instagram.com", "reddit.com", "yelp.com",
+    "glassdoor.com", "indeed.com", "bbb.org",
+    "maps.google.com", "news.google.com",
+)
+
+# CSS background-image regex
+CSS_BG_IMAGE_RE = re.compile(
+    r"""background-image\s*:\s*url\(\s*['"]?(https?://[^'")]+)['"]?\s*\)""",
+    re.IGNORECASE,
+)
+
+# srcset entry regex: url followed by optional size descriptor
+SRCSET_ENTRY_RE = re.compile(r"([^\s,]+)\s+(\d+)[wx]", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ScrapedCandidate:
+    """A candidate image found by scraping a web page."""
+    image_url: str
+    source_page_url: str
+    platform: str
+    candidate_type: str  # "headshot" or "logo"
+    confidence: int
+    reason: str
+
+
+@dataclass
+class ScrapeStats:
+    """Observability counters for the image scrape stage."""
+    grounded_source_urls_received: int = 0
+    grounded_source_urls_relevant: int = 0
+    pages_crawled: int = 0
+    images_extracted: int = 0
+    images_rejected: int = 0
+    rejection_reasons: dict[str, int] = field(default_factory=dict)
+    selected_class: str | None = None
+    null_reason: str | None = None
+
+    def reject(self, reason: str) -> None:
+        self.images_rejected += 1
+        self.rejection_reasons[reason] = self.rejection_reasons.get(reason, 0) + 1
+
+
+def create_scraper_client() -> httpx.Client:
+    """Create an httpx client configured for HTML scraping."""
+    return httpx.Client(
+        follow_redirects=True,
+        max_redirects=3,
+        timeout=SCRAPE_TIMEOUT,
+        headers={
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.5",
+        },
+    )
+
+
+class ImageScraper:
+    """Deterministic web scraper that extracts real image URLs from pages."""
+
+    def __init__(self, client: httpx.Client | None = None) -> None:
+        self._client = client or create_scraper_client()
+
+    def discover_candidates(
+        self,
+        profile: RIAProfile,
+        *,
+        model_candidates: list[ImageCandidate] | None = None,
+        gemini_candidates: list[ImageCandidate] | None = None,
+        grounded_source_urls: list[str] | None = None,
+    ) -> list[ImageCandidate]:
+        """Discover image candidates from all available sources.
+
+        Scrapes real web pages using verified profile data.
+        Crawls relevant grounded source URLs from upstream dossier research.
+        Merges scraped candidates with any model candidates.
+        Returns a ranked list of ImageCandidate objects.
+        """
+        stats = ScrapeStats()
+        scraped: list[ScrapedCandidate] = []
+        person_name = profile.fullName or ""
+        firm_name = profile.currentFirm or ""
+        upstream_candidates = model_candidates if model_candidates is not None else gemini_candidates
+        visited_pages: set[str] = set()
+
+        # 1. FINRA BrokerCheck page (highest trust for individuals)
+        if profile.crdNumber and profile.existsOnFinra:
+            results = self._scrape_finra_brokercheck(profile.crdNumber, person_name)
+            scraped.extend(results)
+            stats.pages_crawled += 1
+
+        # 2. LinkedIn public profile
+        if profile.linkedinUrl:
+            visited_pages.add(_canonicalize_url(profile.linkedinUrl))
+            results = self._scrape_page_rich(
+                url=profile.linkedinUrl,
+                person_name=person_name,
+                platform="linkedin",
+            )
+            scraped.extend(results)
+            stats.pages_crawled += 1
+
+        # 3. Firm website (main + team/about subpages)
+        if profile.websiteUrl:
+            visited_pages.add(_canonicalize_url(profile.websiteUrl))
+            results, pages = self._scrape_firm_website(
+                website_url=profile.websiteUrl,
+                person_name=person_name,
+                firm_name=firm_name,
+                visited_pages=visited_pages,
+            )
+            scraped.extend(results)
+            stats.pages_crawled += pages
+
+        # 4. Twitter / X profile
+        if profile.twitterUrl:
+            visited_pages.add(_canonicalize_url(profile.twitterUrl))
+            results = self._scrape_page_rich(
+                url=profile.twitterUrl,
+                person_name=person_name,
+                platform="twitter",
+            )
+            scraped.extend(results)
+            stats.pages_crawled += 1
+
+        # 5. Crawl model-discovered source pages
+        for candidate in upstream_candidates or []:
+            source_page_url = _normalize_url(candidate.sourcePageUrl)
+            if not source_page_url:
+                continue
+
+            page_key = _canonicalize_url(source_page_url)
+            if page_key in visited_pages:
+                continue
+            visited_pages.add(page_key)
+
+            platform = _normalize_platform(candidate.platform, source_page_url)
+            if platform == "website" and _looks_like_homepage(source_page_url):
+                results, pages = self._scrape_firm_website(
+                    website_url=source_page_url,
+                    person_name=person_name,
+                    firm_name=firm_name,
+                    visited_pages=visited_pages,
+                )
+                scraped.extend(results)
+                stats.pages_crawled += pages
+            else:
+                results = self._scrape_page_rich(
+                    url=source_page_url,
+                    person_name=person_name,
+                    platform=platform,
+                )
+                scraped.extend(results)
+                stats.pages_crawled += 1
+
+        # 6. Crawl relevant grounded source URLs from upstream dossier search results
+        all_grounded = grounded_source_urls or []
+        stats.grounded_source_urls_received = len(all_grounded)
+        relevant_urls = _filter_relevant_source_urls(
+            all_grounded, person_name, firm_name, profile.otherNames,
+        )
+        stats.grounded_source_urls_relevant = len(relevant_urls)
+
+        grounded_crawled = 0
+        for grounded_url in relevant_urls:
+            if grounded_crawled >= MAX_GROUNDED_PAGES:
+                break
+            page_key = _canonicalize_url(grounded_url)
+            if page_key in visited_pages:
+                continue
+            visited_pages.add(page_key)
+
+            platform = _infer_platform_from_url(grounded_url)
+            results = self._scrape_page_rich(
+                url=grounded_url,
+                person_name=person_name,
+                platform=platform,
+            )
+            scraped.extend(results)
+            stats.pages_crawled += 1
+            grounded_crawled += 1
+
+        stats.images_extracted = len(scraped)
+
+        # Convert scraped candidates to ImageCandidate objects
+        image_candidates = _scraped_to_model_candidates(scraped)
+
+        # Merge with direct model candidates (scraped get priority)
+        if upstream_candidates:
+            seen_urls = {c.imageUrl for c in image_candidates if c.imageUrl}
+            for candidate in upstream_candidates:
+                direct_url = _normalize_url(candidate.imageUrl)
+                if direct_url and direct_url not in seen_urls:
+                    image_candidates.append(
+                        candidate.model_copy(update={"imageUrl": direct_url})
+                    )
+                    seen_urls.add(direct_url)
+
+        final = image_candidates[:MAX_TOTAL_CANDIDATES]
+
+        # Determine selected class and null reason for observability
+        if final:
+            top = final[0]
+            if top.candidateType == "headshot":
+                stats.selected_class = f"{top.platform or 'website'}_headshot"
+            else:
+                stats.selected_class = f"{top.platform or 'website'}_logo"
+        else:
+            stats.null_reason = (
+                "only_tiny_assets" if scraped else "no_relevant_page"
+            )
+
+        logger.info(
+            "Image scraper completed for profile=%s "
+            "grounded_received=%d grounded_relevant=%d "
+            "pages_crawled=%d images_extracted=%d "
+            "candidates_returned=%d selected_class=%s null_reason=%s",
+            person_name,
+            stats.grounded_source_urls_received,
+            stats.grounded_source_urls_relevant,
+            stats.pages_crawled,
+            stats.images_extracted,
+            len(final),
+            stats.selected_class,
+            stats.null_reason,
+        )
+
+        return final
+
+    # ------------------------------------------------------------------
+    # Page scraping methods
+    # ------------------------------------------------------------------
+
+    def _scrape_finra_brokercheck(
+        self,
+        crd_number: str,
+        person_name: str,
+    ) -> list[ScrapedCandidate]:
+        """Scrape FINRA BrokerCheck individual summary page."""
+        url = f"https://brokercheck.finra.org/individual/summary/{crd_number}"
+        candidates: list[ScrapedCandidate] = []
+
+        try:
+            html = self._fetch_html(url)
+            if not html:
+                return candidates
+
+            soup = BeautifulSoup(html, "lxml")
+            candidates = self._extract_all_images(soup, url, "finra", person_name)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.info("FINRA BrokerCheck scrape failed for CRD=%s: %s", crd_number, exc)
+
+        return candidates[:MAX_CANDIDATES_PER_SOURCE]
+
+    def _scrape_page_rich(
+        self,
+        url: str,
+        person_name: str,
+        platform: str,
+    ) -> list[ScrapedCandidate]:
+        """Scrape a page using all extraction methods."""
+        candidates: list[ScrapedCandidate] = []
+
+        try:
+            html = self._fetch_html(url)
+            if not html:
+                return candidates
+
+            soup = BeautifulSoup(html, "lxml")
+            candidates = self._extract_all_images(soup, url, platform, person_name)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.info("Page scrape failed for url=%s: %s", url, exc)
+
+        return candidates[:MAX_CANDIDATES_PER_SOURCE]
+
+    def _scrape_firm_website(
+        self,
+        website_url: str,
+        person_name: str,
+        firm_name: str,
+        visited_pages: set[str] | None = None,
+    ) -> tuple[list[ScrapedCandidate], int]:
+        """Scrape firm website: main page for logo, then team/about pages for headshots.
+
+        Returns (candidates, pages_crawled).
+        """
+        candidates: list[ScrapedCandidate] = []
+        pages_crawled = 0
+
+        try:
+            html = self._fetch_html(website_url)
+            if not html:
+                return candidates, pages_crawled
+
+            pages_crawled += 1
+            soup = BeautifulSoup(html, "lxml")
+
+            # Extract logo from main page (skip tiny favicons, find real logos)
+            logo = _extract_best_logo(soup, website_url, firm_name)
+            if logo:
+                candidates.append(logo)
+
+            # Find team/about page links
+            team_urls = _find_team_page_links(soup, website_url)
+
+            if team_urls:
+                for team_url in team_urls[:2]:
+                    if visited_pages and _canonicalize_url(team_url) in visited_pages:
+                        continue
+                    if visited_pages is not None:
+                        visited_pages.add(_canonicalize_url(team_url))
+
+                    team_candidates = self._scrape_page_rich(
+                        url=team_url,
+                        person_name=person_name,
+                        platform="website",
+                    )
+                    candidates.extend(team_candidates)
+                    pages_crawled += 1
+            else:
+                # Try headshots on the main page itself
+                main_candidates = self._extract_all_images(
+                    soup, website_url, "website", person_name,
+                )
+                candidates.extend(main_candidates)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.info("Firm website scrape failed for url=%s: %s", website_url, exc)
+
+        return candidates[:MAX_CANDIDATES_PER_SOURCE], pages_crawled
+
+    def _fetch_html(self, url: str) -> str | None:
+        """Fetch HTML content from a URL. Returns None on failure."""
+        if not _is_https_url(url):
+            return None
+        try:
+            response = self._client.get(url)
+            response.raise_for_status()
+            content_type = (response.headers.get("content-type") or "").lower()
+            if "text/html" not in content_type and "application/xhtml" not in content_type:
+                return None
+            return response.text
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to fetch HTML from %s: %s", url, exc)
+            return None
+
+    # ------------------------------------------------------------------
+    # Rich image extraction (all methods combined)
+    # ------------------------------------------------------------------
+
+    def _extract_all_images(
+        self,
+        soup: BeautifulSoup,
+        page_url: str,
+        platform: str,
+        person_name: str,
+    ) -> list[ScrapedCandidate]:
+        """Extract images using ALL available methods:
+        1. og:image meta
+        2. twitter:image meta
+        3. JSON-LD image
+        4. Platform CDN patterns
+        5. <picture><source> tags
+        6. <img> with srcset (choose largest)
+        7. <img> with data-src / data-lazy-src
+        8. Standard <img src>
+        9. CSS background-image
+        """
+        candidates: list[ScrapedCandidate] = []
+        seen_urls: set[str] = set()
+
+        def _add(c: ScrapedCandidate | None) -> None:
+            if c and c.image_url not in seen_urls:
+                candidates.append(c)
+                seen_urls.add(c.image_url)
+
+        def _add_list(cs: list[ScrapedCandidate]) -> None:
+            for c in cs:
+                _add(c)
+
+        # 1. og:image
+        _add(_extract_og_image(soup, page_url, platform, person_name))
+
+        # 2. twitter:image
+        _add(_extract_twitter_image(soup, page_url, platform, person_name))
+
+        # 3. JSON-LD image
+        _add_list(_extract_json_ld_images(soup, page_url, platform, person_name))
+
+        # 4. Platform CDN patterns
+        _add_list(_extract_cdn_images(soup, page_url, platform, person_name))
+
+        # 5. <picture><source> tags
+        _add_list(_extract_picture_sources(soup, page_url, platform, person_name))
+
+        # 6-8. <img> tags (srcset, data-src, standard src)
+        for img in soup.find_all("img"):
+            img_urls = _resolve_img_urls(img, page_url)
+            for img_url in img_urls:
+                if img_url in seen_urls:
+                    continue
+                if _is_excluded_image(img_url):
+                    continue
+                if _is_tiny_asset(img_url):
+                    continue
+
+                alt = (img.get("alt") or "").lower()
+                score = _score_image_for_person(img, img_url, alt, person_name)
+
+                if score >= 60:
+                    _add(ScrapedCandidate(
+                        image_url=img_url,
+                        source_page_url=page_url,
+                        platform=platform,
+                        candidate_type="headshot",
+                        confidence=min(score, 96),
+                        reason=f"Image on {platform} page (score={score})",
+                    ))
+
+        # 9. CSS background-image
+        _add_list(_extract_css_background_images(soup, page_url, platform, person_name))
+
+        return candidates
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_og_image(
+    soup: BeautifulSoup,
+    page_url: str,
+    platform: str,
+    person_name: str,
+) -> ScrapedCandidate | None:
+    """Extract og:image meta tag as a candidate."""
+    og_tag = soup.find("meta", property="og:image")
+    if not og_tag or not isinstance(og_tag, Tag):
+        return None
+
+    og_url = (og_tag.get("content") or "").strip()
+    if not og_url:
+        return None
+
+    og_url = urljoin(page_url, og_url)
+    if not _is_https_url(og_url):
+        return None
+    if _is_excluded_image(og_url) or _is_tiny_asset(og_url):
+        return None
+
+    confidence = 92 if platform == "linkedin" else 80
+    candidate_type = "headshot"
+
+    if "logo" in og_url.lower():
+        candidate_type = "logo"
+        confidence = 75
+
+    return ScrapedCandidate(
+        image_url=og_url,
+        source_page_url=page_url,
+        platform=platform,
+        candidate_type=candidate_type,
+        confidence=confidence,
+        reason=f"og:image from {platform} page",
+    )
+
+
+def _extract_twitter_image(
+    soup: BeautifulSoup,
+    page_url: str,
+    platform: str,
+    person_name: str,
+) -> ScrapedCandidate | None:
+    """Extract twitter:image meta tag as a candidate."""
+    # Try both name= and property= variants
+    tw_tag = soup.find("meta", attrs={"name": "twitter:image"})
+    if not tw_tag or not isinstance(tw_tag, Tag):
+        tw_tag = soup.find("meta", property="twitter:image")
+    if not tw_tag or not isinstance(tw_tag, Tag):
+        return None
+
+    tw_url = (tw_tag.get("content") or "").strip()
+    if not tw_url:
+        return None
+
+    tw_url = urljoin(page_url, tw_url)
+    if not _is_https_url(tw_url):
+        return None
+    if _is_excluded_image(tw_url) or _is_tiny_asset(tw_url):
+        return None
+
+    candidate_type = "logo" if "logo" in tw_url.lower() else "headshot"
+    confidence = 78
+
+    return ScrapedCandidate(
+        image_url=tw_url,
+        source_page_url=page_url,
+        platform=platform,
+        candidate_type=candidate_type,
+        confidence=confidence,
+        reason=f"twitter:image from {platform} page",
+    )
+
+
+def _extract_json_ld_images(
+    soup: BeautifulSoup,
+    page_url: str,
+    platform: str,
+    person_name: str,
+) -> list[ScrapedCandidate]:
+    """Extract image field from JSON-LD <script type="application/ld+json"> blocks."""
+    candidates: list[ScrapedCandidate] = []
+
+    for script_tag in soup.find_all("script", type="application/ld+json"):
+        text = script_tag.get_text(strip=True)
+        if not text:
+            continue
+        try:
+            data = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            continue
+
+        items = data if isinstance(data, list) else [data]
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            image_val = item.get("image")
+            if not image_val:
+                continue
+
+            # image can be a string URL or an object with .url
+            urls: list[str] = []
+            if isinstance(image_val, str):
+                urls.append(image_val)
+            elif isinstance(image_val, dict):
+                url_val = image_val.get("url") or image_val.get("contentUrl")
+                if isinstance(url_val, str):
+                    urls.append(url_val)
+            elif isinstance(image_val, list):
+                for entry in image_val:
+                    if isinstance(entry, str):
+                        urls.append(entry)
+                    elif isinstance(entry, dict):
+                        url_val = entry.get("url") or entry.get("contentUrl")
+                        if isinstance(url_val, str):
+                            urls.append(url_val)
+
+            for raw_url in urls:
+                abs_url = urljoin(page_url, raw_url.strip())
+                if not _is_https_url(abs_url):
+                    continue
+                if _is_excluded_image(abs_url) or _is_tiny_asset(abs_url):
+                    continue
+
+                # Determine type from JSON-LD @type
+                ld_type = (item.get("@type") or "").lower()
+                candidate_type = "headshot" if ld_type in {"person", "profilepage"} else "logo"
+                confidence = 82 if candidate_type == "headshot" else 74
+
+                candidates.append(ScrapedCandidate(
+                    image_url=abs_url,
+                    source_page_url=page_url,
+                    platform=platform,
+                    candidate_type=candidate_type,
+                    confidence=confidence,
+                    reason=f"JSON-LD image (@type={ld_type or 'unknown'})",
+                ))
+
+    return candidates
+
+
+def _extract_cdn_images(
+    soup: BeautifulSoup,
+    page_url: str,
+    platform: str,
+    person_name: str,
+) -> list[ScrapedCandidate]:
+    """Extract images from known CDN patterns (LinkedIn, Twitter)."""
+    candidates: list[ScrapedCandidate] = []
+
+    for img in soup.find_all("img"):
+        img_urls = _resolve_img_urls(img, page_url)
+        for img_url in img_urls:
+            parsed = urlparse(img_url)
+            domain = (parsed.netloc or "").lower()
+
+            if platform == "linkedin" and any(p in domain for p in LINKEDIN_IMAGE_PATTERNS):
+                if _is_excluded_image(img_url):
+                    continue
+                candidates.append(ScrapedCandidate(
+                    image_url=img_url,
+                    source_page_url=page_url,
+                    platform="linkedin",
+                    candidate_type="headshot",
+                    confidence=95,
+                    reason="LinkedIn CDN profile image",
+                ))
+
+            if platform in {"twitter", "x"} and any(p in img_url for p in TWITTER_IMAGE_PATTERNS):
+                candidates.append(ScrapedCandidate(
+                    image_url=img_url,
+                    source_page_url=page_url,
+                    platform="twitter",
+                    candidate_type="headshot",
+                    confidence=93,
+                    reason="Twitter/X CDN profile image",
+                ))
+
+    return candidates
+
+
+def _extract_picture_sources(
+    soup: BeautifulSoup,
+    page_url: str,
+    platform: str,
+    person_name: str,
+) -> list[ScrapedCandidate]:
+    """Extract images from <picture><source> elements."""
+    candidates: list[ScrapedCandidate] = []
+
+    for picture in soup.find_all("picture"):
+        best_url = None
+        best_width = 0
+
+        # Check <source> children
+        for source in picture.find_all("source"):
+            srcset = (source.get("srcset") or "").strip()
+            if not srcset:
+                continue
+            url, width = _parse_srcset_largest(srcset, page_url)
+            if url and width > best_width:
+                best_url = url
+                best_width = width
+
+        # Fallback to <img> inside <picture>
+        if not best_url:
+            img = picture.find("img")
+            if img and isinstance(img, Tag):
+                urls = _resolve_img_urls(img, page_url)
+                if urls:
+                    best_url = urls[0]
+
+        if not best_url or not _is_https_url(best_url):
+            continue
+        if _is_excluded_image(best_url) or _is_tiny_asset(best_url):
+            continue
+
+        alt = ""
+        img_tag = picture.find("img")
+        if img_tag and isinstance(img_tag, Tag):
+            alt = (img_tag.get("alt") or "").lower()
+
+        score = _score_image_for_person(img_tag or picture, best_url, alt, person_name)
+        if score >= 55:
+            candidates.append(ScrapedCandidate(
+                image_url=best_url,
+                source_page_url=page_url,
+                platform=platform,
+                candidate_type="headshot",
+                confidence=min(score, 94),
+                reason=f"<picture><source> image (score={score})",
+            ))
+
+    return candidates
+
+
+def _extract_css_background_images(
+    soup: BeautifulSoup,
+    page_url: str,
+    platform: str,
+    person_name: str,
+) -> list[ScrapedCandidate]:
+    """Extract images from inline CSS background-image on divs/sections."""
+    candidates: list[ScrapedCandidate] = []
+
+    for element in soup.find_all(style=True):
+        style = element.get("style") or ""
+        match = CSS_BG_IMAGE_RE.search(style)
+        if not match:
+            continue
+
+        bg_url = urljoin(page_url, match.group(1).strip())
+        if not _is_https_url(bg_url):
+            continue
+        if _is_excluded_image(bg_url) or _is_tiny_asset(bg_url):
+            continue
+
+        # Check nearby text for person name
+        nearby_text = (element.get_text() or "").lower()
+        name_lower = person_name.lower().strip()
+        name_parts = [p for p in name_lower.split() if len(p) > 2]
+
+        confidence = 65
+        candidate_type = "headshot"
+
+        if name_lower and name_lower in nearby_text:
+            confidence = 85
+        elif name_parts and any(part in nearby_text for part in name_parts):
+            confidence = 78
+
+        # Check classes/id for headshot signals
+        cls = " ".join(element.get("class", []) if isinstance(element.get("class"), list) else [])
+        el_id = element.get("id") or ""
+        attrs_text = f"{cls} {el_id} {bg_url}".lower()
+        if any(kw in attrs_text for kw in HEADSHOT_INDICATORS):
+            confidence = max(confidence, 75)
+
+        if "logo" in attrs_text:
+            candidate_type = "logo"
+            confidence = min(confidence, 72)
+
+        if confidence >= 65:
+            candidates.append(ScrapedCandidate(
+                image_url=bg_url,
+                source_page_url=page_url,
+                platform=platform,
+                candidate_type=candidate_type,
+                confidence=confidence,
+                reason=f"CSS background-image (confidence={confidence})",
+            ))
+
+    return candidates
+
+
+def _extract_best_logo(
+    soup: BeautifulSoup,
+    page_url: str,
+    firm_name: str,
+) -> ScrapedCandidate | None:
+    """Extract the best firm logo, skipping tiny favicons.
+
+    Prefers: large logo images > apple-touch-icon > standard logo img.
+    Rejects: favicon.ico, 16x16, 32x32, icon fonts.
+    """
+    logo_candidates: list[tuple[str, int, str]] = []  # (url, score, reason)
+
+    # 1. Look for <img> with "logo" in class/id/alt/src
+    for img in soup.find_all("img"):
+        img_urls = _resolve_img_urls(img, page_url)
+        if not img_urls:
+            continue
+        img_url = img_urls[0]
+
+        attrs_text = " ".join([
+            (img.get("alt") or ""),
+            " ".join(img.get("class", [])) if isinstance(img.get("class"), list) else (img.get("class") or ""),
+            (img.get("id") or ""),
+            img_url,
+        ]).lower()
+
+        if "logo" not in attrs_text:
+            continue
+        if _is_tiny_asset(img_url):
+            continue
+
+        # Score: larger declared dimensions = better logo
+        width = _parse_dimension(img.get("width"))
+        height = _parse_dimension(img.get("height"))
+        size_score = 0
+        if width and height:
+            size_score = min(width, height)
+        elif width:
+            size_score = width
+        elif height:
+            size_score = height
+
+        logo_candidates.append((img_url, 88 + min(size_score // 50, 5), "Logo <img> tag"))
+
+    # 2. Check for apple-touch-icon (usually 180x180+)
+    for link_tag in soup.find_all("link"):
+        rel = " ".join(link_tag.get("rel", []))
+        href = (link_tag.get("href") or "").strip()
+        if not href:
+            continue
+        abs_url = urljoin(page_url, href)
+        if not _is_https_url(abs_url):
+            continue
+
+        if "apple-touch-icon" in rel:
+            if not _is_tiny_asset(abs_url):
+                # Parse sizes attribute if available (e.g. sizes="180x180")
+                sizes = (link_tag.get("sizes") or "").lower()
+                size_val = 180  # default for apple-touch-icon
+                if "x" in sizes:
+                    try:
+                        size_val = int(sizes.split("x")[0])
+                    except (ValueError, IndexError):
+                        pass
+                logo_candidates.append((abs_url, 82 + min(size_val // 50, 5), "apple-touch-icon"))
+
+    # 3. Pick the highest-scoring non-tiny logo
+    if not logo_candidates:
+        return None
+
+    logo_candidates.sort(key=lambda t: -t[1])
+    best_url, best_score, best_reason = logo_candidates[0]
+
+    return ScrapedCandidate(
+        image_url=best_url,
+        source_page_url=page_url,
+        platform="website",
+        candidate_type="logo",
+        confidence=best_score,
+        reason=best_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# URL resolution helpers (srcset, data-src, standard src)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_img_urls(img: Tag, base_url: str) -> list[str]:
+    """Resolve all available image URLs from an <img> tag.
+
+    Priority: srcset (largest) > data-src/data-lazy-src > src.
+    Returns deduplicated list of valid HTTPS URLs.
+    """
+    urls: list[str] = []
+    seen: set[str] = set()
+
+    def _add(url: str | None) -> None:
+        if url and url not in seen and _is_https_url(url):
+            urls.append(url)
+            seen.add(url)
+
+    # 1. srcset — choose largest
+    srcset = (img.get("srcset") or "").strip()
+    if srcset:
+        largest_url, _ = _parse_srcset_largest(srcset, base_url)
+        _add(largest_url)
+
+    # 2. data-srcset (lazy-loaded srcset)
+    data_srcset = (img.get("data-srcset") or "").strip()
+    if data_srcset:
+        largest_url, _ = _parse_srcset_largest(data_srcset, base_url)
+        _add(largest_url)
+
+    # 3. data-src / data-lazy-src (lazy loading)
+    for attr in ("data-src", "data-lazy-src"):
+        val = (img.get(attr) or "").strip()
+        if val:
+            _add(urljoin(base_url, val))
+
+    # 4. Standard src
+    src = (img.get("src") or "").strip()
+    if src and not src.startswith("data:"):
+        _add(urljoin(base_url, src))
+
+    return urls
+
+
+def _parse_srcset_largest(srcset: str, base_url: str) -> tuple[str | None, int]:
+    """Parse a srcset attribute and return (url, width) of the largest entry.
+
+    Supports: "img.jpg 400w, img-large.jpg 1200w" and "img.jpg 1x, img@2x.jpg 2x".
+    """
+    entries = SRCSET_ENTRY_RE.findall(srcset)
+    if entries:
+        # [(url, size_str), ...] — pick largest
+        best_url = None
+        best_size = 0
+        for url_part, size_str in entries:
+            try:
+                size = int(size_str)
+            except ValueError:
+                continue
+            if size > best_size:
+                best_size = size
+                best_url = urljoin(base_url, url_part.strip())
+        return best_url, best_size
+
+    # Fallback: no size descriptors, take the first non-empty entry
+    parts = [p.strip().split()[0] for p in srcset.split(",") if p.strip()]
+    if parts:
+        return urljoin(base_url, parts[0]), 0
+
+    return None, 0
+
+
+# ---------------------------------------------------------------------------
+# Grounded source URL filtering
+# ---------------------------------------------------------------------------
+
+
+def _filter_relevant_source_urls(
+    urls: list[str],
+    person_name: str,
+    firm_name: str,
+    other_names: list[str] | None,
+) -> list[str]:
+    """Filter grounded source URLs to only keep likely-relevant pages.
+
+    Relevance heuristics:
+    - URL path contains person name parts or firm name parts
+    - URL path contains team/about/leadership keywords
+    - Domain is not an irrelevant generic site
+    """
+    name_lower = person_name.lower().strip()
+    firm_lower = firm_name.lower().strip()
+    name_parts = [p for p in name_lower.split() if len(p) > 2]
+    firm_parts = [p for p in firm_lower.split() if len(p) > 3]
+
+    # Include aliases
+    alias_parts: list[str] = []
+    for alias in other_names or []:
+        alias_parts.extend(p.lower() for p in alias.split() if len(p) > 2)
+
+    all_name_parts = list(set(name_parts + alias_parts))
+
+    relevant: list[str] = []
+    seen: set[str] = set()
+
+    for url in urls:
+        if not isinstance(url, str) or not _is_https_url(url):
+            continue
+
+        canonical = _canonicalize_url(url)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+
+        parsed = urlparse(url)
+        domain = (parsed.netloc or "").lower()
+        path = (parsed.path or "").lower()
+        full = f"{domain}{path}"
+
+        # Skip irrelevant domains
+        if any(d in domain for d in IRRELEVANT_DOMAIN_PATTERNS):
+            continue
+
+        # Score relevance
+        is_relevant = False
+
+        # Person name in URL
+        if all_name_parts and any(part in full for part in all_name_parts):
+            is_relevant = True
+
+        # Firm name in URL
+        if firm_parts and any(part in full for part in firm_parts):
+            is_relevant = True
+
+        # Team/about/leadership keywords in path
+        if any(kw in path for kw in TEAM_PAGE_SEGMENTS):
+            is_relevant = True
+
+        # FINRA/SEC regulatory pages
+        if "finra.org" in domain or "sec.gov" in domain or "brokercheck" in full:
+            is_relevant = True
+
+        # LinkedIn profiles
+        if "linkedin.com" in domain and "/in/" in path:
+            is_relevant = True
+
+        if is_relevant:
+            relevant.append(url)
+
+    return relevant
+
+
+# ---------------------------------------------------------------------------
+# Scoring and helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_team_page_links(soup: BeautifulSoup, base_url: str) -> list[str]:
+    """Find links to team/about pages from the navigation. Returns up to 3."""
+    found: list[str] = []
+    seen: set[str] = set()
+
+    for a_tag in soup.find_all("a", href=True):
+        href = (a_tag.get("href") or "").strip()
+        if not href or href == "#":
+            continue
+
+        link_text = (a_tag.get_text() or "").strip().lower()
+        href_lower = href.lower()
+
+        for segment in TEAM_PAGE_SEGMENTS:
+            if segment in link_text or segment in href_lower:
+                full_url = urljoin(base_url, href)
+                if _is_https_url(full_url):
+                    key = _canonicalize_url(full_url)
+                    if key not in seen:
+                        found.append(full_url)
+                        seen.add(key)
+                break
+
+        if len(found) >= 3:
+            break
+
+    return found
+
+
+def _normalize_url(url: str | None) -> str | None:
+    if not isinstance(url, str):
+        return None
+    normalized = url.strip()
+    if not normalized or not _is_https_url(normalized):
+        return None
+    return normalized
+
+
+def _normalize_platform(platform: str | None, source_page_url: str) -> str:
+    normalized = (platform or "").strip().lower()
+    if normalized in {"linkedin", "twitter", "x", "website", "news", "other"}:
+        return "twitter" if normalized == "x" else normalized
+    return _infer_platform_from_url(source_page_url)
+
+
+def _infer_platform_from_url(url: str) -> str:
+    url_lower = url.lower()
+    if "linkedin.com" in url_lower or "licdn.com" in url_lower:
+        return "linkedin"
+    if "twitter.com" in url_lower or "x.com" in url_lower or "twimg.com" in url_lower:
+        return "twitter"
+    if "finra.org" in url_lower or "brokercheck" in url_lower:
+        return "finra"
+    return "website"
+
+
+def _canonicalize_url(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _looks_like_homepage(url: str) -> bool:
+    parsed = urlparse(url)
+    path = (parsed.path or "").strip("/")
+    return not path
+
+
+def _score_image_for_person(
+    element: Tag | None,
+    img_url: str,
+    alt_text: str,
+    person_name: str,
+) -> int:
+    """Score an image on how likely it is a person's headshot. Returns 0-100."""
+    score = 40  # base score
+
+    name_lower = person_name.lower().strip()
+    name_parts = [p for p in name_lower.split() if len(p) > 2]
+    url_lower = img_url.lower()
+
+    # Name match in alt text (strong signal)
+    if name_lower and name_lower in alt_text:
+        score += 30
+    elif name_parts and any(part in alt_text for part in name_parts):
+        score += 20
+
+    # Name match in URL
+    if name_parts and any(part in url_lower for part in name_parts):
+        score += 10
+
+    # Headshot keywords in URL or alt
+    combined = f"{url_lower} {alt_text}"
+    if any(kw in combined for kw in HEADSHOT_INDICATORS):
+        score += 10
+
+    # Parent element contains person name
+    if element is not None:
+        parent = element.parent if hasattr(element, "parent") else None
+        if parent and name_parts:
+            parent_text = (parent.get_text() or "").lower()
+            if any(part in parent_text for part in name_parts):
+                score += 15
+
+        # Image dimensions from attributes
+        width = _parse_dimension(element.get("width") if hasattr(element, "get") else None)
+        height = _parse_dimension(element.get("height") if hasattr(element, "get") else None)
+        if width and height:
+            if width >= 150 and height >= 150:
+                score += 5
+            ratio = max(width, height) / max(min(width, height), 1)
+            if ratio <= 1.5:
+                score += 5
+
+    return min(score, 100)
+
+
+def _is_excluded_image(url: str) -> bool:
+    """Check if a URL matches common non-person image patterns."""
+    url_lower = url.lower()
+    return any(pattern in url_lower for pattern in EXCLUDE_PATTERNS)
+
+
+def _is_tiny_asset(url: str) -> bool:
+    """Check if a URL is likely a tiny favicon/icon that should be skipped."""
+    url_lower = url.lower()
+    return any(pattern in url_lower for pattern in TINY_ASSET_PATTERNS)
+
+
+def _is_https_url(value: str) -> bool:
+    """Check if a string is a valid HTTPS URL."""
+    try:
+        parsed = urlparse(value)
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def _parse_dimension(value: object) -> int | None:
+    """Parse a width/height attribute to an integer."""
+    if value is None:
+        return None
+    try:
+        return int(str(value).replace("px", "").strip())
+    except (ValueError, TypeError):
+        return None
+
+
+def _scraped_to_model_candidates(
+    scraped: list[ScrapedCandidate],
+) -> list[ImageCandidate]:
+    """Convert ScrapedCandidate objects to ImageCandidate model objects.
+
+    Deduplicates by image URL, keeping highest confidence. Sorts descending.
+    """
+    best: dict[str, ScrapedCandidate] = {}
+    for sc in scraped:
+        existing = best.get(sc.image_url)
+        if existing is None or sc.confidence > existing.confidence:
+            best[sc.image_url] = sc
+
+    sorted_candidates = sorted(best.values(), key=lambda c: -c.confidence)
+
+    return [
+        ImageCandidate(
+            imageUrl=sc.image_url,
+            sourcePageUrl=sc.source_page_url,
+            platform=sc.platform,
+            candidateType=sc.candidate_type,
+            confidence=sc.confidence,
+        )
+        for sc in sorted_candidates
+    ]

--- a/cloud-run/ria-intelligence-api/app/main.py
+++ b/cloud-run/ria-intelligence-api/app/main.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+import logging
+import os
+from threading import Lock
+from time import perf_counter
+
+from fastapi import FastAPI, HTTPException, Request
+
+from .models import HealthResponse, PublicProfileDossier
+from .service import (
+    DEFAULT_RIA_FALLBACK_MODEL,
+    DEFAULT_RIA_PRIMARY_MODEL,
+    InvalidQueryError,
+    RIAIntelligenceService,
+    RIAUpstreamError,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def create_app(service: RIAIntelligenceService | None = None) -> FastAPI:
+    configured_primary = service.primary_model if service else os.getenv("RIA_PRIMARY_MODEL", DEFAULT_RIA_PRIMARY_MODEL)
+    configured_fallback = service.fallback_model if service else os.getenv("RIA_FALLBACK_MODEL", DEFAULT_RIA_FALLBACK_MODEL)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.service_ready = False
+        app.state.startup_init_ms = None
+        app.state.instance_first_request_pending = True
+        app.state.instance_first_request_lock = Lock()
+
+        startup_started_at = perf_counter()
+        try:
+            initialized_service = service or RIAIntelligenceService()
+            startup_init_ms = round((perf_counter() - startup_started_at) * 1000, 2)
+            app.state.ria_service = initialized_service
+            app.state.service_ready = True
+            app.state.startup_init_ms = startup_init_ms
+            logger.info(
+                "RIA service startup complete service=%s primary_model=%s fallback_model=%s startup_init_ms=%.2f service_initialized=true",
+                "hushh-ria-intelligence-api",
+                initialized_service.primary_model,
+                initialized_service.fallback_model,
+                startup_init_ms,
+            )
+            yield
+        except Exception:  # noqa: BLE001 - startup failure should fail the instance
+            startup_init_ms = round((perf_counter() - startup_started_at) * 1000, 2)
+            logger.exception(
+                "RIA service startup failed service=%s primary_model=%s fallback_model=%s startup_init_ms=%.2f service_initialized=false",
+                "hushh-ria-intelligence-api",
+                configured_primary,
+                configured_fallback,
+                startup_init_ms,
+            )
+            raise
+        finally:
+            app.state.service_ready = False
+
+    app = FastAPI(
+        title="Hushh RIA Intelligence API",
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+
+    @app.middleware("http")
+    async def log_request_lifecycle(request: Request, call_next):
+        request_started_at = perf_counter()
+        with request.app.state.instance_first_request_lock:
+            instance_first_request = request.app.state.instance_first_request_pending
+            if request.app.state.instance_first_request_pending:
+                request.app.state.instance_first_request_pending = False
+
+        try:
+            response = await call_next(request)
+        except Exception:  # noqa: BLE001 - preserve framework error handling
+            duration_ms = round((perf_counter() - request_started_at) * 1000, 2)
+            logger.exception(
+                "Request failed method=%s path=%s duration_ms=%.2f instance_first_request=%s",
+                request.method,
+                request.url.path,
+                duration_ms,
+                instance_first_request,
+            )
+            raise
+
+        duration_ms = round((perf_counter() - request_started_at) * 1000, 2)
+        logger.info(
+            "Request completed method=%s path=%s status_code=%s duration_ms=%.2f instance_first_request=%s",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration_ms,
+            instance_first_request,
+        )
+        return response
+
+    @app.get("/")
+    async def root() -> dict[str, str]:
+        return {
+            "service": "hushh-ria-intelligence-api",
+            "status": "ok",
+        }
+
+    # Cloud Run can conflict with some `*z` URL paths, so `/health` is the
+    # stable public health endpoint and `/healthz` stays as a compatibility alias.
+    @app.get("/health", response_model=HealthResponse)
+    @app.get("/health/", response_model=HealthResponse, include_in_schema=False)
+    @app.get("/healthz", response_model=HealthResponse, include_in_schema=False)
+    @app.get("/healthz/", response_model=HealthResponse, include_in_schema=False)
+    async def health(request: Request) -> HealthResponse:
+        ria_service = _require_service(request)
+        return HealthResponse(
+            status="ok",
+            service="hushh-ria-intelligence-api",
+            primaryModel=ria_service.primary_model,
+            fallbackModel=ria_service.fallback_model,
+        )
+
+    @app.post("/v1/ria/profile", response_model=PublicProfileDossier)
+    def generate_ria_profile(payload: dict, request: Request) -> PublicProfileDossier:
+        try:
+            return _require_service(request).get_ria_profile(payload)
+        except InvalidQueryError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except RIAUpstreamError as exc:
+            logger.warning("Upstream Phase 1 failure: %s", exc)
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001 - convert to API-safe response
+            logger.exception("Unexpected error while generating RIA profile")
+            raise HTTPException(status_code=500, detail="Internal server error") from exc
+
+    return app
+
+
+def _require_service(request: Request) -> RIAIntelligenceService:
+    ria_service = getattr(request.app.state, "ria_service", None)
+    service_ready = bool(getattr(request.app.state, "service_ready", False))
+    if ria_service is None or not service_ready:
+        raise HTTPException(status_code=503, detail="Service is still initializing")
+    return ria_service
+
+
+app = create_app()

--- a/cloud-run/ria-intelligence-api/app/models.py
+++ b/cloud-run/ria-intelligence-api/app/models.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class DisclosureSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    total: int | None = None
+    regulatoryEvent: int | None = None
+    arbitration: int | None = None
+
+
+class DirectOwnerExecutiveOfficer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    position: str | None = None
+    crdNumber: str | None = None
+
+
+class PreviousFirm(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    crdNumber: str | None = None
+
+
+class ImageCandidate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    imageUrl: str | None = None
+    sourcePageUrl: str | None = None
+    platform: str | None = None
+    candidateType: Literal["headshot", "logo"] | None = None
+    confidence: int | None = None
+
+
+class SocialProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    platform: str
+    url: str
+
+    @field_validator("platform", "url")
+    @classmethod
+    def strip_required_value(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("social profile fields must not be blank")
+        return normalized
+
+
+class SeedProfileRequest(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    profile: "RIAProfile"
+
+
+class RIAProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    existsOnFinra: bool = False
+    imageUrl: str | None = None
+    crdNumber: str | None = None
+    secNumber: str | None = None
+    fullName: str | None = None
+    otherNames: list[str] | None = None
+    currentFirm: str | None = None
+    location: str | None = None
+    mainAddress: str | None = None
+    mailingAddress: str | None = None
+    phone: str | None = None
+    establishedIn: str | None = None
+    companyType: str | None = None
+    fiscalYearEnd: str | None = None
+    regulatedBy: str | None = None
+    yearsOfExperience: int | None = None
+    linkedinUrl: str | None = None
+    twitterUrl: str | None = None
+    facebookUrl: str | None = None
+    websiteUrl: str | None = None
+    bio: str | None = None
+    examsPassed: list[str] | None = None
+    stateLicenses: list[str] | None = None
+    otherRegistrations: list[str] | None = None
+    disclosures: DisclosureSummary | None = None
+    directOwnersAndExecutiveOfficers: list[DirectOwnerExecutiveOfficer] | None = None
+    previousFirms: list[PreviousFirm] | None = None
+    education: list[str] | None = None
+    languagesSpoken: list[str] | None = None
+    servicesOffered: list[str] | None = None
+    certifications: list[str] | None = None
+    aum: str | None = None
+    numberOfAccounts: int | None = None
+    numberOfEmployees: int | None = None
+    feeStructure: list[str] | None = None
+    accountMinimum: str | None = None
+    custodians: list[str] | None = None
+    investmentPhilosophy: str | None = None
+    clientTypes: list[str] | None = None
+    compensationArrangements: list[str] | None = None
+    affiliations: list[str] | None = None
+    awardsAndRecognitions: list[str] | None = None
+    specialties: list[str] | None = None
+    publicationsAndMedia: list[str] | None = None
+    reasonIfNotExists: str | None = None
+
+
+class GeminiEnrichment(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    linkedinUrl: str | None = None
+    twitterUrl: str | None = None
+    imageUrl: str | None = None
+    summary: str | None = None
+    fullBio: str | None = None
+    socialProfiles: list[SocialProfile] = Field(default_factory=list)
+
+    def to_profile_updates(self) -> dict[str, Any]:
+        updates: dict[str, Any] = {}
+        if self.linkedinUrl:
+            updates["linkedinUrl"] = self.linkedinUrl
+        if self.twitterUrl:
+            updates["twitterUrl"] = self.twitterUrl
+
+        lower_socials = {
+            profile.platform.strip().lower(): profile.url
+            for profile in self.socialProfiles
+            if profile.platform and profile.url
+        }
+        if "linkedin" in lower_socials and "linkedinUrl" not in updates:
+            updates["linkedinUrl"] = lower_socials["linkedin"]
+        if "twitter" in lower_socials and "twitterUrl" not in updates:
+            updates["twitterUrl"] = lower_socials["twitter"]
+        if "x" in lower_socials and "twitterUrl" not in updates:
+            updates["twitterUrl"] = lower_socials["x"]
+        if "facebook" in lower_socials:
+            updates["facebookUrl"] = lower_socials["facebook"]
+        return updates
+
+
+class ImageDiscoveryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    imageCandidates: list[ImageCandidate] = Field(default_factory=list)
+
+
+class GroundingSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    uri: str
+
+
+class PipelineStatus(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    finra: Literal["verified", "not_found", "failed"]
+    web: Literal["completed", "skipped", "failed"]
+
+
+class ModelUsage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    primary: str
+    used: str
+    fallbackUsed: bool
+
+
+class RIAProfileRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    query: str = Field(..., min_length=1)
+
+    @field_validator("query")
+    @classmethod
+    def strip_query(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("query must not be blank")
+        return normalized
+
+
+class RIAProfileResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool = True
+    profile: RIAProfile
+    enriched: GeminiEnrichment = Field(default_factory=GeminiEnrichment)
+    pipeline: PipelineStatus
+    model: ModelUsage
+    sources: list[GroundingSource] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class HealthResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"]
+    service: str
+    primaryModel: str
+    fallbackModel: str
+
+
+class DossierSubject(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    full_name: str
+    crd_number: str | None = None
+    current_firm: str | None = None
+    location: str | None = None
+
+
+class DossierVerifiedProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    platform: str
+    label: str
+    url: str
+    handle: str | None = None
+    source_title: str
+    source_url: str
+    evidence_note: str
+
+
+class DossierPublicImage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    image_url: str
+    source_page_url: str
+    source_title: str
+    confidence_note: str
+
+
+class DossierKeyFact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    fact: str
+    source_title: str
+    source_url: str
+    evidence_note: str
+
+
+class PublicProfileDossier(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    subject: DossierSubject
+    executive_summary: str
+    verified_profiles: list[DossierVerifiedProfile] = Field(default_factory=list)
+    public_images: list[DossierPublicImage] = Field(default_factory=list)
+    key_facts: list[DossierKeyFact] = Field(default_factory=list)
+    unverified_or_not_found: list[str] = Field(default_factory=list)
+    prompts_used: list[str] = Field(default_factory=list)
+
+
+class RankedImagesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    public_images: list[DossierPublicImage] = Field(default_factory=list)
+
+
+SeedProfileRequest.model_rebuild()
+
+
+def _scalar_schema(kind: str, *, nullable: bool = True) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": kind}
+    if nullable:
+        schema["nullable"] = True
+    return schema
+
+
+def _array_schema(items: dict[str, Any], *, nullable: bool = True) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "ARRAY",
+        "items": items,
+    }
+    if nullable:
+        schema["nullable"] = True
+    return schema
+
+
+def _object_schema(
+    properties: dict[str, Any],
+    *,
+    required: list[str] | None = None,
+    nullable: bool = True,
+) -> dict[str, Any]:
+    schema: dict[str, Any] = {
+        "type": "OBJECT",
+        "properties": properties,
+        "propertyOrdering": list(properties.keys()),
+    }
+    if required:
+        schema["required"] = required
+    if nullable:
+        schema["nullable"] = True
+    return schema
+
+
+def get_stage1_response_schema() -> dict[str, Any]:
+    disclosures = _object_schema(
+        {
+            "total": _scalar_schema("INTEGER"),
+            "regulatoryEvent": _scalar_schema("INTEGER"),
+            "arbitration": _scalar_schema("INTEGER"),
+        }
+    )
+    owner_officer = _object_schema(
+        {
+            "name": _scalar_schema("STRING"),
+            "position": _scalar_schema("STRING"),
+            "crdNumber": _scalar_schema("STRING"),
+        },
+        required=["name", "position", "crdNumber"],
+        nullable=False,
+    )
+    previous_firm = _object_schema(
+        {
+            "name": _scalar_schema("STRING"),
+            "crdNumber": _scalar_schema("STRING"),
+        },
+        required=["name", "crdNumber"],
+        nullable=False,
+    )
+
+    return _object_schema(
+        {
+            "existsOnFinra": _scalar_schema("BOOLEAN", nullable=False),
+            "crdNumber": _scalar_schema("STRING"),
+            "secNumber": _scalar_schema("STRING"),
+            "fullName": _scalar_schema("STRING"),
+            "otherNames": _array_schema(_scalar_schema("STRING", nullable=False)),
+            "currentFirm": _scalar_schema("STRING"),
+            "location": _scalar_schema("STRING"),
+            "mainAddress": _scalar_schema("STRING"),
+            "mailingAddress": _scalar_schema("STRING"),
+            "phone": _scalar_schema("STRING"),
+            "establishedIn": _scalar_schema("STRING"),
+            "companyType": _scalar_schema("STRING"),
+            "fiscalYearEnd": _scalar_schema("STRING"),
+            "regulatedBy": _scalar_schema("STRING"),
+            "yearsOfExperience": _scalar_schema("INTEGER"),
+            "examsPassed": _array_schema(_scalar_schema("STRING", nullable=False)),
+            "stateLicenses": _array_schema(_scalar_schema("STRING", nullable=False)),
+            "otherRegistrations": _array_schema(_scalar_schema("STRING", nullable=False)),
+            "disclosures": disclosures,
+            "directOwnersAndExecutiveOfficers": _array_schema(owner_officer),
+            "previousFirms": _array_schema(previous_firm),
+            "reasonIfNotExists": _scalar_schema("STRING"),
+        },
+        required=["existsOnFinra"],
+        nullable=False,
+    )
+
+
+def get_stage2_response_schema() -> dict[str, Any]:
+    social_profile = _object_schema(
+        {
+            "platform": _scalar_schema("STRING", nullable=False),
+            "url": _scalar_schema("STRING", nullable=False),
+        },
+        required=["platform", "url"],
+        nullable=False,
+    )
+    return _object_schema(
+        {
+            "linkedinUrl": _scalar_schema("STRING"),
+            "twitterUrl": _scalar_schema("STRING"),
+            "imageUrl": _scalar_schema("STRING"),
+            "summary": _scalar_schema("STRING"),
+            "fullBio": _scalar_schema("STRING"),
+            "socialProfiles": _array_schema(social_profile),
+        },
+        nullable=False,
+    )
+
+
+def get_dossier_response_schema() -> dict[str, Any]:
+    verified_profile = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "platform": {"type": "string"},
+            "label": {"type": "string"},
+            "url": {"type": "string"},
+            "handle": {"type": ["string", "null"]},
+            "source_title": {"type": "string"},
+            "source_url": {"type": "string"},
+            "evidence_note": {"type": "string"},
+        },
+        "required": [
+            "platform",
+            "label",
+            "url",
+            "handle",
+            "source_title",
+            "source_url",
+            "evidence_note",
+        ],
+    }
+    public_image = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "kind": {"type": "string"},
+            "image_url": {"type": "string"},
+            "source_page_url": {"type": "string"},
+            "source_title": {"type": "string"},
+            "confidence_note": {"type": "string"},
+        },
+        "required": [
+            "kind",
+            "image_url",
+            "source_page_url",
+            "source_title",
+            "confidence_note",
+        ],
+    }
+    key_fact = {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "fact": {"type": "string"},
+            "source_title": {"type": "string"},
+            "source_url": {"type": "string"},
+            "evidence_note": {"type": "string"},
+        },
+        "required": ["fact", "source_title", "source_url", "evidence_note"],
+    }
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "subject": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "full_name": {"type": "string"},
+                    "crd_number": {"type": ["string", "null"]},
+                    "current_firm": {"type": ["string", "null"]},
+                    "location": {"type": ["string", "null"]},
+                },
+                "required": ["full_name", "crd_number", "current_firm", "location"],
+            },
+            "executive_summary": {"type": "string"},
+            "verified_profiles": {"type": "array", "items": verified_profile},
+            "public_images": {"type": "array", "items": public_image},
+            "key_facts": {"type": "array", "items": key_fact},
+            "unverified_or_not_found": {"type": "array", "items": {"type": "string"}},
+            "prompts_used": {"type": "array", "items": {"type": "string"}},
+        },
+        "required": [
+            "subject",
+            "executive_summary",
+            "verified_profiles",
+            "public_images",
+            "key_facts",
+            "unverified_or_not_found",
+            "prompts_used",
+        ],
+    }
+
+
+def get_ranked_images_response_schema() -> dict[str, Any]:
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "public_images": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "image_url": {"type": "string"},
+                        "source_page_url": {"type": "string"},
+                        "source_title": {"type": "string"},
+                        "confidence_note": {"type": "string"},
+                    },
+                    "required": [
+                        "kind",
+                        "image_url",
+                        "source_page_url",
+                        "source_title",
+                        "confidence_note",
+                    ],
+                },
+            }
+        },
+        "required": ["public_images"],
+    }

--- a/cloud-run/ria-intelligence-api/app/prompts.py
+++ b/cloud-run/ria-intelligence-api/app/prompts.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+
+from .models import ImageCandidate, RIAProfile
+
+STAGE1_SYSTEM_PROMPT = """You are a FINRA and SEC regulatory verification assistant.
+
+Your job is to verify whether a queried advisor or firm can be confidently matched to public U.S. regulatory records.
+
+Rules:
+1. Prioritize FINRA BrokerCheck, SEC adviser info, and other official regulatory sources over marketing pages.
+2. Use grounded public-web search to verify the exact person or firm.
+3. Return only regulatory or base profile facts in this stage.
+4. Do not invent CRD numbers, firm matches, exams, addresses, or employment history.
+5. If no confident FINRA or SEC match exists, set `existsOnFinra=false` and explain why in `reasonIfNotExists`.
+6. Do not include social links, biographies, or marketing summaries in this stage.
+7. Output must strictly match the provided JSON schema."""
+
+
+DOSSIER_SYSTEM_PROMPT = """You are a public-web professional profile research agent.
+
+Your job is to build a source-backed dossier for one person using only public web information.
+
+Rules:
+1. Use only public, non-paywalled, publicly accessible information.
+2. Prefer primary and official sources first:
+   - regulatory databases
+   - official company websites
+   - official LinkedIn/company pages
+   - reputable public profiles
+3. Never invent facts, social handles, or URLs.
+4. If a profile or link cannot be confidently verified, return it in unverified_or_not_found.
+5. Separate verified facts from unverified claims.
+6. Every important fact must have:
+   - source_title
+   - source_url
+   - evidence_note
+7. Return only professional/publicly relevant information.
+8. For images, return only publicly accessible image URLs with their source page URL.
+9. Identify likely image types such as:
+   - headshot
+   - company logo
+   - cover/banner
+   - profile thumbnail
+10. Include a prompts_used section containing the exact search prompts/queries used during the research.
+11. Do not include private or sensitive non-public data.
+12. Output must strictly match the provided JSON schema."""
+
+
+IMAGE_RANK_SYSTEM_PROMPT = """You are a public image verification and ranking assistant.
+
+Your job is to rank only publicly accessible image candidates for one professional dossier.
+
+Rules:
+1. Prefer a real headshot of the subject over company visuals.
+2. If no trustworthy headshot exists, then prefer company logo, then banner/cover.
+3. Only keep images that are relevant to the subject or current firm.
+4. Do not invent URLs or source pages.
+5. Return only the provided candidate URLs, never new ones.
+6. Output must strictly match the provided JSON schema."""
+
+
+def build_stage1_user_prompt(query: str) -> str:
+    return f"""
+Research the following advisor or firm query and verify it against FINRA or SEC public records.
+
+Query:
+{query}
+
+Tasks:
+1. Determine whether this query confidently matches a real person or firm in FINRA BrokerCheck or SEC adviser records.
+2. If a confident match exists, return the structured regulatory/base profile only.
+3. Prefer official regulatory sources over company marketing sites.
+4. Include CRD number, current firm, location, addresses, phone, years of experience, exams, disclosures, previous firms, and related regulatory details when supported.
+5. If no confident match exists, return `existsOnFinra=false` and provide `reasonIfNotExists`.
+6. Do not include social URLs, image URLs, or narrative enrichment in this stage.
+""".strip()
+
+
+def build_dossier_user_prompt(seed_profile: RIAProfile) -> str:
+    seed_json = json.dumps(
+        {"profile": seed_profile.model_dump(exclude_none=False)},
+        indent=2,
+        ensure_ascii=True,
+    )
+    return f"""
+Research the following public profile and create a source-backed dossier.
+
+Seed profile JSON:
+{seed_json}
+
+Tasks:
+1. Verify the person identity.
+2. Find official/public professional links:
+   - LinkedIn
+   - company website
+   - company LinkedIn
+   - X/Twitter
+   - Facebook
+   - Instagram
+   - Crunchbase
+   - BrokerCheck / regulatory pages
+   - any other strong professional/public profile
+3. Find publicly accessible image URLs, including:
+   - best headshot
+   - company logo
+   - company banner/cover image
+   - any additional relevant public image
+4. Build a concise professional summary using verified sources only.
+5. Mark anything uncertain as unverified_or_not_found.
+6. Include the exact web prompts/search phrases you used.
+7. Do not guess missing handles or links.
+8. Keep the result professional and source-backed.
+""".strip()
+
+
+def build_image_rank_user_prompt(
+    seed_profile: RIAProfile,
+    candidates: list[ImageCandidate],
+) -> str:
+    candidate_rows = []
+    for index, candidate in enumerate(candidates, start=1):
+        candidate_rows.append(
+            {
+                "id": index,
+                "image_url": candidate.imageUrl,
+                "source_page_url": candidate.sourcePageUrl,
+                "platform": candidate.platform,
+                "candidate_type": candidate.candidateType,
+                "confidence": candidate.confidence,
+            }
+        )
+
+    payload = {
+        "subject": {
+            "full_name": seed_profile.fullName,
+            "crd_number": seed_profile.crdNumber,
+            "current_firm": seed_profile.currentFirm,
+            "location": seed_profile.location,
+        },
+        "candidates": candidate_rows,
+    }
+    return f"""
+Rank the following public image candidates for the dossier subject.
+
+Subject and candidate JSON:
+{json.dumps(payload, indent=2, ensure_ascii=True)}
+
+Instructions:
+1. Prefer the best public headshot for the exact person.
+2. If no strong headshot exists, prefer the current firm logo.
+3. Use `kind` values like `headshot`, `company logo`, `banner`, or `profile thumbnail`.
+4. Return only candidates that are clearly relevant and trustworthy.
+5. Do not add URLs that are not already present in the candidate list.
+6. Keep the output concise and source-backed.
+""".strip()

--- a/cloud-run/ria-intelligence-api/app/service.py
+++ b/cloud-run/ria-intelligence-api/app/service.py
@@ -1,0 +1,1048 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from .image_scraper import ImageScraper
+from .models import (
+    DossierPublicImage,
+    DossierSubject,
+    DossierVerifiedProfile,
+    GroundingSource,
+    ImageCandidate,
+    PublicProfileDossier,
+    RIAProfile,
+    RIAProfileRequest,
+    RankedImagesResponse,
+    get_dossier_response_schema,
+    get_ranked_images_response_schema,
+    get_stage1_response_schema,
+)
+from .prompts import (
+    DOSSIER_SYSTEM_PROMPT,
+    IMAGE_RANK_SYSTEM_PROMPT,
+    STAGE1_SYSTEM_PROMPT,
+    build_dossier_user_prompt,
+    build_image_rank_user_prompt,
+    build_stage1_user_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RIA_PRIMARY_MODEL = "gemini-3.1-pro-preview"
+DEFAULT_RIA_FALLBACK_MODEL = "gemini-2.5-pro"
+DEFAULT_GOOGLE_CLOUD_LOCATION = "global"
+DEFAULT_OPENAI_MODEL = "gpt-5.4"
+DEFAULT_OPENAI_IMAGE_RANK_MODEL = "gpt-5.4-mini"
+DEFAULT_OPENAI_TIMEOUT_SECONDS = 90.0
+MAX_RANK_INPUT_IMAGES = 8
+MAX_PUBLIC_IMAGES_RETURNED = 4
+
+
+class InvalidQueryError(ValueError):
+    """Raised when the public query payload is missing or blank."""
+
+
+class RIAUpstreamError(RuntimeError):
+    """Raised when upstream providers cannot produce a usable result."""
+
+
+@dataclass(frozen=True)
+class Stage1GenerationResult:
+    query: str
+    profile: RIAProfile
+    sources: list[GroundingSource]
+    used_model: str
+
+
+@dataclass(frozen=True)
+class Phase2GenerationResult:
+    dossier: PublicProfileDossier
+
+
+def create_vertex_client() -> Any:
+    project = os.getenv("GOOGLE_CLOUD_PROJECT") or os.getenv("GCP_PROJECT_ID")
+    if not project:
+        raise RuntimeError("GOOGLE_CLOUD_PROJECT must be set before starting the service.")
+
+    location = os.getenv("GOOGLE_CLOUD_LOCATION", DEFAULT_GOOGLE_CLOUD_LOCATION)
+    try:
+        from google import genai
+        from google.genai import types as genai_types
+    except ImportError as exc:
+        raise RuntimeError(
+            "google-genai is not installed. Install requirements before starting the service."
+        ) from exc
+
+    return genai.Client(
+        vertexai=True,
+        project=project,
+        location=location,
+        http_options=genai_types.HttpOptions(api_version="v1"),
+    )
+
+
+def create_openai_client() -> Any:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY must be set before starting the service.")
+
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise RuntimeError(
+            "openai is not installed. Install requirements before starting the service."
+        ) from exc
+
+    timeout = float(os.getenv("OPENAI_TIMEOUT_SECONDS", DEFAULT_OPENAI_TIMEOUT_SECONDS))
+    return OpenAI(api_key=api_key, timeout=timeout)
+
+
+class RIAIntelligenceService:
+    def __init__(
+        self,
+        vertex_client: Any | None = None,
+        openai_client: Any | None = None,
+        primary_model: str | None = None,
+        fallback_model: str | None = None,
+        openai_model: str | None = None,
+        openai_image_rank_model: str | None = None,
+        image_scraper: ImageScraper | None = None,
+    ) -> None:
+        self.primary_model = primary_model or os.getenv(
+            "RIA_PRIMARY_MODEL",
+            DEFAULT_RIA_PRIMARY_MODEL,
+        )
+        self.fallback_model = fallback_model or os.getenv(
+            "RIA_FALLBACK_MODEL",
+            DEFAULT_RIA_FALLBACK_MODEL,
+        )
+        self.openai_model = openai_model or os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL)
+        self.openai_image_rank_model = openai_image_rank_model or os.getenv(
+            "OPENAI_IMAGE_RANK_MODEL",
+            DEFAULT_OPENAI_IMAGE_RANK_MODEL,
+        )
+        self._vertex_client = vertex_client or create_vertex_client()
+        self._openai_client = openai_client or create_openai_client()
+        self._image_scraper = image_scraper or ImageScraper()
+
+    def get_ria_profile(self, payload: str | dict[str, Any] | RIAProfileRequest) -> PublicProfileDossier:
+        query = _validate_query_payload(payload)
+        stage1 = self._run_stage1(query)
+        if not stage1.profile.existsOnFinra:
+            return self._build_not_found_dossier(stage1)
+
+        try:
+            phase2 = self._run_phase2(stage1.profile)
+        except Exception as exc:  # noqa: BLE001 - final output depends on a usable dossier
+            logger.warning("Phase 2 dossier generation failed for query=%s: %s", query, exc)
+            raise RIAUpstreamError(
+                f"Unable to generate a source-backed dossier from OpenAI. {exc}"
+            ) from exc
+
+        return self._build_completed_dossier(stage1, phase2)
+
+    def _run_stage1(self, query: str) -> Stage1GenerationResult:
+        errors: list[str] = []
+        for model_id in self._vertex_model_chain():
+            try:
+                response = self._vertex_client.models.generate_content(
+                    model=model_id,
+                    contents=build_stage1_user_prompt(query),
+                    config={
+                        "system_instruction": STAGE1_SYSTEM_PROMPT,
+                        "temperature": 0.1,
+                        "max_output_tokens": 8192,
+                        "response_mime_type": "application/json",
+                        "response_schema": get_stage1_response_schema(),
+                        "tools": [{"google_search": {}}],
+                    },
+                )
+                payload = _parse_json_object(_vertex_response_text(response))
+                profile = RIAProfile.model_validate(_sanitize_stage1_payload(payload))
+                sources = _extract_vertex_sources(response)
+                logger.info(
+                    "Stage 1 completed query=%s model=%s existsOnFinra=%s sources=%d",
+                    query,
+                    model_id,
+                    profile.existsOnFinra,
+                    len(sources),
+                )
+                return Stage1GenerationResult(query=query, profile=profile, sources=sources, used_model=model_id)
+            except Exception as exc:  # noqa: BLE001 - model chain fallback
+                logger.warning("Stage 1 model failed query=%s model=%s error=%s", query, model_id, exc)
+                errors.append(f"{model_id}: {exc}")
+
+        raise RIAUpstreamError(
+            "Unable to verify advisor or firm via FINRA/SEC search. "
+            + " | ".join(errors)
+        )
+
+    def _run_phase2(self, verified_profile: RIAProfile) -> Phase2GenerationResult:
+        draft = self._research_dossier(verified_profile)
+        profile_for_images = _merge_seed_profile_with_dossier_links(
+            verified_profile,
+            draft.verified_profiles,
+        )
+        image_candidates = self._discover_image_candidates(profile_for_images, draft.public_images)
+
+        if image_candidates:
+            try:
+                public_images = self._rank_public_images(verified_profile, image_candidates)
+            except Exception as exc:  # noqa: BLE001 - degrade safely for image stage
+                logger.warning("Image ranking failed for %s: %s", verified_profile.fullName, exc)
+                public_images = _fallback_public_images(image_candidates)
+                draft = draft.model_copy(
+                    update={
+                        "unverified_or_not_found": _dedupe_strings(
+                            [
+                                *draft.unverified_or_not_found,
+                                "OpenAI image ranking failed; using locally validated image fallback candidates.",
+                            ]
+                        )
+                    }
+                )
+        else:
+            public_images = []
+
+        dossier = draft.model_copy(update={"public_images": public_images})
+        if not public_images:
+            dossier = dossier.model_copy(
+                update={
+                    "unverified_or_not_found": _dedupe_strings(
+                        [
+                            *dossier.unverified_or_not_found,
+                            "No confidently verified public image could be confirmed.",
+                        ]
+                    )
+                }
+            )
+
+        return Phase2GenerationResult(dossier=dossier)
+
+    def _research_dossier(self, seed_profile: RIAProfile) -> PublicProfileDossier:
+        response = self._openai_client.responses.create(
+            model=self.openai_model,
+            tools=[{"type": "web_search"}],
+            include=["web_search_call.action.sources"],
+            instructions=DOSSIER_SYSTEM_PROMPT,
+            input=build_dossier_user_prompt(seed_profile),
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "public_profile_dossier",
+                    "strict": True,
+                    "schema": get_dossier_response_schema(),
+                }
+            },
+        )
+        payload = _parse_json_object(_openai_response_text(response))
+        dossier = PublicProfileDossier.model_validate(_normalize_dossier_payload(payload, seed_profile))
+        logger.info(
+            "Generated dossier for subject=%s verified_profiles=%d key_facts=%d public_images=%d",
+            dossier.subject.full_name,
+            len(dossier.verified_profiles),
+            len(dossier.key_facts),
+            len(dossier.public_images),
+        )
+        return dossier
+
+    def _discover_image_candidates(
+        self,
+        profile: RIAProfile,
+        public_images: list[DossierPublicImage],
+    ) -> list[ImageCandidate]:
+        seed_candidates = [
+            ImageCandidate(
+                imageUrl=image.image_url,
+                sourcePageUrl=image.source_page_url,
+                platform=_infer_platform(image.source_page_url or image.image_url),
+                candidateType=_map_public_image_kind_to_candidate_type(image.kind),
+                confidence=92,
+            )
+            for image in public_images
+            if _is_https_url(image.source_page_url) and _is_https_url(image.image_url)
+        ]
+        grounded_urls = _dedupe_strings(
+            [
+                *[
+                    image.source_page_url
+                    for image in public_images
+                    if _is_https_url(image.source_page_url)
+                ],
+                *[
+                    (profile_link.sourcePageUrl or profile_link.imageUrl or "")
+                    for profile_link in _profile_links_to_seed_candidates(
+                        public_images=[],
+                        verified_profiles=_extract_verified_profiles_from_profile(profile),
+                    )
+                    if _is_https_url(profile_link.sourcePageUrl or profile_link.imageUrl or "")
+                ],
+            ]
+        )
+
+        return self._image_scraper.discover_candidates(
+            profile,
+            model_candidates=seed_candidates,
+            grounded_source_urls=grounded_urls,
+        )
+
+    def _rank_public_images(
+        self,
+        seed_profile: RIAProfile,
+        candidates: list[ImageCandidate],
+    ) -> list[DossierPublicImage]:
+        shortlist = _prepare_rank_shortlist(candidates)
+        if not shortlist:
+            return []
+
+        image_inputs = [
+            {"type": "input_image", "image_url": candidate.imageUrl}
+            for candidate in shortlist
+            if candidate.imageUrl
+        ]
+        response = self._openai_client.responses.create(
+            model=self.openai_image_rank_model,
+            instructions=IMAGE_RANK_SYSTEM_PROMPT,
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": build_image_rank_user_prompt(seed_profile, shortlist)},
+                        *image_inputs,
+                    ],
+                }
+            ],
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "ranked_public_images",
+                    "strict": True,
+                    "schema": get_ranked_images_response_schema(),
+                }
+            },
+        )
+        payload = _parse_json_object(_openai_response_text(response))
+        ranked = RankedImagesResponse.model_validate(
+            _normalize_ranked_images_payload(payload, shortlist)
+        )
+        return ranked.public_images[:MAX_PUBLIC_IMAGES_RETURNED]
+
+    def _build_not_found_dossier(self, stage1: Stage1GenerationResult) -> PublicProfileDossier:
+        reason = stage1.profile.reasonIfNotExists or "No confident FINRA or SEC match was found for the query."
+        return PublicProfileDossier(
+            subject=DossierSubject(
+                full_name=stage1.profile.fullName or stage1.query,
+                crd_number=None,
+                current_firm=None,
+                location=None,
+            ),
+            executive_summary=reason,
+            verified_profiles=[],
+            public_images=[],
+            key_facts=[],
+            unverified_or_not_found=[reason],
+            prompts_used=[],
+        )
+
+    def _build_completed_dossier(
+        self,
+        stage1: Stage1GenerationResult,
+        phase2: Phase2GenerationResult,
+    ) -> PublicProfileDossier:
+        dossier = phase2.dossier
+        merged_verified_profiles = _merge_verified_profiles_with_stage1_sources(
+            stage1.sources,
+            dossier.verified_profiles,
+        )
+        return dossier.model_copy(
+            update={
+                "subject": DossierSubject(
+                    full_name=stage1.profile.fullName or dossier.subject.full_name or stage1.query,
+                    crd_number=stage1.profile.crdNumber or dossier.subject.crd_number,
+                    current_firm=stage1.profile.currentFirm or dossier.subject.current_firm,
+                    location=stage1.profile.location or dossier.subject.location,
+                ),
+                "verified_profiles": merged_verified_profiles,
+                "unverified_or_not_found": _dedupe_strings(dossier.unverified_or_not_found),
+                "prompts_used": _dedupe_strings(dossier.prompts_used),
+            }
+        )
+
+    def _vertex_model_chain(self) -> list[str]:
+        models = [self.primary_model, self.fallback_model]
+        unique_models: list[str] = []
+        for model_id in models:
+            if model_id and model_id not in unique_models:
+                unique_models.append(model_id)
+        return unique_models
+
+
+def _validate_query_payload(payload: str | dict[str, Any] | RIAProfileRequest) -> str:
+    if isinstance(payload, str):
+        candidate = {"query": payload}
+    elif isinstance(payload, RIAProfileRequest):
+        return payload.query
+    elif isinstance(payload, dict):
+        candidate = payload
+    else:
+        raise InvalidQueryError("A request body with `query` is required.")
+
+    try:
+        request = RIAProfileRequest.model_validate(candidate)
+    except Exception as exc:  # noqa: BLE001
+        if isinstance(candidate, dict):
+            query = candidate.get("query")
+            if isinstance(query, str) and not query.strip():
+                raise InvalidQueryError("query must not be blank") from exc
+        raise InvalidQueryError("A request body with `query` is required.") from exc
+    return request.query
+
+
+def _sanitize_stage1_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {
+        "existsOnFinra": bool(payload.get("existsOnFinra", False)),
+    }
+
+    scalar_fields = [
+        "crdNumber",
+        "secNumber",
+        "fullName",
+        "currentFirm",
+        "location",
+        "mainAddress",
+        "mailingAddress",
+        "phone",
+        "establishedIn",
+        "companyType",
+        "fiscalYearEnd",
+        "regulatedBy",
+        "reasonIfNotExists",
+    ]
+    list_fields = [
+        "otherNames",
+        "examsPassed",
+        "stateLicenses",
+        "otherRegistrations",
+    ]
+
+    for field in scalar_fields:
+        value = _string_or_none(payload.get(field))
+        if value is not None:
+            sanitized[field] = value
+
+    for field in list_fields:
+        values = _normalize_string_list(payload.get(field))
+        if values:
+            sanitized[field] = values
+
+    years_of_experience = _int_or_none(payload.get("yearsOfExperience"))
+    if years_of_experience is not None:
+        sanitized["yearsOfExperience"] = years_of_experience
+
+    disclosures = payload.get("disclosures")
+    if isinstance(disclosures, dict):
+        disclosure_payload = {
+            key: _int_or_none(disclosures.get(key))
+            for key in ("total", "regulatoryEvent", "arbitration")
+        }
+        disclosure_payload = {
+            key: value for key, value in disclosure_payload.items() if value is not None
+        }
+        if disclosure_payload:
+            sanitized["disclosures"] = disclosure_payload
+
+    direct_owners = []
+    for item in payload.get("directOwnersAndExecutiveOfficers", []) if isinstance(payload.get("directOwnersAndExecutiveOfficers"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        normalized_item = {
+            "name": _string_or_none(item.get("name")),
+            "position": _string_or_none(item.get("position")),
+            "crdNumber": _string_or_none(item.get("crdNumber")),
+        }
+        if any(normalized_item.values()):
+            direct_owners.append(normalized_item)
+    if direct_owners:
+        sanitized["directOwnersAndExecutiveOfficers"] = direct_owners
+
+    previous_firms = []
+    for item in payload.get("previousFirms", []) if isinstance(payload.get("previousFirms"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        normalized_item = {
+            "name": _string_or_none(item.get("name")),
+            "crdNumber": _string_or_none(item.get("crdNumber")),
+        }
+        if any(normalized_item.values()):
+            previous_firms.append(normalized_item)
+    if previous_firms:
+        sanitized["previousFirms"] = previous_firms
+
+    if not sanitized["existsOnFinra"] and not sanitized.get("reasonIfNotExists"):
+        sanitized["reasonIfNotExists"] = "No confident FINRA or SEC match was found for the query."
+
+    return sanitized
+
+
+def _normalize_dossier_payload(payload: dict[str, Any], seed_profile: RIAProfile) -> dict[str, Any]:
+    subject = payload.get("subject") if isinstance(payload.get("subject"), dict) else {}
+    normalized = {
+        "subject": {
+            "full_name": seed_profile.fullName or _string_or_default(subject.get("full_name"), ""),
+            "crd_number": seed_profile.crdNumber or _nullable_string_or_default(subject.get("crd_number"), None),
+            "current_firm": seed_profile.currentFirm or _nullable_string_or_default(subject.get("current_firm"), None),
+            "location": seed_profile.location or _nullable_string_or_default(subject.get("location"), None),
+        },
+        "executive_summary": _string_or_default(
+            payload.get("executive_summary"),
+            seed_profile.bio or "No executive summary could be generated from verified public sources.",
+        ),
+        "verified_profiles": _normalize_verified_profiles(payload.get("verified_profiles")),
+        "public_images": _normalize_public_images(payload.get("public_images")),
+        "key_facts": _normalize_key_facts(payload.get("key_facts")),
+        "unverified_or_not_found": _normalize_string_list(payload.get("unverified_or_not_found")),
+        "prompts_used": _normalize_string_list(payload.get("prompts_used")),
+    }
+    if not normalized["prompts_used"]:
+        normalized["unverified_or_not_found"] = _dedupe_strings(
+            [
+                *normalized["unverified_or_not_found"],
+                "Exact web prompts/search phrases were not available in the structured model output.",
+            ]
+        )
+    return normalized
+
+
+def _normalize_verified_profiles(value: Any) -> list[dict[str, Any]]:
+    profiles: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value if isinstance(value, list) else []:
+        if not isinstance(item, dict):
+            continue
+        platform = _string_or_none(item.get("platform"))
+        label = _string_or_none(item.get("label"))
+        url = _string_or_none(item.get("url"))
+        if not platform or not label or not url or not _is_https_url(url):
+            continue
+        dedupe_key = (platform.lower(), url)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        profiles.append(
+            {
+                "platform": platform,
+                "label": label,
+                "url": url,
+                "handle": _string_or_none(item.get("handle")),
+                "source_title": _string_or_default(item.get("source_title"), _source_title_from_url(url)),
+                "source_url": _string_or_default(item.get("source_url"), url),
+                "evidence_note": _string_or_default(
+                    item.get("evidence_note"),
+                    "Verified through public-web research.",
+                ),
+            }
+        )
+    return profiles
+
+
+def _normalize_public_images(value: Any) -> list[dict[str, Any]]:
+    images: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value if isinstance(value, list) else []:
+        if not isinstance(item, dict):
+            continue
+        image_url = _string_or_none(item.get("image_url"))
+        source_page_url = _string_or_none(item.get("source_page_url"))
+        if not image_url or not source_page_url:
+            continue
+        if not _is_https_url(image_url) or not _is_https_url(source_page_url):
+            continue
+        dedupe_key = (image_url, source_page_url)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        images.append(
+            {
+                "kind": _string_or_default(item.get("kind"), "headshot"),
+                "image_url": image_url,
+                "source_page_url": source_page_url,
+                "source_title": _string_or_default(
+                    item.get("source_title"),
+                    _source_title_from_url(source_page_url),
+                ),
+                "confidence_note": _string_or_default(
+                    item.get("confidence_note"),
+                    "Candidate returned from public-web research.",
+                ),
+            }
+        )
+    return images
+
+
+def _normalize_key_facts(value: Any) -> list[dict[str, Any]]:
+    facts: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in value if isinstance(value, list) else []:
+        if not isinstance(item, dict):
+            continue
+        fact = _string_or_none(item.get("fact"))
+        source_title = _string_or_none(item.get("source_title"))
+        source_url = _string_or_none(item.get("source_url"))
+        evidence_note = _string_or_none(item.get("evidence_note"))
+        if not fact or not source_title or not source_url or not evidence_note or not _is_https_url(source_url):
+            continue
+        dedupe_key = (fact, source_url)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        facts.append(
+            {
+                "fact": fact,
+                "source_title": source_title,
+                "source_url": source_url,
+                "evidence_note": evidence_note,
+            }
+        )
+    return facts
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    return _dedupe_strings(
+        [item.strip() for item in value if isinstance(item, str) and item.strip()]
+        if isinstance(value, list)
+        else []
+    )
+
+
+def _merge_verified_profiles_with_stage1_sources(
+    stage1_sources: list[GroundingSource],
+    verified_profiles: list[DossierVerifiedProfile],
+) -> list[DossierVerifiedProfile]:
+    merged: list[DossierVerifiedProfile] = []
+    seen_urls: set[str] = set()
+
+    for source in stage1_sources:
+        if source.uri in seen_urls:
+            continue
+        seen_urls.add(source.uri)
+        merged.append(
+            DossierVerifiedProfile(
+                platform=_platform_from_source_uri(source.uri),
+                label=source.title,
+                url=source.uri,
+                handle=None,
+                source_title=source.title,
+                source_url=source.uri,
+                evidence_note="Official regulatory source captured during Phase 1 verification.",
+            )
+        )
+
+    for profile in verified_profiles:
+        if profile.url in seen_urls:
+            continue
+        seen_urls.add(profile.url)
+        merged.append(profile)
+
+    return merged
+
+
+def _merge_seed_profile_with_dossier_links(
+    seed_profile: RIAProfile,
+    verified_profiles: list[DossierVerifiedProfile],
+) -> RIAProfile:
+    updates: dict[str, Any] = {}
+    for profile in verified_profiles:
+        platform = profile.platform.strip().lower()
+        if platform == "linkedin" and not updates.get("linkedinUrl") and not seed_profile.linkedinUrl:
+            updates["linkedinUrl"] = profile.url
+        elif platform in {"twitter", "x"} and not updates.get("twitterUrl") and not seed_profile.twitterUrl:
+            updates["twitterUrl"] = profile.url
+        elif platform == "facebook" and not updates.get("facebookUrl") and not seed_profile.facebookUrl:
+            updates["facebookUrl"] = profile.url
+        elif platform in {"website", "company website"} and not updates.get("websiteUrl") and not seed_profile.websiteUrl:
+            updates["websiteUrl"] = profile.url
+
+    return seed_profile.model_copy(update=updates)
+
+
+def _prepare_rank_shortlist(candidates: list[ImageCandidate]) -> list[ImageCandidate]:
+    shortlist: list[ImageCandidate] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate.imageUrl or not candidate.sourcePageUrl:
+            continue
+        if not _is_https_url(candidate.imageUrl) or not _is_https_url(candidate.sourcePageUrl):
+            continue
+        if candidate.imageUrl in seen:
+            continue
+        seen.add(candidate.imageUrl)
+        shortlist.append(candidate)
+        if len(shortlist) >= MAX_RANK_INPUT_IMAGES:
+            break
+    return shortlist
+
+
+def _normalize_ranked_images_payload(
+    payload: dict[str, Any],
+    candidates: list[ImageCandidate],
+) -> dict[str, Any]:
+    candidate_by_image_url = {
+        candidate.imageUrl: candidate
+        for candidate in candidates
+        if candidate.imageUrl and candidate.sourcePageUrl
+    }
+    public_images: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in payload.get("public_images", []) if isinstance(payload.get("public_images"), list) else []:
+        if not isinstance(item, dict):
+            continue
+        image_url = _string_or_none(item.get("image_url"))
+        if not image_url or image_url not in candidate_by_image_url or image_url in seen:
+            continue
+        candidate = candidate_by_image_url[image_url]
+        seen.add(image_url)
+        public_images.append(
+            {
+                "kind": _string_or_default(item.get("kind"), _kind_from_candidate(candidate)),
+                "image_url": image_url,
+                "source_page_url": _string_or_default(item.get("source_page_url"), candidate.sourcePageUrl or ""),
+                "source_title": _string_or_default(
+                    item.get("source_title"),
+                    _source_title_from_url(candidate.sourcePageUrl or image_url),
+                ),
+                "confidence_note": _string_or_default(
+                    item.get("confidence_note"),
+                    f"Ranked from validated public candidate (platform={candidate.platform or 'website'}).",
+                ),
+            }
+        )
+    return {"public_images": public_images}
+
+
+def _fallback_public_images(candidates: list[ImageCandidate]) -> list[DossierPublicImage]:
+    images: list[DossierPublicImage] = []
+    for candidate in _prepare_rank_shortlist(candidates)[:MAX_PUBLIC_IMAGES_RETURNED]:
+        images.append(
+            DossierPublicImage(
+                kind=_kind_from_candidate(candidate),
+                image_url=candidate.imageUrl or "",
+                source_page_url=candidate.sourcePageUrl or "",
+                source_title=_source_title_from_url(candidate.sourcePageUrl or candidate.imageUrl or ""),
+                confidence_note=(
+                    f"Validated from a public {candidate.platform or 'website'} source page "
+                    f"with scraper confidence {candidate.confidence or 0}."
+                ),
+            )
+        )
+    return images
+
+
+def _profile_links_to_seed_candidates(
+    public_images: list[DossierPublicImage],
+    verified_profiles: list[DossierVerifiedProfile],
+) -> list[ImageCandidate]:
+    candidates: list[ImageCandidate] = []
+    for profile in verified_profiles:
+        platform = profile.platform.strip().lower()
+        candidate_type = "logo"
+        if platform in {"linkedin", "twitter", "x"}:
+            candidate_type = "headshot"
+        candidates.append(
+            ImageCandidate(
+                imageUrl=None,
+                sourcePageUrl=profile.url,
+                platform=_infer_platform(profile.url),
+                candidateType=candidate_type,
+                confidence=90,
+            )
+        )
+    for image in public_images:
+        candidates.append(
+            ImageCandidate(
+                imageUrl=image.image_url,
+                sourcePageUrl=image.source_page_url,
+                platform=_infer_platform(image.source_page_url or image.image_url),
+                candidateType=_map_public_image_kind_to_candidate_type(image.kind),
+                confidence=92,
+            )
+        )
+    return candidates
+
+
+def _extract_verified_profiles_from_profile(profile: RIAProfile) -> list[DossierVerifiedProfile]:
+    records: list[DossierVerifiedProfile] = []
+    mappings = [
+        ("LinkedIn", profile.linkedinUrl),
+        ("Twitter", profile.twitterUrl),
+        ("Facebook", profile.facebookUrl),
+        ("Website", profile.websiteUrl),
+    ]
+    for platform, url in mappings:
+        if not url or not _is_https_url(url):
+            continue
+        records.append(
+            DossierVerifiedProfile(
+                platform=platform,
+                label=platform,
+                url=url,
+                handle=None,
+                source_title=_source_title_from_url(url),
+                source_url=url,
+                evidence_note="Seed profile link carried into image verification.",
+            )
+        )
+    return records
+
+
+def _vertex_response_text(response: Any) -> str:
+    text = getattr(response, "text", None)
+    if callable(text):
+        text = text()
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+
+    response_data = _to_plain_data(response)
+    if isinstance(response_data, dict):
+        raw_text = response_data.get("text")
+        if isinstance(raw_text, str) and raw_text.strip():
+            return raw_text.strip()
+
+        candidates = response_data.get("candidates") or []
+        for item in candidates:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content") or {}
+            parts = content.get("parts") or []
+            for part in parts:
+                if not isinstance(part, dict):
+                    continue
+                part_text = part.get("text")
+                if isinstance(part_text, str) and part_text.strip():
+                    return part_text.strip()
+
+    raise ValueError("Vertex AI returned an empty response body")
+
+
+def _openai_response_text(response: Any) -> str:
+    text = getattr(response, "output_text", None)
+    if callable(text):
+        text = text()
+    if isinstance(text, str) and text.strip():
+        return text.strip()
+
+    response_data = _to_plain_data(response)
+    if isinstance(response_data, dict):
+        output_text = response_data.get("output_text")
+        if isinstance(output_text, str) and output_text.strip():
+            return output_text.strip()
+
+        output = response_data.get("output") or []
+        text_parts: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content") or []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") in {"output_text", "text"} and isinstance(block.get("text"), str):
+                    text_parts.append(block["text"])
+        if text_parts:
+            return "\n".join(text_parts).strip()
+
+    raise ValueError("OpenAI Responses API returned an empty response body")
+
+
+def _extract_vertex_sources(response: Any) -> list[GroundingSource]:
+    response_data = _to_plain_data(response)
+    if not isinstance(response_data, dict):
+        return []
+
+    sources: list[GroundingSource] = []
+    for candidate in response_data.get("candidates", []) if isinstance(response_data.get("candidates"), list) else []:
+        if not isinstance(candidate, dict):
+            continue
+        grounding_metadata = candidate.get("grounding_metadata") or candidate.get("groundingMetadata") or {}
+        if not isinstance(grounding_metadata, dict):
+            continue
+        chunks = grounding_metadata.get("grounding_chunks") or grounding_metadata.get("groundingChunks") or []
+        for chunk in chunks if isinstance(chunks, list) else []:
+            if not isinstance(chunk, dict):
+                continue
+            web = chunk.get("web") or chunk.get("retrievedContext") or {}
+            if not isinstance(web, dict):
+                continue
+            title = _string_or_none(web.get("title"))
+            uri = _string_or_none(web.get("uri") or web.get("url"))
+            if title and uri and _is_https_url(uri):
+                sources.append(GroundingSource(title=title, uri=uri))
+
+    return _dedupe_sources(sources)
+
+
+def _parse_json_object(text: str) -> dict[str, Any]:
+    cleaned = _strip_json_fences(text)
+    for candidate in (cleaned, _extract_json_fragment(cleaned)):
+        try:
+            payload = json.loads(candidate)
+        except (TypeError, json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(payload, dict):
+            return payload
+    raise ValueError("Provider did not return a JSON object")
+
+
+def _strip_json_fences(text: str) -> str:
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.split("\n", 1)[-1]
+    if cleaned.endswith("```"):
+        cleaned = cleaned.rsplit("```", 1)[0]
+    return cleaned.strip()
+
+
+def _extract_json_fragment(text: str) -> str:
+    starts = [index for index in (text.find("{"), text.find("[")) if index != -1]
+    if not starts:
+        return text
+    start = min(starts)
+    object_end = text.rfind("}")
+    array_end = text.rfind("]")
+    end = max(object_end, array_end)
+    if end < start:
+        return text
+    return text[start : end + 1].strip()
+
+
+def _to_plain_data(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_to_plain_data(item) for item in value]
+    if isinstance(value, tuple):
+        return [_to_plain_data(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _to_plain_data(item) for key, item in value.items()}
+    if hasattr(value, "model_dump"):
+        return _to_plain_data(value.model_dump(exclude_none=True))
+    if hasattr(value, "__dict__"):
+        return {
+            key: _to_plain_data(item)
+            for key, item in vars(value).items()
+            if not key.startswith("_")
+        }
+    return value
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _string_or_default(value: Any, default: str) -> str:
+    normalized = _string_or_none(value)
+    return normalized if normalized is not None else default
+
+
+def _nullable_string_or_default(value: Any, default: str | None) -> str | None:
+    normalized = _string_or_none(value)
+    if normalized is not None:
+        return normalized
+    return default
+
+
+def _int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def _dedupe_sources(sources: list[GroundingSource]) -> list[GroundingSource]:
+    deduped: list[GroundingSource] = []
+    seen: set[tuple[str, str]] = set()
+    for source in sources:
+        key = (source.title.strip(), source.uri.strip())
+        if not key[0] or not key[1] or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(source)
+    return deduped
+
+
+def _kind_from_candidate(candidate: ImageCandidate) -> str:
+    if candidate.candidateType == "logo":
+        return "company logo"
+    if (candidate.platform or "").lower() in {"linkedin", "twitter", "x"}:
+        return "headshot"
+    return "headshot" if candidate.candidateType == "headshot" else "company logo"
+
+
+def _map_public_image_kind_to_candidate_type(kind: str | None) -> str:
+    normalized = (kind or "").strip().lower()
+    if "logo" in normalized or "banner" in normalized:
+        return "logo"
+    return "headshot"
+
+
+def _source_title_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    domain = parsed.netloc.replace("www.", "") or "source"
+    return domain
+
+
+def _platform_from_source_uri(uri: str) -> str:
+    uri_lower = uri.lower()
+    if "brokercheck" in uri_lower or "finra.org" in uri_lower:
+        return "FINRA BrokerCheck"
+    if "sec.gov" in uri_lower or "adviserinfo" in uri_lower:
+        return "SEC"
+    return "Regulatory Source"
+
+
+def _infer_platform(url: str | None) -> str:
+    if not url:
+        return "website"
+    host = (urlparse(url).netloc or "").lower()
+    if "linkedin.com" in host:
+        return "linkedin"
+    if "twitter.com" in host or "x.com" in host:
+        return "twitter"
+    if "facebook.com" in host:
+        return "facebook"
+    if "brokercheck.finra.org" in host or "finra.org" in host:
+        return "finra"
+    return "website"
+
+
+def _is_https_url(value: str | None) -> bool:
+    if not value or not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme == "https" and bool(parsed.netloc)

--- a/cloud-run/ria-intelligence-api/requirements.txt
+++ b/cloud-run/ria-intelligence-api/requirements.txt
@@ -1,0 +1,11 @@
+beautifulsoup4>=4.12.0,<5.0.0
+fastapi>=0.115.0,<1.0.0
+google-genai>=1.36.0,<2.0.0
+google-cloud-storage>=2.19.0,<3.0.0
+gunicorn>=23.0.0,<24.0.0
+httpx>=0.28.0,<1.0.0
+lxml>=5.0.0,<6.0.0
+openai>=1.0.0,<2.0.0
+Pillow>=11.0.0,<12.0.0
+pydantic>=2.9.0,<3.0.0
+uvicorn>=0.30.0,<1.0.0

--- a/cloud-run/ria-intelligence-api/tests/__init__.py
+++ b/cloud-run/ria-intelligence-api/tests/__init__.py
@@ -1,0 +1,1 @@
+"""RIA Intelligence API test package."""

--- a/cloud-run/ria-intelligence-api/tests/test_api.py
+++ b/cloud-run/ria-intelligence-api/tests/test_api.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.models import PublicProfileDossier
+from app.service import InvalidQueryError, RIAUpstreamError
+
+
+def make_response() -> PublicProfileDossier:
+    return PublicProfileDossier.model_validate(
+        {
+            "subject": {
+                "full_name": "Ana Roumenova Carter",
+                "crd_number": "4424794",
+                "current_firm": "LCG CAPITAL ADVISORS, LLC",
+                "location": "Tampa, Florida",
+            },
+            "executive_summary": "Ana Carter summary",
+            "verified_profiles": [
+                {
+                    "platform": "LinkedIn",
+                    "label": "LinkedIn",
+                    "url": "https://www.linkedin.com/in/anacarter01/",
+                    "handle": "anacarter01",
+                    "source_title": "LinkedIn",
+                    "source_url": "https://www.linkedin.com/in/anacarter01/",
+                    "evidence_note": "Matched name and firm.",
+                }
+            ],
+            "public_images": [],
+            "key_facts": [],
+            "unverified_or_not_found": [],
+            "prompts_used": ["Ana Roumenova Carter LinkedIn"],
+        }
+    )
+
+
+class FakeService:
+    def __init__(self) -> None:
+        self.payloads: list[dict] = []
+
+    @property
+    def primary_model(self) -> str:
+        return "gemini-3.1-pro-preview"
+
+    @property
+    def fallback_model(self) -> str:
+        return "gemini-2.5-pro"
+
+    def get_ria_profile(self, payload: dict) -> PublicProfileDossier:
+        self.payloads.append(payload)
+        return make_response()
+
+
+class InvalidQueryService(FakeService):
+    def get_ria_profile(self, payload: dict) -> PublicProfileDossier:
+        raise InvalidQueryError("query must not be blank")
+
+
+class ErrorService(FakeService):
+    def get_ria_profile(self, payload: dict) -> PublicProfileDossier:
+        raise RIAUpstreamError("stage 1 unavailable")
+
+
+class ConstructibleService(FakeService):
+    init_count = 0
+    last_instance: "ConstructibleService | None" = None
+
+    def __init__(self) -> None:
+        super().__init__()
+        type(self).init_count += 1
+        type(self).last_instance = self
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.init_count = 0
+        cls.last_instance = None
+
+
+class APITests(unittest.TestCase):
+    def test_health_endpoint(self) -> None:
+        with TestClient(create_app(service=FakeService())) as client:
+            response = client.get("/health")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+        self.assertEqual(response.json()["primaryModel"], "gemini-3.1-pro-preview")
+
+    def test_healthz_alias(self) -> None:
+        with TestClient(create_app(service=FakeService())) as client:
+            response = client.get("/healthz")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+    def test_profile_route_accepts_query_payload_and_returns_dossier(self) -> None:
+        service = FakeService()
+        with TestClient(create_app(service=service)) as client:
+            response = client.post(
+                "/v1/ria/profile",
+                json={"query": "ANA ROUMENOVA CARTER"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["subject"]["full_name"], "Ana Roumenova Carter")
+        self.assertEqual(response.json()["executive_summary"], "Ana Carter summary")
+        self.assertEqual(service.payloads[0]["query"], "ANA ROUMENOVA CARTER")
+
+    def test_profile_route_maps_invalid_query_to_400(self) -> None:
+        with TestClient(create_app(service=InvalidQueryService())) as client:
+            response = client.post("/v1/ria/profile", json={"query": "   "})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("query", response.text)
+
+    def test_profile_route_maps_upstream_failures_to_502(self) -> None:
+        with TestClient(create_app(service=ErrorService())) as client:
+            response = client.post(
+                "/v1/ria/profile",
+                json={"query": "Jane Doe"},
+            )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertIn("stage 1 unavailable", response.text)
+
+    def test_app_startup_initializes_service_before_first_request(self) -> None:
+        ConstructibleService.reset()
+
+        with patch("app.main.RIAIntelligenceService", ConstructibleService):
+            with TestClient(create_app()) as client:
+                self.assertEqual(ConstructibleService.init_count, 1)
+                self.assertTrue(client.app.state.service_ready)
+                self.assertIs(client.app.state.ria_service, ConstructibleService.last_instance)
+
+                response = client.get("/health")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ConstructibleService.init_count, 1)
+
+    def test_repeated_requests_reuse_single_initialized_service_instance(self) -> None:
+        ConstructibleService.reset()
+
+        query_payload = {"query": "Jane Doe"}
+        with patch("app.main.RIAIntelligenceService", ConstructibleService):
+            with TestClient(create_app()) as client:
+                startup_service = client.app.state.ria_service
+
+                first_response = client.post("/v1/ria/profile", json=query_payload)
+                second_response = client.post("/v1/ria/profile", json=query_payload)
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        self.assertEqual(ConstructibleService.init_count, 1)
+        self.assertIs(startup_service, ConstructibleService.last_instance)
+        self.assertEqual(len(ConstructibleService.last_instance.payloads), 2)
+
+    def test_first_request_flag_is_true_once_per_instance(self) -> None:
+        with TestClient(create_app(service=FakeService())) as client:
+            self.assertTrue(client.app.state.instance_first_request_pending)
+
+            first_response = client.get("/health")
+            first_request_pending_after = client.app.state.instance_first_request_pending
+            second_response = client.get("/health")
+
+        self.assertEqual(first_response.status_code, 200)
+        self.assertEqual(second_response.status_code, 200)
+        self.assertFalse(first_request_pending_after)
+        self.assertFalse(client.app.state.instance_first_request_pending)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud-run/ria-intelligence-api/tests/test_image_pipeline.py
+++ b/cloud-run/ria-intelligence-api/tests/test_image_pipeline.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import io
+import unittest
+
+import httpx
+from PIL import Image
+
+from app.image_pipeline import (
+    DEFAULT_IMAGE_MAX_BYTES,
+    FetchedImage,
+    HTTPImageFetcher,
+    ImagePipeline,
+)
+from app.models import ImageCandidate, RIAProfile
+
+
+def make_image_bytes(*, size: tuple[int, int], image_format: str = "PNG") -> bytes:
+    buffer = io.BytesIO()
+    image = Image.new("RGB", size, color=(12, 34, 56))
+    image.save(buffer, format=image_format)
+    return buffer.getvalue()
+
+
+class FakeStore:
+    def __init__(self, fresh_urls: dict[str, str] | None = None) -> None:
+        self.fresh_urls = fresh_urls or {}
+        self.uploads: list[dict[str, object]] = []
+
+    def get_fresh_public_url(self, base_object_key: str, refresh_days: int) -> str | None:
+        return self.fresh_urls.get(base_object_key)
+
+    def upload_image(
+        self,
+        *,
+        base_object_key: str,
+        extension: str,
+        data: bytes,
+        content_type: str,
+    ) -> str:
+        self.uploads.append(
+            {
+                "base_object_key": base_object_key,
+                "extension": extension,
+                "data": data,
+                "content_type": content_type,
+            }
+        )
+        return f"https://storage.googleapis.com/test-bucket/{base_object_key}.{extension}"
+
+
+class FakeFetcher:
+    def __init__(
+        self,
+        *,
+        fetch_results: dict[str, object] | None = None,
+        public_access: dict[str, bool] | None = None,
+    ) -> None:
+        self.fetch_results = fetch_results or {}
+        self.public_access = public_access or {}
+        self.fetch_calls: list[str] = []
+        self.access_calls: list[str] = []
+
+    def fetch(self, url: str, max_bytes: int) -> FetchedImage:
+        del max_bytes
+        self.fetch_calls.append(url)
+        result = self.fetch_results[url]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def is_publicly_accessible(self, url: str) -> bool:
+        self.access_calls.append(url)
+        return self.public_access.get(url, True)
+
+
+class ImagePipelineTests(unittest.TestCase):
+    def test_headshot_candidate_is_uploaded_to_advisor_path(self) -> None:
+        profile = RIAProfile(
+            existsOnFinra=True,
+            fullName="Jane Doe",
+            currentFirm="Northstar Advisors",
+            crdNumber="12345",
+        )
+        headshot_url = "https://media.example/jane.jpg"
+        logo_url = "https://cdn.example/logo.png"
+        store = FakeStore()
+        fetcher = FakeFetcher(
+            fetch_results={
+                headshot_url: FetchedImage(
+                    data=make_image_bytes(size=(600, 600), image_format="JPEG"),
+                    content_type="image/jpeg",
+                    extension="jpg",
+                    width=600,
+                    height=600,
+                    final_url=headshot_url,
+                ),
+                logo_url: FetchedImage(
+                    data=make_image_bytes(size=(300, 300)),
+                    content_type="image/png",
+                    extension="png",
+                    width=300,
+                    height=300,
+                    final_url=logo_url,
+                ),
+            }
+        )
+        pipeline = ImagePipeline(bucket_name="test-bucket", store=store, fetcher=fetcher)
+
+        result = pipeline.resolve_image(
+            profile=profile,
+            image_candidates=[
+                ImageCandidate(
+                    imageUrl=logo_url,
+                    sourcePageUrl="https://northstar.example/about",
+                    platform="website",
+                    candidateType="logo",
+                    confidence=93,
+                ),
+                ImageCandidate(
+                    imageUrl=headshot_url,
+                    sourcePageUrl="https://www.linkedin.com/in/jane-doe",
+                    platform="linkedin",
+                    candidateType="headshot",
+                    confidence=98,
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            result.public_url,
+            "https://storage.googleapis.com/test-bucket/ria-images/advisors/12345/profile.jpg",
+        )
+        self.assertEqual(result.warnings, [])
+        self.assertEqual(fetcher.fetch_calls, [headshot_url])
+        self.assertEqual(
+            store.uploads[0]["base_object_key"],
+            "ria-images/advisors/12345/profile",
+        )
+
+    def test_logo_fallback_is_used_when_headshot_is_too_small(self) -> None:
+        profile = RIAProfile(
+            existsOnFinra=True,
+            fullName="Northstar Advisors",
+            currentFirm="Northstar Advisors",
+        )
+        headshot_url = "https://northstar.example/team/jane.jpg"
+        logo_url = "https://northstar.example/assets/logo.png"
+        store = FakeStore()
+        fetcher = FakeFetcher(
+            fetch_results={
+                headshot_url: FetchedImage(
+                    data=make_image_bytes(size=(180, 180)),
+                    content_type="image/png",
+                    extension="png",
+                    width=180,
+                    height=180,
+                    final_url=headshot_url,
+                ),
+                logo_url: FetchedImage(
+                    data=make_image_bytes(size=(240, 240)),
+                    content_type="image/png",
+                    extension="png",
+                    width=240,
+                    height=240,
+                    final_url=logo_url,
+                ),
+            }
+        )
+        pipeline = ImagePipeline(bucket_name="test-bucket", store=store, fetcher=fetcher)
+
+        result = pipeline.resolve_image(
+            profile=profile,
+            image_candidates=[
+                ImageCandidate(
+                    imageUrl=headshot_url,
+                    sourcePageUrl="https://northstar.example/team/jane-doe",
+                    platform="website",
+                    candidateType="headshot",
+                    confidence=96,
+                ),
+                ImageCandidate(
+                    imageUrl=logo_url,
+                    sourcePageUrl="https://northstar.example/about",
+                    platform="website",
+                    candidateType="logo",
+                    confidence=92,
+                ),
+            ],
+        )
+
+        self.assertEqual(
+            result.public_url,
+            "https://storage.googleapis.com/test-bucket/ria-images/firms/northstar-advisors/logo.png",
+        )
+        self.assertEqual(fetcher.fetch_calls, [headshot_url, logo_url])
+        self.assertEqual(
+            store.uploads[0]["base_object_key"],
+            "ria-images/firms/northstar-advisors/logo",
+        )
+
+    def test_existing_fresh_image_is_reused_without_fetching(self) -> None:
+        profile = RIAProfile(existsOnFinra=True, fullName="Jane Doe", crdNumber="12345")
+        fresh_url = "https://storage.googleapis.com/test-bucket/ria-images/advisors/12345/profile.jpg"
+        store = FakeStore(fresh_urls={"ria-images/advisors/12345/profile": fresh_url})
+        fetcher = FakeFetcher(public_access={fresh_url: True})
+        pipeline = ImagePipeline(bucket_name="test-bucket", store=store, fetcher=fetcher)
+
+        result = pipeline.resolve_image(
+            profile=profile,
+            image_candidates=[
+                ImageCandidate(
+                    imageUrl="https://media.example/jane.jpg",
+                    sourcePageUrl="https://www.linkedin.com/in/jane-doe",
+                    platform="linkedin",
+                    candidateType="headshot",
+                    confidence=97,
+                )
+            ],
+        )
+
+        self.assertEqual(result.public_url, fresh_url)
+        self.assertEqual(result.warnings, [])
+        self.assertEqual(fetcher.fetch_calls, [])
+        self.assertEqual(store.uploads, [])
+
+    def test_public_gcs_access_failure_returns_warning(self) -> None:
+        profile = RIAProfile(existsOnFinra=True, fullName="Jane Doe", crdNumber="12345")
+        candidate_url = "https://media.example/jane.jpg"
+        uploaded_url = "https://storage.googleapis.com/test-bucket/ria-images/advisors/12345/profile.jpg"
+        store = FakeStore()
+        fetcher = FakeFetcher(
+            fetch_results={
+                candidate_url: FetchedImage(
+                    data=make_image_bytes(size=(400, 400), image_format="JPEG"),
+                    content_type="image/jpeg",
+                    extension="jpg",
+                    width=400,
+                    height=400,
+                    final_url=candidate_url,
+                )
+            },
+            public_access={uploaded_url: False},
+        )
+        pipeline = ImagePipeline(bucket_name="test-bucket", store=store, fetcher=fetcher)
+
+        result = pipeline.resolve_image(
+            profile=profile,
+            image_candidates=[
+                ImageCandidate(
+                    imageUrl=candidate_url,
+                    sourcePageUrl="https://www.linkedin.com/in/jane-doe",
+                    platform="linkedin",
+                    candidateType="headshot",
+                    confidence=97,
+                )
+            ],
+        )
+
+        self.assertIsNone(result.public_url)
+        self.assertEqual(
+            result.warnings,
+            ["Image uploaded to GCS but public delivery is blocked by bucket or org policy."],
+        )
+
+    def test_http_image_fetcher_rejects_invalid_content_types_and_oversized_images(self) -> None:
+        valid_png = make_image_bytes(size=(220, 220))
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path == "/html":
+                return httpx.Response(
+                    200,
+                    headers={"content-type": "text/html"},
+                    text="<html>not an image</html>",
+                )
+            if request.url.path == "/svg":
+                return httpx.Response(
+                    200,
+                    headers={"content-type": "image/svg+xml"},
+                    text="<svg></svg>",
+                )
+            if request.url.path == "/oversized":
+                return httpx.Response(
+                    200,
+                    headers={
+                        "content-type": "image/png",
+                        "content-length": str(DEFAULT_IMAGE_MAX_BYTES + 1),
+                    },
+                    content=valid_png,
+                )
+            return httpx.Response(
+                200,
+                headers={"content-type": "image/png"},
+                content=valid_png,
+            )
+
+        client = httpx.Client(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=True,
+            max_redirects=3,
+        )
+        fetcher = HTTPImageFetcher(client=client)
+
+        with self.assertRaises(ValueError):
+            fetcher.fetch("https://example.com/html", DEFAULT_IMAGE_MAX_BYTES)
+
+        with self.assertRaises(ValueError):
+            fetcher.fetch("https://example.com/svg", DEFAULT_IMAGE_MAX_BYTES)
+
+        with self.assertRaises(ValueError):
+            fetcher.fetch("https://example.com/oversized", DEFAULT_IMAGE_MAX_BYTES)
+
+        fetched = fetcher.fetch("https://example.com/ok", DEFAULT_IMAGE_MAX_BYTES)
+        self.assertEqual(fetched.content_type, "image/png")
+        self.assertEqual((fetched.width, fetched.height), (220, 220))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud-run/ria-intelligence-api/tests/test_image_scraper.py
+++ b/cloud-run/ria-intelligence-api/tests/test_image_scraper.py
@@ -1,0 +1,456 @@
+"""Tests for the upgraded image scraper with rich extraction methods."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+import httpx
+from bs4 import BeautifulSoup
+
+from app.image_scraper import (
+    ImageScraper,
+    _extract_best_logo,
+    _extract_css_background_images,
+    _extract_json_ld_images,
+    _extract_og_image,
+    _extract_picture_sources,
+    _extract_twitter_image,
+    _filter_relevant_source_urls,
+    _is_tiny_asset,
+    _parse_srcset_largest,
+    _resolve_img_urls,
+)
+from app.models import ImageCandidate, RIAProfile
+
+
+def _make_profile(**overrides) -> RIAProfile:
+    defaults = {
+        "existsOnFinra": True,
+        "crdNumber": "12345",
+        "fullName": "Jane Doe",
+        "currentFirm": "Northstar Advisors",
+        "location": "Tampa, Florida",
+    }
+    defaults.update(overrides)
+    return RIAProfile.model_validate(defaults)
+
+
+def _soup(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
+
+
+class SrcsetTests(unittest.TestCase):
+    """Tests for srcset parsing — should choose the largest valid asset."""
+
+    def test_srcset_chooses_largest_width_descriptor(self):
+        url, width = _parse_srcset_largest(
+            "https://example.com/small.jpg 400w, https://example.com/large.jpg 1200w",
+            "https://example.com",
+        )
+        self.assertEqual(url, "https://example.com/large.jpg")
+        self.assertEqual(width, 1200)
+
+    def test_srcset_with_three_entries(self):
+        url, width = _parse_srcset_largest(
+            "thumb.jpg 200w, medium.jpg 600w, full.jpg 1800w",
+            "https://example.com/",
+        )
+        self.assertEqual(url, "https://example.com/full.jpg")
+        self.assertEqual(width, 1800)
+
+    def test_srcset_with_x_descriptors(self):
+        url, width = _parse_srcset_largest(
+            "photo.jpg 1x, photo@2x.jpg 2x",
+            "https://example.com/",
+        )
+        self.assertEqual(url, "https://example.com/photo@2x.jpg")
+        self.assertEqual(width, 2)
+
+    def test_srcset_no_descriptors_fallback(self):
+        url, width = _parse_srcset_largest(
+            "https://example.com/only.jpg",
+            "https://example.com",
+        )
+        self.assertEqual(url, "https://example.com/only.jpg")
+        self.assertEqual(width, 0)
+
+    def test_srcset_empty(self):
+        url, width = _parse_srcset_largest("", "https://example.com")
+        self.assertIsNone(url)
+        self.assertEqual(width, 0)
+
+
+class ImgUrlResolutionTests(unittest.TestCase):
+    """Tests for _resolve_img_urls — srcset, data-src, data-lazy-src, standard src."""
+
+    def test_data_src_extracted(self):
+        html = '<img data-src="https://example.com/lazy-photo.jpg" src="data:image/gif;base64,R0lGOD">'
+        soup = _soup(html)
+        img = soup.find("img")
+        urls = _resolve_img_urls(img, "https://example.com")
+        self.assertIn("https://example.com/lazy-photo.jpg", urls)
+        # data: URLs should be excluded
+        self.assertTrue(all(not u.startswith("data:") for u in urls))
+
+    def test_data_lazy_src_extracted(self):
+        html = '<img data-lazy-src="https://example.com/lazy.jpg" src="placeholder.png">'
+        soup = _soup(html)
+        img = soup.find("img")
+        urls = _resolve_img_urls(img, "https://example.com")
+        self.assertIn("https://example.com/lazy.jpg", urls)
+
+    def test_srcset_img_tag(self):
+        html = '<img srcset="https://example.com/sm.jpg 400w, https://example.com/lg.jpg 1200w" src="https://example.com/sm.jpg">'
+        soup = _soup(html)
+        img = soup.find("img")
+        urls = _resolve_img_urls(img, "https://example.com")
+        # Should pick the largest from srcset
+        self.assertIn("https://example.com/lg.jpg", urls)
+
+    def test_data_srcset_extracted(self):
+        html = '<img data-srcset="https://example.com/a.jpg 800w, https://example.com/b.jpg 1600w">'
+        soup = _soup(html)
+        img = soup.find("img")
+        urls = _resolve_img_urls(img, "https://example.com")
+        self.assertIn("https://example.com/b.jpg", urls)
+
+    def test_relative_src_resolved(self):
+        html = '<img src="/images/photo.jpg">'
+        soup = _soup(html)
+        img = soup.find("img")
+        urls = _resolve_img_urls(img, "https://example.com")
+        self.assertIn("https://example.com/images/photo.jpg", urls)
+
+
+class PictureSourceTests(unittest.TestCase):
+    """Tests for <picture><source> extraction."""
+
+    def test_picture_source_picks_largest(self):
+        html = """
+        <picture>
+            <source srcset="https://example.com/small.webp 400w, https://example.com/large.webp 1200w" type="image/webp">
+            <img src="https://example.com/fallback.jpg" alt="Jane Doe">
+        </picture>
+        """
+        soup = _soup(html)
+        candidates = _extract_picture_sources(soup, "https://example.com", "website", "Jane Doe")
+        self.assertTrue(len(candidates) >= 1)
+        self.assertEqual(candidates[0].image_url, "https://example.com/large.webp")
+
+    def test_picture_fallback_to_img(self):
+        html = """
+        <picture>
+            <img src="https://example.com/photo.jpg" alt="Jane Doe team headshot">
+        </picture>
+        """
+        soup = _soup(html)
+        candidates = _extract_picture_sources(soup, "https://example.com", "website", "Jane Doe")
+        # Should pick the <img> fallback with score >= 55
+        urls = [c.image_url for c in candidates]
+        self.assertIn("https://example.com/photo.jpg", urls)
+
+
+class TwitterImageTests(unittest.TestCase):
+    """Tests for twitter:image meta extraction."""
+
+    def test_twitter_image_name_attr(self):
+        html = '<html><head><meta name="twitter:image" content="https://example.com/tw-photo.jpg"></head></html>'
+        soup = _soup(html)
+        candidate = _extract_twitter_image(soup, "https://example.com", "website", "Jane Doe")
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.image_url, "https://example.com/tw-photo.jpg")
+        self.assertEqual(candidate.candidate_type, "headshot")
+
+    def test_twitter_image_property_attr(self):
+        html = '<html><head><meta property="twitter:image" content="https://example.com/tw2.jpg"></head></html>'
+        soup = _soup(html)
+        candidate = _extract_twitter_image(soup, "https://example.com", "website", "Jane")
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.image_url, "https://example.com/tw2.jpg")
+
+    def test_twitter_image_logo_detection(self):
+        html = '<html><head><meta name="twitter:image" content="https://example.com/company-logo.png"></head></html>'
+        soup = _soup(html)
+        candidate = _extract_twitter_image(soup, "https://example.com", "website", "Jane")
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.candidate_type, "logo")
+
+    def test_no_twitter_image(self):
+        html = "<html><head><title>No twitter meta</title></head></html>"
+        soup = _soup(html)
+        candidate = _extract_twitter_image(soup, "https://example.com", "website", "Jane")
+        self.assertIsNone(candidate)
+
+
+class JsonLdTests(unittest.TestCase):
+    """Tests for JSON-LD image extraction."""
+
+    def test_person_json_ld_image(self):
+        ld = json.dumps({
+            "@type": "Person",
+            "name": "Jane Doe",
+            "image": "https://example.com/jane-headshot.jpg",
+        })
+        html = f'<script type="application/ld+json">{ld}</script>'
+        soup = _soup(html)
+        candidates = _extract_json_ld_images(soup, "https://example.com", "website", "Jane Doe")
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].image_url, "https://example.com/jane-headshot.jpg")
+        self.assertEqual(candidates[0].candidate_type, "headshot")
+
+    def test_organization_json_ld_image(self):
+        ld = json.dumps({
+            "@type": "Organization",
+            "name": "Northstar Advisors",
+            "image": {"url": "https://example.com/org-logo.png"},
+        })
+        html = f'<script type="application/ld+json">{ld}</script>'
+        soup = _soup(html)
+        candidates = _extract_json_ld_images(soup, "https://example.com", "website", "Jane")
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].image_url, "https://example.com/org-logo.png")
+        self.assertEqual(candidates[0].candidate_type, "logo")
+
+    def test_json_ld_image_array(self):
+        ld = json.dumps({
+            "@type": "Person",
+            "image": [
+                "https://example.com/photo1.jpg",
+                "https://example.com/photo2.jpg",
+            ],
+        })
+        html = f'<script type="application/ld+json">{ld}</script>'
+        soup = _soup(html)
+        candidates = _extract_json_ld_images(soup, "https://example.com", "website", "Jane")
+        self.assertEqual(len(candidates), 2)
+
+    def test_invalid_json_ld_skipped(self):
+        html = '<script type="application/ld+json">not json at all</script>'
+        soup = _soup(html)
+        candidates = _extract_json_ld_images(soup, "https://example.com", "website", "Jane")
+        self.assertEqual(len(candidates), 0)
+
+
+class CssBackgroundImageTests(unittest.TestCase):
+    """Tests for CSS background-image extraction."""
+
+    def test_background_image_with_name_match(self):
+        html = '''
+        <div class="team-member" style="background-image: url(https://example.com/jane-headshot.jpg)">
+            <h3>Jane Doe</h3>
+            <p>Financial Advisor</p>
+        </div>
+        '''
+        soup = _soup(html)
+        candidates = _extract_css_background_images(soup, "https://example.com", "website", "Jane Doe")
+        self.assertTrue(len(candidates) >= 1)
+        self.assertEqual(candidates[0].image_url, "https://example.com/jane-headshot.jpg")
+        self.assertEqual(candidates[0].candidate_type, "headshot")
+        self.assertGreaterEqual(candidates[0].confidence, 78)
+
+    def test_background_image_with_quotes(self):
+        html = '''<div style="background-image: url('https://example.com/bg-photo.jpg')">Content</div>'''
+        soup = _soup(html)
+        candidates = _extract_css_background_images(soup, "https://example.com", "website", "Someone Else")
+        self.assertTrue(len(candidates) >= 1)
+        self.assertEqual(candidates[0].image_url, "https://example.com/bg-photo.jpg")
+
+    def test_no_background_image(self):
+        html = '<div style="color: red;">No bg image</div>'
+        soup = _soup(html)
+        candidates = _extract_css_background_images(soup, "https://example.com", "website", "Jane")
+        self.assertEqual(len(candidates), 0)
+
+
+class TinyAssetRejectionTests(unittest.TestCase):
+    """Tests for favicon/tiny icon rejection."""
+
+    def test_favicon_is_tiny(self):
+        self.assertTrue(_is_tiny_asset("https://example.com/favicon.ico"))
+        self.assertTrue(_is_tiny_asset("https://example.com/favicon-32x32.png"))
+
+    def test_apple_touch_icon_is_tiny(self):
+        self.assertTrue(_is_tiny_asset("https://example.com/apple-touch-icon.png"))
+
+    def test_small_icons_detected(self):
+        self.assertTrue(_is_tiny_asset("https://example.com/icon-16x16.png"))
+        self.assertTrue(_is_tiny_asset("https://example.com/assets/icons/check.png"))
+
+    def test_real_images_not_tiny(self):
+        self.assertFalse(_is_tiny_asset("https://example.com/team/jane-doe-headshot.jpg"))
+        self.assertFalse(_is_tiny_asset("https://example.com/images/company-logo.png"))
+
+    def test_best_logo_skips_favicon_picks_real_logo(self):
+        html = """
+        <html>
+        <head>
+            <link rel="shortcut icon" href="https://example.com/favicon.ico">
+            <link rel="apple-touch-icon" sizes="180x180" href="https://example.com/apple-touch-icon.png">
+        </head>
+        <body>
+            <img src="https://example.com/images/company-logo-512.png" alt="Company Logo" class="site-logo" width="512" height="128">
+        </body>
+        </html>
+        """
+        soup = _soup(html)
+        logo = _extract_best_logo(soup, "https://example.com", "Example Corp")
+        self.assertIsNotNone(logo)
+        # Should pick the large logo, not the favicon/apple-touch-icon
+        self.assertEqual(logo.image_url, "https://example.com/images/company-logo-512.png")
+        self.assertEqual(logo.candidate_type, "logo")
+
+
+class GroundedSourceFilterTests(unittest.TestCase):
+    """Tests for filtering grounded source URLs for relevance."""
+
+    def test_person_name_in_url_is_relevant(self):
+        urls = [
+            "https://northstar.example/team/jane-doe",
+            "https://unrelated.example/random-page",
+        ]
+        relevant = _filter_relevant_source_urls(urls, "Jane Doe", "Northstar Advisors", None)
+        self.assertIn("https://northstar.example/team/jane-doe", relevant)
+        self.assertNotIn("https://unrelated.example/random-page", relevant)
+
+    def test_firm_name_in_url_is_relevant(self):
+        urls = ["https://example.com/northstar-advisors-review"]
+        relevant = _filter_relevant_source_urls(urls, "Jane Doe", "Northstar Advisors", None)
+        self.assertIn("https://example.com/northstar-advisors-review", relevant)
+
+    def test_team_keyword_in_path_is_relevant(self):
+        urls = ["https://somefirm.example/about-us"]
+        relevant = _filter_relevant_source_urls(urls, "Jane Doe", "Acme", None)
+        self.assertIn("https://somefirm.example/about-us", relevant)
+
+    def test_linkedin_profile_is_relevant(self):
+        urls = ["https://www.linkedin.com/in/jane-doe-12345"]
+        relevant = _filter_relevant_source_urls(urls, "Jane Doe", "Acme", None)
+        self.assertIn("https://www.linkedin.com/in/jane-doe-12345", relevant)
+
+    def test_irrelevant_domains_filtered(self):
+        urls = [
+            "https://en.wikipedia.org/wiki/Financial_advisor",
+            "https://www.youtube.com/watch?v=123",
+            "https://www.facebook.com/page",
+            "https://www.reddit.com/r/investing",
+        ]
+        relevant = _filter_relevant_source_urls(urls, "Jane Doe", "Acme", None)
+        self.assertEqual(len(relevant), 0)
+
+    def test_aliases_considered(self):
+        urls = ["https://firm.example/team/jane-smith"]
+        relevant = _filter_relevant_source_urls(
+            urls, "Jane Doe", "Acme",
+            other_names=["Jane Smith", "J. Doe"],
+        )
+        self.assertIn("https://firm.example/team/jane-smith", relevant)
+
+    def test_finra_and_sec_always_relevant(self):
+        urls = [
+            "https://brokercheck.finra.org/individual/summary/12345",
+            "https://www.sec.gov/cgi-bin/browse-ia?action=getcompany",
+        ]
+        relevant = _filter_relevant_source_urls(urls, "Nobody", "Nonexistent", None)
+        self.assertEqual(len(relevant), 2)
+
+    def test_duplicates_deduped(self):
+        urls = [
+            "https://example.com/team/jane-doe",
+            "https://example.com/team/jane-doe",
+            "https://example.com/team/jane-doe/",
+        ]
+        relevant = _filter_relevant_source_urls(urls, "Jane Doe", "Acme", None)
+        # Should have at most 2 (with and without trailing slash)
+        self.assertLessEqual(len(relevant), 2)
+
+
+class OgImageTests(unittest.TestCase):
+    """Tests for og:image extraction (backward compat)."""
+
+    def test_og_image_extracted(self):
+        html = '<html><head><meta property="og:image" content="https://example.com/og-photo.jpg"></head></html>'
+        soup = _soup(html)
+        candidate = _extract_og_image(soup, "https://example.com", "website", "Jane")
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.image_url, "https://example.com/og-photo.jpg")
+
+    def test_og_image_logo_detected(self):
+        html = '<html><head><meta property="og:image" content="https://example.com/site-logo.png"></head></html>'
+        soup = _soup(html)
+        candidate = _extract_og_image(soup, "https://example.com", "website", "Jane")
+        self.assertIsNotNone(candidate)
+        self.assertEqual(candidate.candidate_type, "logo")
+
+
+class IntegrationTests(unittest.TestCase):
+    """Integration tests for the full ImageScraper.discover_candidates flow."""
+
+    def test_grounded_sources_are_passed_and_crawled(self):
+        """When grounded source URLs are passed, relevant ones are crawled."""
+        profile = _make_profile(websiteUrl=None, linkedinUrl=None, twitterUrl=None)
+
+        # Create a mock client that returns a team page with a headshot
+        transport = httpx.MockTransport(self._make_team_page_handler("Jane Doe"))
+        client = httpx.Client(transport=transport)
+        scraper = ImageScraper(client=client)
+
+        candidates = scraper.discover_candidates(
+            profile,
+            grounded_source_urls=[
+                "https://northstar.example/team/jane-doe",
+                "https://en.wikipedia.org/wiki/Financial_advisor",  # should be filtered
+            ],
+        )
+
+        # Should have found candidates from the team page
+        urls = [c.imageUrl for c in candidates]
+        self.assertTrue(
+            any("jane-doe-headshot" in url for url in urls),
+            f"Expected headshot URL in {urls}",
+        )
+
+    def test_no_candidates_returns_empty(self):
+        """When no relevant pages exist, returns empty list."""
+        profile = _make_profile(
+            websiteUrl=None, linkedinUrl=None, twitterUrl=None, crdNumber=None,
+        )
+        transport = httpx.MockTransport(lambda req: httpx.Response(404))
+        client = httpx.Client(transport=transport)
+        scraper = ImageScraper(client=client)
+
+        candidates = scraper.discover_candidates(profile)
+        self.assertEqual(len(candidates), 0)
+
+    def _make_team_page_handler(self, person_name: str):
+        name_slug = person_name.lower().replace(" ", "-")
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            html = f"""
+            <html>
+            <head>
+                <meta property="og:image" content="https://northstar.example/images/{name_slug}-headshot.jpg">
+                <meta name="twitter:image" content="https://northstar.example/images/{name_slug}-tw.jpg">
+                <script type="application/ld+json">
+                {{"@type": "Person", "name": "{person_name}", "image": "https://northstar.example/images/{name_slug}-ld.jpg"}}
+                </script>
+            </head>
+            <body>
+                <div class="team-member" style="background-image: url('https://northstar.example/images/{name_slug}-bg.jpg')">
+                    <h3>{person_name}</h3>
+                </div>
+                <img src="https://northstar.example/images/{name_slug}-photo.jpg" alt="{person_name} headshot" width="300" height="300">
+            </body>
+            </html>
+            """
+            return httpx.Response(
+                200,
+                content=html.encode(),
+                headers={"Content-Type": "text/html"},
+            )
+
+        return handler
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud-run/ria-intelligence-api/tests/test_openai_dossier.py
+++ b/cloud-run/ria-intelligence-api/tests/test_openai_dossier.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import unittest
+
+from app.models import ImageCandidate, RIAProfile
+from app.prompts import (
+    DOSSIER_SYSTEM_PROMPT,
+    IMAGE_RANK_SYSTEM_PROMPT,
+    STAGE1_SYSTEM_PROMPT,
+    build_dossier_user_prompt,
+    build_image_rank_user_prompt,
+    build_stage1_user_prompt,
+)
+from app.service import _normalize_dossier_payload, _parse_json_object
+
+
+class DossierPromptTests(unittest.TestCase):
+    def test_stage1_prompt_contains_query_and_regulatory_instructions(self) -> None:
+        prompt = build_stage1_user_prompt("ANA ROUMENOVA CARTER")
+
+        self.assertIn("ANA ROUMENOVA CARTER", prompt)
+        self.assertIn("FINRA or SEC public records", prompt)
+        self.assertIn("Do not include social URLs", prompt)
+        self.assertIn("regulatory verification assistant", STAGE1_SYSTEM_PROMPT)
+
+    def test_dossier_prompt_contains_seed_context_and_tasks(self) -> None:
+        profile = RIAProfile.model_validate(
+            {
+                "existsOnFinra": True,
+                "fullName": "ANA ROUMENOVA CARTER",
+                "currentFirm": "LCG CAPITAL ADVISORS, LLC",
+                "location": "Tampa, Florida",
+                "crdNumber": "4424794",
+                "websiteUrl": "https://cartanaconsulting.com",
+            }
+        )
+
+        prompt = build_dossier_user_prompt(profile)
+
+        self.assertIn('"fullName": "ANA ROUMENOVA CARTER"', prompt)
+        self.assertIn('"crdNumber": "4424794"', prompt)
+        self.assertIn("Find official/public professional links", prompt)
+        self.assertIn("Find publicly accessible image URLs", prompt)
+        self.assertIn("exact web prompts/search phrases", prompt)
+        self.assertIn("source-backed dossier", DOSSIER_SYSTEM_PROMPT)
+
+    def test_image_rank_prompt_contains_subject_and_candidates(self) -> None:
+        profile = RIAProfile.model_validate(
+            {
+                "existsOnFinra": True,
+                "fullName": "ANA ROUMENOVA CARTER",
+                "crdNumber": "4424794",
+                "currentFirm": "LCG CAPITAL ADVISORS, LLC",
+                "location": "Tampa, Florida",
+            }
+        )
+        prompt = build_image_rank_user_prompt(
+            profile,
+            [
+                ImageCandidate(
+                    imageUrl="https://images.example/ana.jpg",
+                    sourcePageUrl="https://www.linkedin.com/in/ana-carter",
+                    platform="linkedin",
+                    candidateType="headshot",
+                    confidence=97,
+                )
+            ],
+        )
+
+        self.assertIn('"full_name": "ANA ROUMENOVA CARTER"', prompt)
+        self.assertIn('"image_url": "https://images.example/ana.jpg"', prompt)
+        self.assertIn("Prefer the best public headshot", prompt)
+        self.assertIn("public image verification and ranking assistant", IMAGE_RANK_SYSTEM_PROMPT)
+
+
+class DossierParsingTests(unittest.TestCase):
+    def test_parse_json_object_extracts_prose_wrapped_json(self) -> None:
+        text = """
+        I found a usable dossier.
+        {
+          "subject": {"full_name": "ANA ROUMENOVA CARTER", "crd_number": "4424794", "current_firm": "LCG CAPITAL ADVISORS, LLC", "location": "Tampa, Florida"},
+          "executive_summary": "Ana Carter summary",
+          "verified_profiles": [],
+          "public_images": [],
+          "key_facts": [],
+          "unverified_or_not_found": [],
+          "prompts_used": ["ana carter linkedin"]
+        }
+        """
+
+        payload = _parse_json_object(text)
+
+        self.assertEqual(payload["subject"]["full_name"], "ANA ROUMENOVA CARTER")
+        self.assertEqual(payload["prompts_used"], ["ana carter linkedin"])
+
+    def test_normalize_dossier_payload_fills_from_seed(self) -> None:
+        profile = RIAProfile.model_validate(
+            {
+                "existsOnFinra": True,
+                "fullName": "ANA ROUMENOVA CARTER",
+                "currentFirm": "LCG CAPITAL ADVISORS, LLC",
+                "location": "Tampa, Florida",
+                "crdNumber": "4424794",
+            }
+        )
+
+        payload = _normalize_dossier_payload(
+            {
+                "subject": {
+                    "full_name": "Wrong Name",
+                    "crd_number": "99999",
+                    "current_firm": "Wrong Firm",
+                    "location": "Wrong City",
+                },
+                "verified_profiles": [],
+            },
+            profile,
+        )
+
+        self.assertEqual(payload["subject"]["full_name"], "ANA ROUMENOVA CARTER")
+        self.assertEqual(payload["subject"]["crd_number"], "4424794")
+        self.assertEqual(payload["subject"]["current_firm"], "LCG CAPITAL ADVISORS, LLC")
+        self.assertEqual(payload["subject"]["location"], "Tampa, Florida")
+        self.assertEqual(payload["verified_profiles"], [])
+        self.assertEqual(payload["public_images"], [])
+        self.assertIn("Exact web prompts/search phrases were not available", payload["unverified_or_not_found"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud-run/ria-intelligence-api/tests/test_service.py
+++ b/cloud-run/ria-intelligence-api/tests/test_service.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+import json
+import unittest
+from types import SimpleNamespace
+
+from app.models import ImageCandidate
+from app.service import InvalidQueryError, RIAIntelligenceService, RIAUpstreamError
+
+
+def make_vertex_response(payload: dict, sources: list[tuple[str, str]] | None = None) -> SimpleNamespace:
+    grounding_chunks = [
+        {"web": {"title": title, "uri": uri}}
+        for title, uri in (sources or [])
+    ]
+    return SimpleNamespace(
+        text=json.dumps(payload),
+        candidates=[
+            {
+                "grounding_metadata": {
+                    "grounding_chunks": grounding_chunks,
+                }
+            }
+        ],
+    )
+
+
+def make_openai_response(payload: dict) -> SimpleNamespace:
+    return SimpleNamespace(output_text=json.dumps(payload))
+
+
+class FakeVertexModels:
+    def __init__(self, scripted_results: list[object]) -> None:
+        self._scripted_results = list(scripted_results)
+        self.calls: list[dict[str, object]] = []
+
+    def generate_content(self, **kwargs) -> object:
+        self.calls.append(kwargs)
+        next_item = self._scripted_results.pop(0)
+        if isinstance(next_item, Exception):
+            raise next_item
+        return next_item
+
+
+class FakeVertexClient:
+    def __init__(self, scripted_results: list[object]) -> None:
+        self.models = FakeVertexModels(scripted_results)
+
+
+class FakeOpenAIResponses:
+    def __init__(self, scripted_results: list[object]) -> None:
+        self._scripted_results = list(scripted_results)
+        self.calls: list[dict[str, object]] = []
+
+    def create(self, **kwargs) -> object:
+        self.calls.append(kwargs)
+        next_item = self._scripted_results.pop(0)
+        if isinstance(next_item, Exception):
+            raise next_item
+        return next_item
+
+
+class FakeOpenAIClient:
+    def __init__(self, scripted_results: list[object]) -> None:
+        self.responses = FakeOpenAIResponses(scripted_results)
+
+
+class FakeImageScraper:
+    def __init__(
+        self,
+        result: list[ImageCandidate] | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.result = result or []
+        self.error = error
+        self.calls: list[dict[str, object]] = []
+
+    def discover_candidates(
+        self,
+        profile,
+        *,
+        model_candidates=None,
+        gemini_candidates=None,
+        grounded_source_urls=None,
+    ):
+        self.calls.append(
+            {
+                "profile": profile,
+                "model_candidates": model_candidates,
+                "gemini_candidates": gemini_candidates,
+                "grounded_source_urls": grounded_source_urls,
+            }
+        )
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def stage1_verified_response() -> SimpleNamespace:
+    return make_vertex_response(
+        {
+            "existsOnFinra": True,
+            "crdNumber": "4424794",
+            "fullName": "ANA ROUMENOVA CARTER",
+            "currentFirm": "LCG CAPITAL ADVISORS, LLC",
+            "location": "Tampa, Florida",
+            "websiteUrl": "https://cartanaconsulting.com",
+            "yearsOfExperience": 17,
+            "regulatedBy": "FINRA",
+        },
+        sources=[
+            (
+                "BrokerCheck Report - ANA ROUMENOVA CARTER",
+                "https://files.brokercheck.finra.org/individual/individual_4424794.pdf",
+            )
+        ],
+    )
+
+
+def stage2_dossier_response() -> SimpleNamespace:
+    return make_openai_response(
+        {
+            "subject": {
+                "full_name": "ANA ROUMENOVA CARTER",
+                "crd_number": "4424794",
+                "current_firm": "Some Other Firm Should Not Win",
+                "location": "Tampa, Florida",
+            },
+            "executive_summary": "Ana Carter is a finance executive and outsourced FINOP.",
+            "verified_profiles": [
+                {
+                    "platform": "LinkedIn",
+                    "label": "Ana Carter LinkedIn profile",
+                    "url": "https://www.linkedin.com/in/anacarter01/",
+                    "handle": "anacarter01",
+                    "source_title": "About Cartana",
+                    "source_url": "https://cartanaconsulting.com/about-cartana/",
+                    "evidence_note": "Official company page links directly to LinkedIn.",
+                },
+                {
+                    "platform": "Company Website",
+                    "label": "Cartana Consulting Solutions",
+                    "url": "https://cartanaconsulting.com",
+                    "handle": None,
+                    "source_title": "Cartana Consulting Solutions",
+                    "source_url": "https://cartanaconsulting.com",
+                    "evidence_note": "Official company site.",
+                },
+            ],
+            "public_images": [
+                {
+                    "kind": "headshot",
+                    "image_url": "https://images.example/ana-raw.jpg",
+                    "source_page_url": "https://cartanaconsulting.com/about-cartana/",
+                    "source_title": "About Cartana",
+                    "confidence_note": "Public headshot candidate.",
+                }
+            ],
+            "key_facts": [
+                {
+                    "fact": "Founder of Cartana Consulting Solutions.",
+                    "source_title": "About Cartana",
+                    "source_url": "https://cartanaconsulting.com/about-cartana/",
+                    "evidence_note": "Official company biography.",
+                }
+            ],
+            "unverified_or_not_found": ["No verified public X/Twitter profile was confirmed."],
+            "prompts_used": ["Ana Roumenova Carter LinkedIn"],
+        }
+    )
+
+
+class RIAIntelligenceServiceTests(unittest.TestCase):
+    def test_stage1_verified_then_phase2_success_returns_dossier(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient([stage1_verified_response()]),
+            openai_client=FakeOpenAIClient(
+                [
+                    stage2_dossier_response(),
+                    make_openai_response(
+                        {
+                            "public_images": [
+                                {
+                                    "kind": "headshot",
+                                    "image_url": "https://images.example/ana-final.jpg",
+                                    "source_page_url": "https://cartanaconsulting.com/about-cartana/",
+                                    "source_title": "About Cartana",
+                                    "confidence_note": "Best public headshot.",
+                                }
+                            ]
+                        }
+                    ),
+                ]
+            ),
+            image_scraper=FakeImageScraper(
+                result=[
+                    ImageCandidate(
+                        imageUrl="https://images.example/ana-final.jpg",
+                        sourcePageUrl="https://cartanaconsulting.com/about-cartana/",
+                        platform="website",
+                        candidateType="headshot",
+                        confidence=97,
+                    )
+                ]
+            ),
+        )
+
+        result = service.get_ria_profile({"query": "ANA ROUMENOVA CARTER"})
+
+        self.assertEqual(result.subject.full_name, "ANA ROUMENOVA CARTER")
+        self.assertEqual(result.subject.crd_number, "4424794")
+        self.assertEqual(result.subject.current_firm, "LCG CAPITAL ADVISORS, LLC")
+        self.assertEqual(result.subject.location, "Tampa, Florida")
+        self.assertEqual(result.executive_summary, "Ana Carter is a finance executive and outsourced FINOP.")
+        self.assertEqual(result.verified_profiles[0].platform, "FINRA BrokerCheck")
+        self.assertEqual(result.verified_profiles[0].url, "https://files.brokercheck.finra.org/individual/individual_4424794.pdf")
+        self.assertEqual(result.verified_profiles[1].url, "https://www.linkedin.com/in/anacarter01/")
+        self.assertEqual(result.public_images[0].image_url, "https://images.example/ana-final.jpg")
+        self.assertEqual(result.key_facts[0].fact, "Founder of Cartana Consulting Solutions.")
+        self.assertEqual(result.prompts_used, ["Ana Roumenova Carter LinkedIn"])
+        self.assertIn("No verified public X/Twitter profile was confirmed.", result.unverified_or_not_found)
+
+    def test_stage1_not_found_skips_phase2(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient(
+                [
+                    make_vertex_response(
+                        {
+                            "existsOnFinra": False,
+                            "reasonIfNotExists": "No confident FINRA or SEC match was found for the query.",
+                        }
+                    )
+                ]
+            ),
+            openai_client=FakeOpenAIClient([]),
+            image_scraper=FakeImageScraper(),
+        )
+
+        result = service.get_ria_profile({"query": "Unknown Person"})
+
+        self.assertEqual(result.subject.full_name, "Unknown Person")
+        self.assertIsNone(result.subject.crd_number)
+        self.assertEqual(result.verified_profiles, [])
+        self.assertEqual(result.public_images, [])
+        self.assertEqual(result.key_facts, [])
+        self.assertEqual(result.prompts_used, [])
+        self.assertIn("No confident FINRA or SEC match was found", result.unverified_or_not_found[0])
+
+    def test_missing_query_raises_invalid_query(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient([]),
+            openai_client=FakeOpenAIClient([]),
+            image_scraper=FakeImageScraper(),
+        )
+
+        with self.assertRaises(InvalidQueryError):
+            service.get_ria_profile({})
+
+    def test_blank_query_raises_invalid_query(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient([]),
+            openai_client=FakeOpenAIClient([]),
+            image_scraper=FakeImageScraper(),
+        )
+
+        with self.assertRaises(InvalidQueryError):
+            service.get_ria_profile({"query": "   "})
+
+    def test_stage1_full_failure_raises_upstream_error(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient(
+                [
+                    RuntimeError("primary unavailable"),
+                    RuntimeError("fallback unavailable"),
+                ]
+            ),
+            openai_client=FakeOpenAIClient([]),
+            image_scraper=FakeImageScraper(),
+        )
+
+        with self.assertRaises(RIAUpstreamError):
+            service.get_ria_profile({"query": "ANA ROUMENOVA CARTER"})
+
+    def test_phase2_failure_raises_upstream_error(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient([stage1_verified_response()]),
+            openai_client=FakeOpenAIClient([RuntimeError("openai unavailable")]),
+            image_scraper=FakeImageScraper(),
+        )
+
+        with self.assertRaises(RIAUpstreamError):
+            service.get_ria_profile({"query": "ANA ROUMENOVA CARTER"})
+
+    def test_image_ranking_failure_falls_back_to_local_public_image(self) -> None:
+        service = RIAIntelligenceService(
+            vertex_client=FakeVertexClient([stage1_verified_response()]),
+            openai_client=FakeOpenAIClient(
+                [
+                    stage2_dossier_response(),
+                    RuntimeError("vision ranking unavailable"),
+                ]
+            ),
+            image_scraper=FakeImageScraper(
+                result=[
+                    ImageCandidate(
+                        imageUrl="https://images.example/ana-final.jpg",
+                        sourcePageUrl="https://cartanaconsulting.com/about-cartana/",
+                        platform="website",
+                        candidateType="headshot",
+                        confidence=95,
+                    )
+                ]
+            ),
+        )
+
+        result = service.get_ria_profile({"query": "ANA ROUMENOVA CARTER"})
+
+        self.assertEqual(result.public_images[0].image_url, "https://images.example/ana-final.jpg")
+        self.assertTrue(
+            any("OpenAI image ranking failed" in warning for warning in result.unverified_or_not_found)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/RIA_INTELLIGENCE_API.md
+++ b/docs/RIA_INTELLIGENCE_API.md
@@ -1,0 +1,162 @@
+# RIA Intelligence API
+
+## Summary
+
+The public API is query-first:
+
+1. client sends `{ "query": "<advisor or firm name>" }`
+2. Phase 1 verifies the query against FINRA and SEC public records using Gemini on Vertex AI
+3. the verified Phase 1 profile is passed into OpenAI Responses API as seed JSON
+4. backend scrapes public image source pages and ranks validated image candidates
+5. API returns the final dossier JSON only
+
+This version does not generate DOCX, markdown, HTML, or stored file artifacts.
+
+## Endpoint
+
+### `POST /v1/ria/profile`
+
+Request:
+
+```json
+{
+  "query": "ANA ROUMENOVA CARTER"
+}
+```
+
+Response:
+
+```json
+{
+  "subject": {
+    "full_name": "ANA ROUMENOVA CARTER",
+    "crd_number": "4424794",
+    "current_firm": "LCG CAPITAL ADVISORS, LLC",
+    "location": "Tampa, Florida"
+  },
+  "executive_summary": "Ana Carter is a finance executive and outsourced FINOP.",
+  "verified_profiles": [
+    {
+      "platform": "FINRA BrokerCheck",
+      "label": "BrokerCheck Report - ANA ROUMENOVA CARTER",
+      "url": "https://files.brokercheck.finra.org/individual/individual_4424794.pdf",
+      "handle": null,
+      "source_title": "BrokerCheck Report - ANA ROUMENOVA CARTER",
+      "source_url": "https://files.brokercheck.finra.org/individual/individual_4424794.pdf",
+      "evidence_note": "Official regulatory source captured during Phase 1 verification."
+    }
+  ],
+  "public_images": [
+    {
+      "kind": "headshot",
+      "image_url": "https://images.example/ana-final.jpg",
+      "source_page_url": "https://cartanaconsulting.com/about-cartana/",
+      "source_title": "About Cartana",
+      "confidence_note": "Best public headshot among validated candidates."
+    }
+  ],
+  "key_facts": [
+    {
+      "fact": "Founder of Cartana Consulting Solutions.",
+      "source_title": "About Cartana",
+      "source_url": "https://cartanaconsulting.com/about-cartana/",
+      "evidence_note": "Official company biography."
+    }
+  ],
+  "unverified_or_not_found": [],
+  "prompts_used": [
+    "Ana Roumenova Carter LinkedIn"
+  ]
+}
+```
+
+## Response Contract
+
+- `subject`: final verified identity summary, with Phase 1 values taking precedence
+- `executive_summary`: source-backed summary from OpenAI dossier research
+- `verified_profiles`: official regulatory URLs plus other confidently verified public profiles
+- `public_images`: validated public image URLs only
+- `key_facts`: source-backed facts only
+- `unverified_or_not_found`: missing, ambiguous, or unverified items
+- `prompts_used`: search phrases returned by structured output when available
+
+## Behavior
+
+- Blank query returns `400`
+- Phase 1 verified plus OpenAI dossier success returns `200` with dossier JSON
+- Phase 1 verified plus image-ranking fallback still returns `200` with dossier JSON
+- Phase 1 no confident FINRA or SEC match still returns `200` with:
+  - `subject.full_name` from the query
+  - `subject.crd_number = null`
+  - `subject.current_firm = null`
+  - `subject.location = null`
+  - empty `verified_profiles`, `public_images`, `key_facts`
+  - not-found reason in `unverified_or_not_found`
+  - empty `prompts_used`
+- Upstream Phase 1 or OpenAI failure before a usable dossier exists returns `502`
+
+## Image Flow
+
+- OpenAI research returns public image and source-page evidence
+- backend fetches source pages and extracts candidates from:
+  - `meta[property="og:image"]`
+  - `meta[name="twitter:image"]`
+  - `<img>`
+- a second OpenAI pass ranks shortlisted images
+- if image ranking fails, the service falls back to locally validated candidates
+- this endpoint returns public image URLs only and does not upload images to GCS
+
+## Models
+
+- Phase 1 verification:
+  - primary: `gemini-3.1-pro-preview`
+  - fallback: `gemini-2.5-pro`
+- OpenAI dossier research:
+  - `gpt-5.4`
+- OpenAI image ranking:
+  - `gpt-5.4-mini`
+
+## Environment
+
+Required:
+
+- `GOOGLE_CLOUD_PROJECT`
+- `OPENAI_API_KEY`
+
+Optional:
+
+- `GOOGLE_CLOUD_LOCATION=global`
+- `RIA_PRIMARY_MODEL=gemini-3.1-pro-preview`
+- `RIA_FALLBACK_MODEL=gemini-2.5-pro`
+- `OPENAI_MODEL=gpt-5.4`
+- `OPENAI_IMAGE_RANK_MODEL=gpt-5.4-mini`
+- `OPENAI_TIMEOUT_SECONDS=90`
+- `PORT=8080`
+
+## Local Run
+
+```bash
+cd cloud-run/ria-intelligence-api
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID
+export GOOGLE_CLOUD_LOCATION=global
+export OPENAI_API_KEY=YOUR_OPENAI_KEY
+uvicorn app.main:app --reload
+```
+
+## Deploy
+
+```bash
+./scripts/deploy-ria-intelligence-api.sh \
+  --project YOUR_PROJECT_ID \
+  --region us-central1 \
+  --openai-api-key-secret YOUR_SECRET_NAME
+```
+
+## Security
+
+- keep `OPENAI_API_KEY` server-side only
+- prefer Secret Manager injection for Cloud Run
+- if a key was shared in chat on March 21, 2026, rotate it before production use

--- a/scripts/deploy-ria-intelligence-api.sh
+++ b/scripts/deploy-ria-intelligence-api.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SERVICE_NAME="hushh-ria-intelligence-api"
+REGION="us-central1"
+PROJECT_ID=""
+SERVICE_ACCOUNT=""
+MEMORY="1Gi"
+CPU="1"
+MIN_INSTANCES="1"
+MAX_INSTANCES="10"
+CONCURRENCY="8"
+TIMEOUT="600s"
+GOOGLE_CLOUD_LOCATION="global"
+RIA_PRIMARY_MODEL="gemini-3.1-pro-preview"
+RIA_FALLBACK_MODEL="gemini-2.5-pro"
+OPENAI_MODEL="gpt-5.4"
+OPENAI_IMAGE_RANK_MODEL="gpt-5.4-mini"
+OPENAI_TIMEOUT_SECONDS="90"
+OPENAI_API_KEY_SECRET=""
+SOURCE_DIR="cloud-run/ria-intelligence-api"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT_ID="$2"; shift 2 ;;
+    --region) REGION="$2"; shift 2 ;;
+    --service) SERVICE_NAME="$2"; shift 2 ;;
+    --service-account) SERVICE_ACCOUNT="$2"; shift 2 ;;
+    --memory) MEMORY="$2"; shift 2 ;;
+    --cpu) CPU="$2"; shift 2 ;;
+    --min-instances) MIN_INSTANCES="$2"; shift 2 ;;
+    --max-instances) MAX_INSTANCES="$2"; shift 2 ;;
+    --concurrency) CONCURRENCY="$2"; shift 2 ;;
+    --timeout) TIMEOUT="$2"; shift 2 ;;
+    --google-cloud-location) GOOGLE_CLOUD_LOCATION="$2"; shift 2 ;;
+    --ria-primary-model) RIA_PRIMARY_MODEL="$2"; shift 2 ;;
+    --ria-fallback-model) RIA_FALLBACK_MODEL="$2"; shift 2 ;;
+    --openai-model) OPENAI_MODEL="$2"; shift 2 ;;
+    --openai-image-rank-model) OPENAI_IMAGE_RANK_MODEL="$2"; shift 2 ;;
+    --openai-timeout-seconds) OPENAI_TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --openai-api-key-secret) OPENAI_API_KEY_SECRET="$2"; shift 2 ;;
+    --help|-h)
+      echo "Usage: $0 [--project PROJECT_ID] [--region REGION] [--service NAME] [--service-account EMAIL] [--google-cloud-location LOCATION] [--ria-primary-model MODEL] [--ria-fallback-model MODEL] [--openai-api-key-secret SECRET_NAME]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID="$(gcloud config get-value project 2>/dev/null || true)"
+fi
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "No GCP project configured. Use --project or run: gcloud config set project YOUR_PROJECT_ID"
+  exit 1
+fi
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "Source directory not found: $SOURCE_DIR"
+  exit 1
+fi
+
+echo "===================================================="
+echo "Deploying Hushh RIA Intelligence API"
+echo "  Project:             $PROJECT_ID"
+echo "  Service:             $SERVICE_NAME"
+echo "  Region:              $REGION"
+echo "  Source:              $SOURCE_DIR"
+echo "  Memory / CPU:        $MEMORY / $CPU"
+echo "  Min / Max:           $MIN_INSTANCES / $MAX_INSTANCES"
+echo "  Concurrency:         $CONCURRENCY"
+echo "  Timeout:             $TIMEOUT"
+echo "  GCP location:        $GOOGLE_CLOUD_LOCATION"
+echo "  RIA primary model:   $RIA_PRIMARY_MODEL"
+echo "  RIA fallback model:  $RIA_FALLBACK_MODEL"
+echo "  OpenAI model:        $OPENAI_MODEL"
+echo "  Image rank model:    $OPENAI_IMAGE_RANK_MODEL"
+echo "  OpenAI timeout:      ${OPENAI_TIMEOUT_SECONDS}s"
+if [[ -n "$OPENAI_API_KEY_SECRET" ]]; then
+  echo "  OpenAI key secret:   $OPENAI_API_KEY_SECRET"
+else
+  echo "  OpenAI key secret:   (not set; service will require external env/secret injection)"
+fi
+if [[ -n "$SERVICE_ACCOUNT" ]]; then
+  echo "  Service account:     $SERVICE_ACCOUNT"
+else
+  echo "  Service account:     (Cloud Run default)"
+fi
+echo "===================================================="
+
+gcloud services enable run.googleapis.com cloudbuild.googleapis.com artifactregistry.googleapis.com --project="$PROJECT_ID" >/dev/null
+
+ENV_VARS="GOOGLE_CLOUD_PROJECT=${PROJECT_ID},GOOGLE_CLOUD_LOCATION=${GOOGLE_CLOUD_LOCATION},RIA_PRIMARY_MODEL=${RIA_PRIMARY_MODEL},RIA_FALLBACK_MODEL=${RIA_FALLBACK_MODEL},OPENAI_MODEL=${OPENAI_MODEL},OPENAI_IMAGE_RANK_MODEL=${OPENAI_IMAGE_RANK_MODEL},OPENAI_TIMEOUT_SECONDS=${OPENAI_TIMEOUT_SECONDS}"
+
+DEPLOY_ARGS=(
+  run deploy "$SERVICE_NAME"
+  --source "$SOURCE_DIR"
+  --project "$PROJECT_ID"
+  --region "$REGION"
+  --platform managed
+  --allow-unauthenticated
+  --memory "$MEMORY"
+  --cpu "$CPU"
+  --min-instances "$MIN_INSTANCES"
+  --max-instances "$MAX_INSTANCES"
+  --concurrency "$CONCURRENCY"
+  --cpu-boost
+  --timeout "$TIMEOUT"
+  --set-env-vars "$ENV_VARS"
+  --quiet
+)
+
+if [[ -n "$OPENAI_API_KEY_SECRET" ]]; then
+  DEPLOY_ARGS+=(--set-secrets "OPENAI_API_KEY=${OPENAI_API_KEY_SECRET}:latest")
+fi
+
+if [[ -n "$SERVICE_ACCOUNT" ]]; then
+  DEPLOY_ARGS+=(--service-account "$SERVICE_ACCOUNT")
+fi
+
+gcloud "${DEPLOY_ARGS[@]}"
+
+SERVICE_URL="$(gcloud run services describe "$SERVICE_NAME" --project "$PROJECT_ID" --region "$REGION" --format='value(status.url)')"
+
+echo ""
+echo "Deployment complete"
+echo "Service URL: $SERVICE_URL"
+echo ""
+echo "Recommended setup:"
+echo "  Store OPENAI_API_KEY in Secret Manager and deploy with --openai-api-key-secret SECRET_NAME."
+echo "  Rotate any previously exposed OpenAI API key before production use."
+echo "  This deploy helper keeps 1 warm instance and enables startup CPU boost to reduce cold-start latency."


### PR DESCRIPTION
## Summary
- add the standalone Cloud Run RIA intelligence API service
- implement query -> FINRA/SEC Phase 1 -> OpenAI dossier JSON flow
- add deployment script, API docs, and automated tests

## Testing
- python3 -m py_compile cloud-run/ria-intelligence-api/app/*.py cloud-run/ria-intelligence-api/tests/*.py
- source /tmp/ria-intelligence-venv/bin/activate && cd cloud-run/ria-intelligence-api && python -m unittest discover -s tests -v
- live curl check against Cloud Run for ANA ROUMENOVA CARTER

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched RIA Intelligence API service with `/v1/ria/profile` endpoint enabling profile lookup, automatic image discovery, and public profile dossier generation.
  * Added health check endpoints (`/health`, `/healthz`) for service status monitoring.

* **Documentation**
  * Added comprehensive README and deployment guide for the RIA Intelligence API.
  * Included Cloud Run deployment script with environment configuration and secret management support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->