### PR TITLE
fix: move Gemini API key server-side via /api/gemini-proxy, remove VITE_ browser exposure

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -111,34 +111,21 @@ VITE_ALLOW_INSECURE_BROWSER_LLM=false
 VITE_VOICE_AGENT_URL=https://YOUR_PROJECT_REF.supabase.co/functions/v1/voice-agent-turn
 
 # =====================================================
-# Gemini API Configuration
+# Gemini API Configuration — SERVER SIDE ONLY
 # =====================================================
-# Google Gemini API keys for active AI experiences such as Kai and Studio.
-#
-# DEV / TRANSITIONAL SETUP:
-# Any Gemini key under VITE_* is visible to the browser bundle.
-# Keep these only for local debugging or temporary browser-only flows.
+# These keys are used exclusively by api/gemini-proxy.js
+# NO VITE_ prefix — never shipped in the browser bundle.
+# Client code must call /api/gemini-proxy instead of
+# hitting the Gemini API directly from the browser.
 #
 # Create API keys at: https://aistudio.google.com/apikey
-# - Create 4 separate API keys for redundancy
-# - Name them clearly so rotation is easy to manage
+# - Create 4 separate keys for rotation on quota errors
 # - All keys should have NO expiry date
 #
-# Primary API key (required)
-VITE_GEMINI_API_KEY=YOUR_DEV_ONLY_GEMINI_API_KEY
-
-# Fallback API keys (optional but recommended for production)
-# These are also browser-visible when set under VITE_*
-VITE_GEMINI_API_KEY_FALLBACK_1=YOUR_DEV_ONLY_GEMINI_FALLBACK_KEY_1
-VITE_GEMINI_API_KEY_FALLBACK_2=YOUR_DEV_ONLY_GEMINI_FALLBACK_KEY_2
-VITE_GEMINI_API_KEY_FALLBACK_3=YOUR_DEV_ONLY_GEMINI_FALLBACK_KEY_3
-
-# TIP: Do not add these to production unless you accept browser exposure:
-#   - VITE_GEMINI_API_KEY
-#   - VITE_GEMINI_API_KEY_FALLBACK_1
-#   - VITE_GEMINI_API_KEY_FALLBACK_2
-#   - VITE_GEMINI_API_KEY_FALLBACK_3
-
+GEMINI_API_KEY=YOUR_GEMINI_API_KEY
+GEMINI_API_KEY_FALLBACK_1=YOUR_GEMINI_FALLBACK_KEY_1
+GEMINI_API_KEY_FALLBACK_2=YOUR_GEMINI_FALLBACK_KEY_2
+GEMINI_API_KEY_FALLBACK_3=YOUR_GEMINI_FALLBACK_KEY_3
 # =====================================================
 # Plaid Financial Verification (Pre-KYC)
 # =====================================================

--- a/api/gemini-proxy.js
+++ b/api/gemini-proxy.js
@@ -1,0 +1,50 @@
+const FALLBACK_KEYS = [
+  process.env.GEMINI_API_KEY,
+  process.env.GEMINI_API_KEY_FALLBACK_1,
+  process.env.GEMINI_API_KEY_FALLBACK_2,
+  process.env.GEMINI_API_KEY_FALLBACK_3,
+].filter(Boolean);
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (FALLBACK_KEYS.length === 0) {
+    return res.status(500).json({ error: 'No Gemini API keys configured server-side' });
+  }
+
+  const { model = 'gemini-1.5-flash', contents, generationConfig } = req.body;
+
+  if (!contents) {
+    return res.status(400).json({ error: 'Missing required field: contents' });
+  }
+
+  for (const apiKey of FALLBACK_KEYS) {
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ contents, generationConfig }),
+        }
+      );
+
+      if (response.status === 429 || response.status === 403) continue;
+
+      if (!response.ok) {
+        const error = await response.text();
+        return res.status(response.status).json({ error });
+      }
+
+      const data = await response.json();
+      return res.status(200).json(data);
+
+    } catch (err) {
+      continue;
+    }
+  }
+
+  return res.status(503).json({ error: 'All Gemini API keys exhausted or unavailable' });
+}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -39,6 +39,8 @@ const CONFIG = {
     /sk_live_[A-Za-z0-9]+/,  // Stripe live key
     /sk_test_[A-Za-z0-9]+/,  // Stripe test key
     /AKIA[A-Z0-9]{16}/,       // AWS Access Key
+    /VITE_GEMINI_API_KEY/,
+    /VITE_OPENAI_API_KEY/,
   ],
   
   // Files that should trigger extra review


### PR DESCRIPTION
## Summary
- Created api/gemini-proxy.js as a server-side Vercel function to handle 
  all Gemini API calls — mirrors the existing pattern used for OPENAI_API_KEY 
  in api/generate-investor-profile.js
- Removed VITE_GEMINI_API_KEY and all 3 fallback keys from .env.local.example 
  since they were browser-visible under the VITE_ prefix
- Replaced with GEMINI_API_KEY (no VITE_ prefix) so keys stay server-side only
- Patched dangerfile.ts to detect and flag any future VITE_GEMINI_API_KEY 
  or VITE_OPENAI_API_KEY entries in incoming PRs

## Validation
- [x] `npm run test`
- [x] `npx vite build`
- [x] verified api/gemini-proxy.js follows same structure as existing api/ handlers
- [x] security checks — this PR directly addresses credential exposure in the browser bundle

## Notes
- Deployment impact: GEMINI_API_KEY must be set as a server-side environment 
  variable in Vercel — it should never be set under VITE_ prefix in production
- Any existing code calling Gemini directly from the browser must be updated 
  to call /api/gemini-proxy instead
- Follow-up: audit remaining VITE_ prefixed keys to ensure no other secrets 
  are browser-exposed

