### PR TITLE
[codex] fix kai-india startup crash

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import HomePage from './pages/home/ui';
@@ -74,7 +74,6 @@ import HushhAIPage from './hushh-ai/pages';
 import { LoginPage as HushhAILoginPage, SignupPage as HushhAISignupPage } from './hushh-ai/presentation/pages';
 import HushhAgentApp from './hushh-agent/pages';
 import KaiApp from './kai/pages';
-import KaiIndiaApp from './kai-india/pages';
 import HushhStudioApp from './hushh-studio/pages';
 import HushhAgentsApp from './hushh-agents/pages';
 import GlobalNDAGate from './components/GlobalNDAGate';
@@ -84,6 +83,7 @@ import NDAAdminPage from './pages/nda-admin';
 
 // Google Analytics configuration
 const GA_TRACKING_ID = 'G-R58S9WWPM0';
+const KaiIndiaApp = React.lazy(() => import('./kai-india/pages'));
 
 // Content wrapper component that applies conditional margin
 const ContentWrapper = ({ children }: { children: ReactNode }) => {
@@ -439,7 +439,14 @@ function App() {
             <Route path='/kai' element={<KaiApp />} />
             {/* Kai India - Indian Market Intelligence Dashboard */}
             {/* Real-time NSE/BSE market data powered by Gemini 2.5 Flash with Google Search */}
-            <Route path='/kai-india' element={<KaiIndiaApp />} />
+            <Route
+              path='/kai-india'
+              element={
+                <Suspense fallback={<div className="min-h-screen bg-black" />}>
+                  <KaiIndiaApp />
+                </Suspense>
+              }
+            />
             {/* Hushh Studio - FREE AI Video Generation */}
             {/* Powered by Google Veo 3.1 - No login required, free for Indian audience */}
             <Route path='/studio' element={<HushhStudioApp />} />

--- a/src/kai-india/services/geminiService.ts
+++ b/src/kai-india/services/geminiService.ts
@@ -23,12 +23,27 @@ const isValidMarketItem = (item: MarketItem): boolean => {
   return true;
 };
 
-const ai = new GoogleGenAI({ apiKey: import.meta.env.VITE_GEMINI_API_KEY });
+let aiClient: GoogleGenAI | null = null;
+
+const getAiClient = (): GoogleGenAI => {
+  if (aiClient) {
+    return aiClient;
+  }
+
+  const apiKey = import.meta.env.VITE_GEMINI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("Kai India is unavailable because VITE_GEMINI_API_KEY is not configured.");
+  }
+
+  aiClient = new GoogleGenAI({ apiKey });
+  return aiClient;
+};
 
 // Retry wrapper for API calls with exponential backoff
 const generateWithRetry = async (model: string, prompt: string, tools?: any[]) => {
   let retries = 3;
   let delay = 2000;
+  const ai = getAiClient();
 
   while (true) {
     try {


### PR DESCRIPTION
## What changed

This change isolates the Kai India module so it can no longer take down the main website when `VITE_GEMINI_API_KEY` is missing in production.

- lazy-load the `/kai-india` route in the main app router
- stop creating the Gemini client at module import time in the Kai India service
- instantiate the Gemini client only when Kai India is actually used

## Why it changed

`hushhtech.com` was loading the Kai India module on app startup. On the apex production deployment, `VITE_GEMINI_API_KEY` was not present, and the Kai India service was constructing `GoogleGenAI` during module import. That caused a startup crash in Chromium and left the homepage blank.

## User impact

- the main homepage can render even when Kai India is not configured
- Kai India now fails only when that route is used and the key is missing
- the production homepage is protected from this specific class of startup failure

## Root cause

The Kai India Gemini client was initialized at import time instead of at feature-use time, and the route was eagerly imported into the main app bundle.

## Validation

- `npx vite build`
- reproduced the Chromium blank-page failure against production before the fix
- verified the fix compiles cleanly after rebasing on `origin/main`
