### PR TITLE
chore: bump app version to 1.3.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@
       gtag('config', 'G-R58S9WWPM0');
     </script>
 
-    <meta name="app-version" content="1.3.1" />
-    <meta name="deploy-verified" content="2026-04-01T16:27:00Z" />
+    <meta name="app-version" content="1.3.2" />
+    <meta name="deploy-verified" content="2026-04-01T18:02:00Z" />
     <title>Hushh Technologies</title>
   </head>
   <body>


### PR DESCRIPTION
Bump app-version meta tag from 1.3.1 → 1.3.2 to verify CI/CD pipeline deploys to production correctly.