### PR TITLE
chore: bump app version to 1.3.1 — CI/CD pipeline verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="google-site-verification" content="NGkmaMm7bqtQ1y8EfcHbYg4DozGnurZ-xeYCJtJ8J0g" />
     <meta name="google-site-verification" content="OKGA8f_h2AxAqs3qyPBc3VW9i3HNktJNtbjxU-YXh4s" />
-    
+
     <!-- Google Analytics 4 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-R58S9WWPM0"></script>
     <script>
@@ -16,12 +16,12 @@
       gtag('js', new Date());
       gtag('config', 'G-R58S9WWPM0');
     </script>
-    
+
     <!-- Google Fonts - Playfair Display, Manrope, JetBrains Mono, Inter -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Manrope:wght@300;400;500;600&family=JetBrains+Mono:wght@400&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    
+
     <!-- Google Material Symbols -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
 
@@ -34,7 +34,8 @@
       gtag('config', 'G-R58S9WWPM0');
     </script>
 
-    <meta name="app-version" content="1.3.0" />
+    <meta name="app-version" content="1.3.1" />
+    <meta name="deploy-verified" content="2026-04-01T16:27:00Z" />
     <title>Hushh Technologies</title>
   </head>
   <body>


### PR DESCRIPTION
## What
- Bumps app-version meta tag from 1.3.0 → 1.3.1
- Adds deploy-verified meta tag with timestamp

## Why
End-to-end CI/CD pipeline verification — confirming that:
1. PR checks pass (tests, lint, build)
2. Merge to main triggers deploy-prod.yml
3. Change reflects on hushhtech.com

## How to verify
After merge + deploy, run:
```bash
curl -s https://hushhtech.com | grep 'app-version'
```
Expected: `content="1.3.1"`