### PR TITLE
fix: Add branded 404 Not Found page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ import DocumentViewerPage from './pages/document-viewer';
 import NDAAdminPage from './pages/nda-admin';
 import { AuthSessionProvider, useAuthSession } from './auth/AuthSessionProvider';
 import AuthRequiredRoute from './components/AuthRequiredRoute';
+import NotFoundPage from './pages/not-found/ui';
 
 // Google Analytics configuration
 const GA_TRACKING_ID = 'G-R58S9WWPM0';
@@ -403,6 +404,8 @@ function App() {
             <Route path='/document-viewer' element={<DocumentViewerPage />} />
             {/* NDA Admin Page - Password protected view of all NDA agreements */}
             <Route path='/nda-admin' element={<NDAAdminPage />} />
+            {/* Catch-all 404 Route */}
+            <Route path='*' element={<NotFoundPage />} />
           </Routes>
         </ContentWrapper>
         {showFooter && <Footer />}

--- a/src/pages/not-found/ui.tsx
+++ b/src/pages/not-found/ui.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const playfair = { fontFamily: "'Playfair Display', serif" };
+
+export default function NotFoundPage() {
+  return (
+    <div className="min-h-[80vh] bg-black text-white flex flex-col items-center justify-center p-6 text-center antialiased rounded-3xl mx-4 my-8 md:mx-auto md:max-w-4xl shadow-2xl border border-gray-800">
+      <div className="max-w-md w-full flex flex-col items-center">
+        <h1 className="text-[6rem] md:text-[8rem] font-light tracking-tighter text-gray-500 mb-2 leading-none" style={playfair}>
+          404
+        </h1>
+        <h2 className="text-2xl md:text-3xl font-normal mb-4 tracking-tight" style={playfair}>
+          Page Not Found
+        </h2>
+        <p className="text-gray-400 font-light mb-10 text-sm md:text-base leading-relaxed">
+          The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.
+        </p>
+        
+        <Link 
+          to="/"
+          className="bg-white text-black px-8 py-3.5 rounded-full font-semibold text-sm hover:bg-gray-200 transition-colors duration-200 shadow-md"
+        >
+          Return to Home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**Problem**: Navigating to an unknown route previously resulted in a blank white screen due to a missing catch-all route.

**Fix**:
- Created a new `NotFoundPage` matching the app's dark theme using the Playfair typography.
- Updated `App.tsx` routes with a catch-all `<Route path="*" element={<NotFoundPage />} />`.

**Result**: Unknown URLs now show a branded 404 page with a button to return Home.
closed #440