### PR TITLE
fix: include Apple wallet type in shared payload

### DIFF
--- a/api/shared/walletPassModel.js
+++ b/api/shared/walletPassModel.js
@@ -75,6 +75,7 @@ export const buildGoldPassPayload = (input = {}) => {
   const content = buildWalletCardContent(input);
 
   return {
+    type: "storeCard",
     passType: "storeCard",
     description: content.title,
     organizationName: WALLET_CARD_ORGANIZATION_NAME,

--- a/tests/walletPass.test.ts
+++ b/tests/walletPass.test.ts
@@ -52,6 +52,7 @@ describe("wallet pass service", () => {
     expect(form?.getAttribute("method")).toBe("POST");
     expect(payloadInput).not.toBeNull();
     expect(JSON.parse(payloadInput!.value)).toMatchObject({
+      type: "storeCard",
       passType: "storeCard",
       description: "Hushh Gold Investor Pass",
       barcode: { message: "https://hushhtech.com/investor/test-user" },


### PR DESCRIPTION
## Summary
- add the upstream-required Apple Wallet `type` field to the shared pass payload
- keep `passType` in place for compatibility
- extend the wallet payload test to lock the contract

## Testing
- npx vitest run tests/walletPass.test.ts tests/walletApiRoutes.test.ts tests/googleWalletLocalRoute.test.ts
- npm run build