### PR TITLE
fix: handle rejected auth promises in Hero, LoginPage, SignupPage, HushhAI

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -174,7 +174,7 @@ export default function Hero() {
 
     config.supabaseClient.auth.getSession().then(({ data: { session } }) => {
       setSession(session);
-    });
+    }).catch(console.error);
 
     const { data: { subscription } } = config.supabaseClient.auth.onAuthStateChange((_event, session) => {
       setSession(session);

--- a/src/hushh-ai/pages/index.tsx
+++ b/src/hushh-ai/pages/index.tsx
@@ -130,7 +130,7 @@ export default function HushhAIPage() {
             setPersistedChatId(null);
             navigate('/hushh-ai/login');
           }
-        });
+        }).catch(console.error);
         return;
       }
 

--- a/src/hushh-ai/presentation/pages/LoginPage.tsx
+++ b/src/hushh-ai/presentation/pages/LoginPage.tsx
@@ -90,7 +90,7 @@ export default function HushhAILoginPage() {
       if (session) {
         navigate("/hushh-ai");
       }
-    });
+    }).catch(console.error);
 
     const {
       data: { subscription },

--- a/src/hushh-ai/presentation/pages/SignupPage.tsx
+++ b/src/hushh-ai/presentation/pages/SignupPage.tsx
@@ -90,7 +90,7 @@ export default function HushhAISignupPage() {
       if (session) {
         navigate("/hushh-ai");
       }
-    });
+    }).catch(console.error);
 
     const {
       data: { subscription },

--- a/tests/authPromiseRejection.test.tsx
+++ b/tests/authPromiseRejection.test.tsx
@@ -50,6 +50,23 @@ vi.mock('../src/components/hushh-tech-footer/HushhTechFooter', () => ({
   default: () => React.createElement('div', null, 'footer'),
 }));
 
+vi.mock('../src/auth/AuthSessionProvider', () => ({
+  useAuthSession: () => ({ status: 'anonymous', startOAuth: vi.fn() }),
+  AuthSessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// ─── Mock: hushhAI service (used by HushhAIPage) ──────────────────────────────
+const isAuthenticatedMock = vi.fn();
+const onAuthChangeMock = vi.fn(() => () => {});
+
+vi.mock('../src/hushh-ai/services/hushhAIService', () => ({
+  isAuthenticated: () => isAuthenticatedMock(),
+  onAuthChange: () => onAuthChangeMock(),
+  getChats: () => Promise.resolve([]),
+  getOrCreateUser: () => Promise.resolve(null),
+  getMediaLimits: () => Promise.resolve(null),
+}));
+
 // ─── Helper ───────────────────────────────────────────────────────────────────
 const wrap = (component: React.ReactElement) =>
   React.createElement(
@@ -74,7 +91,11 @@ describe('auth path promise rejection handling', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: isAuthenticated resolves false (unauthenticated, no redirect loop)
+    isAuthenticatedMock.mockResolvedValue(false);
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+    Element.prototype.scrollIntoView = vi.fn();
 
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
@@ -148,6 +169,25 @@ describe('auth path promise rejection handling', () => {
       await flush();
 
       expect(consoleErrorSpy).toHaveBeenCalledWith(networkError);
+    });
+  });
+
+  describe('HushhAIPage — cached auth background verification', () => {
+    it('logs the error when background isAuthenticated rejects', async () => {
+      const networkError = new Error('service unreachable');
+      // Simulate cached auth (fast path) so the background verify runs
+      sessionStorage.setItem('hushh_ai_auth_cached', 'true');
+      isAuthenticatedMock.mockRejectedValue(networkError);
+
+      const HushhAIPage = (await import('../src/hushh-ai/pages/index')).default;
+
+      await act(async () => {
+        root.render(wrap(React.createElement(HushhAIPage)));
+      });
+      await flush();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(networkError);
+      sessionStorage.removeItem('hushh_ai_auth_cached');
     });
   });
 

--- a/tests/authPromiseRejection.test.tsx
+++ b/tests/authPromiseRejection.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for unhandled Promise rejections in auth paths.
+ *
+ * Each component calls supabaseClient.auth.getSession() (or a service
+ * equivalent) in a useEffect and previously had no .catch() handler.
+ * These tests verify that when the call rejects, console.error is invoked
+ * and the component does NOT produce an unhandled rejection.
+ */
+
+import React from 'react';
+import { act } from 'react';
+import { ChakraProvider } from '@chakra-ui/react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import theme from '../src/theme';
+
+// ─── Shared mock: supabase client ─────────────────────────────────────────────
+const getSessionMock = vi.fn();
+const onAuthStateChangeMock = vi.fn(() => ({
+  data: { subscription: { unsubscribe: vi.fn() } },
+}));
+
+vi.mock('../src/resources/config/config', () => ({
+  default: {
+    SUPABASE_URL: 'https://test.supabase.co',
+    SUPABASE_ANON_KEY: 'test-anon-key',
+    redirect_url: 'http://localhost:5173/auth/callback',
+    supabaseClient: {
+      auth: {
+        getSession: () => getSessionMock(),
+        onAuthStateChange: () => onAuthStateChangeMock(),
+      },
+      from: () => ({
+        select: () => ({
+          eq: () => ({ maybeSingle: () => Promise.resolve({ data: null, error: null }) }),
+        }),
+      }),
+    },
+  },
+}));
+
+vi.mock('../src/components/images/Hushhogo.png', () => ({ default: 'logo.png' }));
+vi.mock('../src/components/hushh-tech-header/HushhTechHeader', () => ({
+  default: () => React.createElement('div', null, 'header'),
+}));
+vi.mock('../src/components/hushh-tech-footer/HushhTechFooter', () => ({
+  default: () => React.createElement('div', null, 'footer'),
+}));
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+const wrap = (component: React.ReactElement) =>
+  React.createElement(
+    ChakraProvider,
+    { theme },
+    React.createElement(MemoryRouter, null, component)
+  );
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+describe('auth path promise rejection handling', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let consoleErrorSpy: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('Hero component', () => {
+    it('logs the error when getSession rejects', async () => {
+      const networkError = new Error('network offline');
+      getSessionMock.mockRejectedValue(networkError);
+
+      const Hero = (await import('../src/components/Hero')).default;
+
+      await act(async () => {
+        root.render(wrap(React.createElement(Hero)));
+      });
+      await flush();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(networkError);
+    });
+
+    it('renders the page even when getSession rejects', async () => {
+      getSessionMock.mockRejectedValue(new Error('timeout'));
+
+      const Hero = (await import('../src/components/Hero')).default;
+
+      await act(async () => {
+        root.render(wrap(React.createElement(Hero)));
+      });
+      await flush();
+
+      expect(container.textContent).toContain('Fund A');
+    });
+  });
+
+  describe('Hushh AI LoginPage', () => {
+    it('logs the error when getSession rejects', async () => {
+      const networkError = new Error('auth service unavailable');
+      getSessionMock.mockRejectedValue(networkError);
+
+      const LoginPage = (
+        await import('../src/hushh-ai/presentation/pages/LoginPage')
+      ).default;
+
+      await act(async () => {
+        root.render(wrap(React.createElement(LoginPage)));
+      });
+      await flush();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(networkError);
+    });
+  });
+
+  describe('Hushh AI SignupPage', () => {
+    it('logs the error when getSession rejects', async () => {
+      const networkError = new Error('auth service unavailable');
+      getSessionMock.mockRejectedValue(networkError);
+
+      const SignupPage = (
+        await import('../src/hushh-ai/presentation/pages/SignupPage')
+      ).default;
+
+      await act(async () => {
+        root.render(wrap(React.createElement(SignupPage)));
+      });
+      await flush();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(networkError);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     globals: true,
     environment: 'node',
-    include: ['tests/**/*.test.ts'],
+    include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
     exclude: [
       'node_modules/**',
       // Live Supabase integration suite (disabled until backend/schema is stable again)


### PR DESCRIPTION
### **User description**
## Summary

- Added `.catch(console.error)` to four `getSession()` / `isAuthenticated()` 
  calls in auth-path `useEffect` hooks that had no rejection handler
- Without this, a network error or auth service outage silently breaks 
  the auth state with no log and no user feedback

## Validation

- [x] `npm run test` — 4 new tests pass, no regressions
- [ ] `npx vite build`
- [x] Hero, LoginPage, SignupPage, HushhAI index routes smoke checked

## Notes

- No deployment impact, no env changes needed
- Follow-up: remaining `.then()` chains across the codebase could use 
  the same treatment


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Improves auth robustness by handling promise rejections.

- Adds `.catch(console.error)` to log auth API errors.

- Introduces tests for auth promise rejection scenarios.

- Updates Vitest configuration to test React components.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Auth Flow
      A[Component Mounts] --> B{Auth Call};
      B -- "Promise resolves" --> C[Update UI];
      B -- "Promise rejects" --> D[Log Error];
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Hero.tsx</strong><dd><code>Add error handling for authentication promise</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Hero.tsx

<ul><li>Adds a <code>.catch(console.error)</code> to the <code>getSession()</code> promise chain to <br>handle potential rejections.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/776/files#diff-1cadf8397b7345b9f320a7c7e007a8bc697f2c9deec3085de9bd17e057ac0f0a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Add error handling for authentication check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hushh-ai/pages/index.tsx

<ul><li>Adds a <code>.catch(console.error)</code> to the <code>isAuthenticated()</code> promise chain to <br>handle potential rejections.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/776/files#diff-89c16fbabaff9414e229aae38b5d7a6cf24eec5b15b26f07a9b92adf8f8f1c7b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LoginPage.tsx</strong><dd><code>Add error handling for authentication promise</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hushh-ai/presentation/pages/LoginPage.tsx

<ul><li>Adds a <code>.catch(console.error)</code> to the <code>getSession()</code> promise chain to <br>handle potential rejections.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/776/files#diff-67d42d10d8f998c71b16bba673bd24b8997c8fd87e87ed06f6d4acaccd6b6f76">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SignupPage.tsx</strong><dd><code>Add error handling for authentication promise</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hushh-ai/presentation/pages/SignupPage.tsx

<ul><li>Adds a <code>.catch(console.error)</code> to the <code>getSession()</code> promise chain to <br>handle potential rejections.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/776/files#diff-bd4c30513b78086e384071509f4d433a46dbbc347beb5cddaffa1e101c813d5b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authPromiseRejection.test.tsx</strong><dd><code>Add tests for auth promise rejection handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/authPromiseRejection.test.tsx

<ul><li>Adds a new test suite to verify that rejected auth promises are caught <br>and logged.<br> <li> Mocks the Supabase client and spies on <code>console.error</code> to assert the <br>fix.<br> <li> Covers <code>Hero</code>, <code>LoginPage</code>, <code>SignupPage</code>, and <code>HushhAIPage</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/776/files#diff-9c0171c68f8d984b2ab2c82c1ebcd55dd36dda01b047f34a21e046970e01a19b">+211/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vitest.config.ts</strong><dd><code>Update Vitest config for React component testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

vitest.config.ts

<ul><li>Adds the <code>@vitejs/plugin-react</code> to enable testing of React components.<br> <li> Updates the <code>include</code> pattern to run tests in <code>.tsx</code> files.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/776/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
