### PR TITLE
fix(security): harden server-side vendor API proxies with origin allowlist and rate limit

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -186,3 +186,12 @@ SUPABASE_SERVICE_ROLE_KEY=YOUR_SUPABASE_SERVICE_ROLE_KEY
 N8N_BASIC_AUTH_USER=admin
 N8N_BASIC_AUTH_PASSWORD=your_secure_password
 N8N_ENCRYPTION_KEY=your_32_char_encryption_key_here
+
+# =============================================================================
+# API ENDPOINT HARDENING
+# =============================================================================
+# Comma-separated list of allowed origins for vendor-call API endpoints
+# (generate-investor-profile, enrich-preferences, send-email-notification).
+# In production, restrict to your canonical hosts. Localhost is auto-allowed
+# in non-production via NODE_ENV.
+API_ALLOWED_ORIGINS=https://hushhtech.com,https://hushh-tech.vercel.app

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,5 +14,6 @@ paths = [
   '''^src/components/images/''',
   '''^\.planning/''',
   '''^supabase/\.temp/''',
-  '''^\.env\.local\.example$'''
+  '''^\.env\.local\.example$''',
+  '''tests/apiSecurity\.test\.ts$'''
 ]

--- a/api/enrich-preferences.js
+++ b/api/enrich-preferences.js
@@ -163,7 +163,9 @@ function normalizeBudget(budgetPerNight) {
 }
 
 export default async function handler(request, response) {
-  if (applyCors(request, response)) return;
+  const cors = applyCors(request, response, ['POST']);
+  if (cors.done) return;
+
   if (requireMethod(request, response, ["POST"])) return;
 
   const rl = checkRateLimit(request, {

--- a/api/enrich-preferences.js
+++ b/api/enrich-preferences.js
@@ -1,5 +1,12 @@
 import { parsePhoneNumberFromString } from "libphonenumber-js";
 
+import {
+  applyCors,
+  checkRateLimit,
+  requireMethod,
+  stripSecretsFromError,
+} from "./shared/security.js";
+
 const REQUIRED_FIELDS = [
   "name",
   "email",
@@ -156,8 +163,17 @@ function normalizeBudget(budgetPerNight) {
 }
 
 export default async function handler(request, response) {
-  if (request.method !== "POST") {
-    return response.status(405).json({ error: "Method not allowed" });
+  if (applyCors(request, response)) return;
+  if (requireMethod(request, response, ["POST"])) return;
+
+  const rl = checkRateLimit(request, {
+    key: "enrich-prefs",
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (!rl.allowed) {
+    response.setHeader("Retry-After", String(rl.retryAfterSec));
+    return response.status(429).json({ error: "Too many requests" });
   }
 
   try {
@@ -249,8 +265,7 @@ Rules:
 
     return response.status(200).json({ preferences: parsed });
   } catch (error) {
-    console.error("Enrichment handler failed:", error);
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return response.status(500).json({ error: message });
+    console.error("[enrich-preferences] error:", error);
+    return response.status(500).json({ error: stripSecretsFromError(error) });
   }
 }

--- a/api/generate-investor-profile.js
+++ b/api/generate-investor-profile.js
@@ -3,6 +3,13 @@
  * This runs server-side to avoid CORS issues and keep API keys secure
  */
 
+import {
+  applyCors,
+  checkRateLimit,
+  requireMethod,
+  stripSecretsFromError,
+} from "./shared/security.js";
+
 const SYSTEM_PROMPT = `You are an assistant that PRE-FILLS an INVESTOR PROFILE from minimal information.
 
 You are given:
@@ -100,24 +107,17 @@ const PROFILE_SCHEMA = {
 };
 
 export default async function handler(req, res) {
-  // Set CORS headers
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,PATCH,DELETE,POST,PUT');
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version, Authorization'
-  );
+  if (applyCors(req, res)) return;
+  if (requireMethod(req, res, ['POST'])) return;
 
-  // Handle preflight request
-  if (req.method === 'OPTIONS') {
-    res.status(200).end();
-    return;
-  }
-
-  // Only allow POST requests
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed. Use POST.' });
+  const rl = checkRateLimit(req, {
+    key: 'investor-profile',
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (!rl.allowed) {
+    res.setHeader('Retry-After', String(rl.retryAfterSec));
+    return res.status(429).json({ error: 'Too many requests' });
   }
 
   try {
@@ -215,9 +215,7 @@ export default async function handler(req, res) {
     });
 
   } catch (error) {
-    console.error('Error generating investor profile:', error);
-    return res.status(500).json({ 
-      error: error.message || 'Failed to generate investor profile' 
-    });
+    console.error('[generate-investor-profile] error:', error);
+    return res.status(500).json({ error: stripSecretsFromError(error) });
   }
 }

--- a/api/generate-investor-profile.js
+++ b/api/generate-investor-profile.js
@@ -107,7 +107,9 @@ const PROFILE_SCHEMA = {
 };
 
 export default async function handler(req, res) {
-  if (applyCors(req, res)) return;
+  const cors = applyCors(req, res, ['POST']);
+  if (cors.done) return;
+
   if (requireMethod(req, res, ['POST'])) return;
 
   const rl = checkRateLimit(req, {

--- a/api/send-email-notification.js
+++ b/api/send-email-notification.js
@@ -4,12 +4,12 @@
 import nodemailer from 'nodemailer';
 import { createClient } from '@supabase/supabase-js';
 
-// CORS headers
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-};
+import {
+  applyCors,
+  checkRateLimit,
+  requireMethod,
+  stripSecretsFromError,
+} from './shared/security.js';
 
 function createSupabaseAdminClient() {
   const supabaseUrl = process.env.SUPABASE_URL?.trim();
@@ -52,13 +52,17 @@ async function resolvePublicProfileOwner(slug) {
 }
 
 export default async function handler(req, res) {
-  // Handle CORS preflight
-  if (req.method === 'OPTIONS') {
-    return res.status(200).json({ ok: true });
-  }
+  if (applyCors(req, res)) return;
+  if (requireMethod(req, res, ['POST'])) return;
 
-  if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' });
+  const rl = checkRateLimit(req, {
+    key: 'email-notify',
+    limit: 5,
+    windowMs: 60_000,
+  });
+  if (!rl.allowed) {
+    res.setHeader('Retry-After', String(rl.retryAfterSec));
+    return res.status(429).json({ error: 'Too many requests' });
   }
 
   try {
@@ -186,10 +190,7 @@ export default async function handler(req, res) {
 
     return res.status(200).json({ success: true, emailSent: true });
   } catch (error) {
-    console.error('Email error:', error);
-    return res.status(500).json({ 
-      error: error.message || 'Failed to send email',
-      details: error.toString()
-    });
+    console.error('[send-email-notification] error:', error);
+    return res.status(500).json({ error: stripSecretsFromError(error) });
   }
 }

--- a/api/send-email-notification.js
+++ b/api/send-email-notification.js
@@ -52,7 +52,9 @@ async function resolvePublicProfileOwner(slug) {
 }
 
 export default async function handler(req, res) {
-  if (applyCors(req, res)) return;
+  const cors = applyCors(req, res, ['POST']);
+  if (cors.done) return;
+
   if (requireMethod(req, res, ['POST'])) return;
 
   const rl = checkRateLimit(req, {

--- a/api/shared/security.js
+++ b/api/shared/security.js
@@ -1,26 +1,26 @@
 /**
  * api/shared/security.js
  *
- * Shared security envelope helpers for serverless vendor-proxy endpoints.
- * Four helpers wrap the existing business logic in each handler:
- *   - applyCors             origin allowlist + preflight handling
- *   - checkRateLimit        per-IP sliding-window limiter
- *   - requireMethod         HTTP method guard with Allow header
- *   - stripSecretsFromError redact vendor keys/tokens before responding
+ * Fail-closed security envelope for serverless vendor-proxy endpoints.
  *
- * No npm dependencies; vanilla Node only.
+ * Origin policy: state-changing requests (POST/PUT/PATCH/DELETE) with a
+ * missing or blocked Origin are rejected 403 before any side effect runs.
+ * CORS headers are a browser-side control; this module enforces the policy
+ * server-side so non-browser callers cannot bypass it by omitting headers.
  *
- * Rate-limit scope: the limiter stores counters in module-level memory,
- * so it is best-effort and per-instance. Vercel / Cloud Run can spin up
- * multiple instances, so a determined attacker can still fan out. For
- * durable cross-instance limiting, migrate to the existing
- * `hushh_ai_rate_limits` Supabase table (see api/delete-account-service.js
- * ~line 635). That migration is intentionally out of scope here.
+ * Rate-limit IP: the rightmost X-Forwarded-For entry is the trusted value.
+ * On Vercel and Cloud Run the platform appends exactly one entry (the real
+ * client IP), so rotating the leftmost (caller-controlled) entry does not
+ * change the rate-limit bucket. Client identity is SHA-256(ip|UA) to raise
+ * the cost of evasion. A per-key global cap provides a ceiling even when an
+ * attacker rotates both IP and UA indefinitely.
  */
 
+import { createHash } from 'node:crypto';
+
 const DEFAULT_ALLOWED_ORIGINS = [
-  "https://hushhtech.com",
-  "https://hushh-tech.vercel.app",
+  'https://hushhtech.com',
+  'https://hushh-tech.vercel.app',
 ];
 
 const LOCALHOST_PATTERNS = [
@@ -28,176 +28,219 @@ const LOCALHOST_PATTERNS = [
   /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
 ];
 
+const IDEMPOTENT = new Set(['GET', 'HEAD']);
+
 function parseAllowedOrigins() {
   const raw = process.env.API_ALLOWED_ORIGINS;
-  if (!raw || !raw.trim()) {
-    return [...DEFAULT_ALLOWED_ORIGINS];
-  }
-  return raw
-    .split(",")
-    .map((value) => value.trim())
-    .filter(Boolean);
+  if (!raw?.trim()) return [...DEFAULT_ALLOWED_ORIGINS];
+  return raw.split(',').map((v) => v.trim()).filter(Boolean);
 }
 
 function isOriginAllowed(origin) {
   if (!origin) return false;
-  const allowlist = parseAllowedOrigins();
-  if (allowlist.includes(origin)) return true;
-  if (process.env.NODE_ENV !== "production") {
-    return LOCALHOST_PATTERNS.some((pattern) => pattern.test(origin));
+  const list = parseAllowedOrigins();
+  if (list.includes(origin)) return true;
+  if (process.env.NODE_ENV !== 'production') {
+    return LOCALHOST_PATTERNS.some((p) => p.test(origin));
   }
   return false;
 }
 
 /**
- * Apply CORS headers based on the origin allowlist and handle preflight.
- * Echoes the request origin back only if it is allowlisted; otherwise
- * omits the Access-Control-Allow-Origin header entirely (browsers then
- * block the cross-origin response). Server-to-server callers with no
- * Origin header are allowed through — browsers enforce CORS, not us.
+ * Apply CORS policy and handle OPTIONS preflights. Fails closed: blocked or
+ * missing-Origin state-changing requests are rejected 403; OPTIONS with
+ * missing Origin returns 400. GET/HEAD with missing Origin are allowed through
+ * without CORS headers (same-origin / server-to-server reads).
  *
- * @param {{ method?: string, headers?: Record<string, string|undefined> }} req
- * @param {{ setHeader: (name: string, value: string) => void, status: (code: number) => any, end: () => void }} res
- * @returns {boolean} true when an OPTIONS preflight was handled; caller should early-return.
+ * @param {object} req
+ * @param {object} res
+ * @param {string[]} [allowedMethods] uppercase methods the endpoint accepts
+ * @returns {{ done: boolean, allowed: boolean }}
+ *   done:true  — response already sent; caller must return immediately.
+ *   done:false — continue with handler logic; allowed is always true here.
  */
-export function applyCors(req, res) {
+export function applyCors(req, res, allowedMethods = ['GET', 'POST', 'OPTIONS']) {
   const origin = req?.headers?.origin;
-  if (origin && isOriginAllowed(origin)) {
-    res.setHeader("Access-Control-Allow-Origin", origin);
-    res.setHeader("Vary", "Origin");
-  }
-  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-  res.setHeader("Access-Control-Max-Age", "600");
+  const method = (req?.method || 'GET').toUpperCase();
+  const advertised = [...new Set([...allowedMethods.map((m) => m.toUpperCase()), 'OPTIONS'])];
 
-  if (req?.method === "OPTIONS") {
+  if (method === 'OPTIONS') {
+    if (!origin) {
+      res.status(400).json({ error: 'Invalid preflight' });
+      return { done: true, allowed: false };
+    }
+    if (!isOriginAllowed(origin)) {
+      res.status(403).end();
+      return { done: true, allowed: false };
+    }
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', advertised.join(', '));
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.setHeader('Access-Control-Max-Age', '600');
     res.status(204).end();
-    return true;
+    return { done: true, allowed: true };
   }
-  return false;
-}
 
-/** @type {Map<string, number[]>} */
-const rateLimitStore = new Map();
-
-function resolveClientIp(req) {
-  const xff = req?.headers?.["x-forwarded-for"];
-  if (typeof xff === "string" && xff.length > 0) {
-    const first = xff.split(",")[0];
-    if (first) return first.trim();
+  if (IDEMPOTENT.has(method)) {
+    if (origin && !isOriginAllowed(origin)) {
+      res.status(403).end();
+      return { done: true, allowed: false };
+    }
+    if (origin && isOriginAllowed(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+    }
+    return { done: false, allowed: true };
   }
-  const xri = req?.headers?.["x-real-ip"];
-  if (typeof xri === "string" && xri.length > 0) return xri.trim();
-  return req?.socket?.remoteAddress || "unknown";
+
+  // State-changing methods (POST / PUT / PATCH / DELETE)
+  if (!origin) {
+    console.warn('[security] state-changing request rejected: no Origin');
+    res.status(403).end();
+    return { done: true, allowed: false };
+  }
+  if (!isOriginAllowed(origin)) {
+    res.status(403).end();
+    return { done: true, allowed: false };
+  }
+  res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  return { done: false, allowed: true };
 }
 
 /**
- * Best-effort per-IP sliding-window rate limiter. In-memory, per-instance.
+ * Extract the trusted client identifier from a request.
+ * Uses the rightmost X-Forwarded-For entry (platform-appended on Vercel /
+ * Cloud Run). Falls back to X-Real-IP, socket.remoteAddress, then 'unknown'.
+ * Returns SHA-256(ip|user-agent)[0..16] to raise the cost of pure-IP evasion.
+ * @internal
+ */
+export function _getClientId(req) {
+  const xff = req?.headers?.['x-forwarded-for'];
+  let ip;
+  if (typeof xff === 'string') {
+    const parts = xff.split(',').map((s) => s.trim()).filter(Boolean);
+    if (parts.length > 0) ip = parts[parts.length - 1]; // rightmost = trusted
+  }
+  if (!ip) {
+    const xri = req?.headers?.['x-real-ip'];
+    if (typeof xri === 'string' && xri.trim()) ip = xri.trim();
+  }
+  if (!ip) ip = req?.socket?.remoteAddress || 'unknown';
+  const ua = req?.headers?.['user-agent'] || '';
+  return createHash('sha256').update(`${ip}|${ua}`).digest('hex').slice(0, 16);
+}
+
+/** @type {Map<string, number[]>} per-client sliding-window timestamps */
+const rateLimitStore = new Map();
+/** @type {Map<string, number[]>} per-key global sliding-window timestamps */
+const globalRateLimitStore = new Map();
+
+/**
+ * Sliding-window rate limiter keyed on trusted client identity.
+ * Checks a per-client bucket first, then a per-key global cap that bounds
+ * full-spoof attacks that rotate both IP and User-Agent.
  *
- * @param {{ headers?: Record<string, string|undefined>, socket?: { remoteAddress?: string } }} req
- * @param {{ key: string, limit: number, windowMs: number }} opts
- * @returns {{ allowed: boolean, remaining: number, retryAfterSec: number }}
+ * @param {object} req
+ * @param {{ key: string, limit: number, windowMs: number, globalCap?: number }} opts
+ * @returns {{ allowed: boolean, remaining: number, retryAfterSec: number, reason?: string }}
  */
 export function checkRateLimit(req, opts) {
-  const key = opts?.key || "default";
+  const key = opts?.key || 'default';
   const limit = Number.isFinite(opts?.limit) ? opts.limit : 60;
   const windowMs = Number.isFinite(opts?.windowMs) ? opts.windowMs : 60_000;
-  const ip = resolveClientIp(req);
-  const storeKey = `${key}:${ip}`;
+  const globalCap = Number.isFinite(opts?.globalCap) ? opts.globalCap : limit * 10;
+  const clientId = _getClientId(req);
+  const storeKey = `${key}:${clientId}`;
   const now = Date.now();
 
   const entries = rateLimitStore.get(storeKey) || [];
   const fresh = entries.filter((ts) => now - ts < windowMs);
 
   if (fresh.length >= limit) {
-    const oldest = fresh[0];
-    const retryAfterSec = Math.max(
-      1,
-      Math.ceil((oldest + windowMs - now) / 1000)
-    );
+    const retryAfterSec = Math.max(1, Math.ceil((fresh[0] + windowMs - now) / 1000));
     rateLimitStore.set(storeKey, fresh);
-    return { allowed: false, remaining: 0, retryAfterSec };
+    return { allowed: false, remaining: 0, retryAfterSec, reason: 'per-client' };
+  }
+
+  const gEntries = globalRateLimitStore.get(key) || [];
+  const gFresh = gEntries.filter((ts) => now - ts < windowMs);
+
+  if (gFresh.length >= globalCap) {
+    const retryAfterSec = Math.max(1, Math.ceil((gFresh[0] + windowMs - now) / 1000));
+    globalRateLimitStore.set(key, gFresh);
+    return { allowed: false, remaining: 0, retryAfterSec, reason: 'global' };
   }
 
   fresh.push(now);
   rateLimitStore.set(storeKey, fresh);
-  return {
-    allowed: true,
-    remaining: Math.max(0, limit - fresh.length),
-    retryAfterSec: 0,
-  };
+  gFresh.push(now);
+  globalRateLimitStore.set(key, gFresh);
+  return { allowed: true, remaining: Math.max(0, limit - fresh.length), retryAfterSec: 0 };
 }
 
 /**
- * Clear the in-memory rate-limit store. Intended for tests only.
+ * Clear both rate-limit stores. Intended for tests only.
  * @internal
  */
 export function _resetRateLimitStore() {
   rateLimitStore.clear();
+  globalRateLimitStore.clear();
 }
 
 /**
  * Enforce an allowed-methods list. Returns 405 with an Allow header on
- * mismatch. The caller should early-return when this returns true.
- *
- * @param {{ method?: string }} req
- * @param {{ setHeader: (name: string, value: string) => void, status: (code: number) => any }} res
- * @param {string[]} methods uppercase HTTP methods, e.g. ['POST']
- * @returns {boolean}
+ * mismatch. Caller must early-return when this returns true.
  */
 export function requireMethod(req, res, methods) {
   const allowed = Array.isArray(methods) ? methods : [];
-  if (allowed.includes(req?.method || "")) return false;
-
-  res.setHeader("Allow", allowed.join(", "));
-  res.status(405).json({ error: "Method not allowed" });
+  if (allowed.includes(req?.method || '')) return false;
+  res.setHeader('Allow', allowed.join(', '));
+  res.status(405).json({ error: 'Method not allowed' });
   return true;
 }
 
 const ENV_VAR_NAMES = [
-  "OPENAI_API_KEY",
-  "GEMINI_API_KEY",
-  "SUPABASE_SERVICE_ROLE_KEY",
-  "GMAIL_APP_PASSWORD",
-  "GOOGLE_WALLET_PRIVATE_KEY",
+  'OPENAI_API_KEY',
+  'GEMINI_API_KEY',
+  'SUPABASE_SERVICE_ROLE_KEY',
+  'GMAIL_APP_PASSWORD',
+  'GOOGLE_WALLET_PRIVATE_KEY',
 ];
 
-const SECRET_PATTERNS = [
-  /Bearer\s+[A-Za-z0-9_\-.]+/gi,
-  /sk-[A-Za-z0-9_\-]{20,}/g,
-  /AIza[0-9A-Za-z_\-]{20,}/g,
-];
+const SECRET_PATTERN_REPLACEMENTS = /** @type {[RegExp, string][]} */ ([
+  [/Bearer\s+[A-Za-z0-9_\-.]+/gi, '[redacted]'],
+  [/sk-[A-Za-z0-9_\-]{20,}/g, '[redacted]'],
+  [/AIza[0-9A-Za-z_\-]{20,}/g, '[redacted]'],
+  // Query-string secret params: ?api_key=VALUE or &token=VALUE etc.
+  [/(\?|&)(api[_-]?key|token|access[_-]?token|secret|password)=[^&\s]+/gi, '$1$2=[redacted]'],
+]);
 
 /**
- * Convert an error-like value to a client-safe string. Redacts common
- * vendor secrets and literal env var names. Never leaks stack traces.
- *
- * @param {unknown} err
- * @returns {string}
+ * Convert an error-like value to a client-safe string. Redacts common vendor
+ * secrets, env var names, and query-string secret parameters.
  */
 export function stripSecretsFromError(err) {
-  if (err === null || err === undefined) return "Internal error";
-
+  if (err === null || err === undefined) return 'Internal error';
   let message;
-  if (typeof err === "string") {
+  if (typeof err === 'string') {
     message = err;
   } else if (err instanceof Error) {
-    message = err.message || "";
-  } else if (typeof err === "object") {
-    message = typeof err.message === "string" ? err.message : "";
+    message = err.message || '';
+  } else if (typeof err === 'object') {
+    message = typeof err.message === 'string' ? err.message : '';
   } else {
     message = String(err);
   }
-
-  if (!message) return "Internal error";
-
+  if (!message) return 'Internal error';
   let out = message;
   for (const name of ENV_VAR_NAMES) {
-    out = out.split(name).join("[redacted]");
+    out = out.split(name).join('[redacted]');
   }
-  for (const pattern of SECRET_PATTERNS) {
-    out = out.replace(pattern, "[redacted]");
+  for (const [pattern, replacement] of SECRET_PATTERN_REPLACEMENTS) {
+    out = out.replace(pattern, replacement);
   }
-  if (!out.trim()) return "Internal error";
+  if (!out.trim()) return 'Internal error';
   return out;
 }

--- a/api/shared/security.js
+++ b/api/shared/security.js
@@ -1,0 +1,203 @@
+/**
+ * api/shared/security.js
+ *
+ * Shared security envelope helpers for serverless vendor-proxy endpoints.
+ * Four helpers wrap the existing business logic in each handler:
+ *   - applyCors             origin allowlist + preflight handling
+ *   - checkRateLimit        per-IP sliding-window limiter
+ *   - requireMethod         HTTP method guard with Allow header
+ *   - stripSecretsFromError redact vendor keys/tokens before responding
+ *
+ * No npm dependencies; vanilla Node only.
+ *
+ * Rate-limit scope: the limiter stores counters in module-level memory,
+ * so it is best-effort and per-instance. Vercel / Cloud Run can spin up
+ * multiple instances, so a determined attacker can still fan out. For
+ * durable cross-instance limiting, migrate to the existing
+ * `hushh_ai_rate_limits` Supabase table (see api/delete-account-service.js
+ * ~line 635). That migration is intentionally out of scope here.
+ */
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  "https://hushhtech.com",
+  "https://hushh-tech.vercel.app",
+];
+
+const LOCALHOST_PATTERNS = [
+  /^https?:\/\/localhost(:\d+)?$/,
+  /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
+];
+
+function parseAllowedOrigins() {
+  const raw = process.env.API_ALLOWED_ORIGINS;
+  if (!raw || !raw.trim()) {
+    return [...DEFAULT_ALLOWED_ORIGINS];
+  }
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function isOriginAllowed(origin) {
+  if (!origin) return false;
+  const allowlist = parseAllowedOrigins();
+  if (allowlist.includes(origin)) return true;
+  if (process.env.NODE_ENV !== "production") {
+    return LOCALHOST_PATTERNS.some((pattern) => pattern.test(origin));
+  }
+  return false;
+}
+
+/**
+ * Apply CORS headers based on the origin allowlist and handle preflight.
+ * Echoes the request origin back only if it is allowlisted; otherwise
+ * omits the Access-Control-Allow-Origin header entirely (browsers then
+ * block the cross-origin response). Server-to-server callers with no
+ * Origin header are allowed through — browsers enforce CORS, not us.
+ *
+ * @param {{ method?: string, headers?: Record<string, string|undefined> }} req
+ * @param {{ setHeader: (name: string, value: string) => void, status: (code: number) => any, end: () => void }} res
+ * @returns {boolean} true when an OPTIONS preflight was handled; caller should early-return.
+ */
+export function applyCors(req, res) {
+  const origin = req?.headers?.origin;
+  if (origin && isOriginAllowed(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+    res.setHeader("Vary", "Origin");
+  }
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Max-Age", "600");
+
+  if (req?.method === "OPTIONS") {
+    res.status(204).end();
+    return true;
+  }
+  return false;
+}
+
+/** @type {Map<string, number[]>} */
+const rateLimitStore = new Map();
+
+function resolveClientIp(req) {
+  const xff = req?.headers?.["x-forwarded-for"];
+  if (typeof xff === "string" && xff.length > 0) {
+    const first = xff.split(",")[0];
+    if (first) return first.trim();
+  }
+  const xri = req?.headers?.["x-real-ip"];
+  if (typeof xri === "string" && xri.length > 0) return xri.trim();
+  return req?.socket?.remoteAddress || "unknown";
+}
+
+/**
+ * Best-effort per-IP sliding-window rate limiter. In-memory, per-instance.
+ *
+ * @param {{ headers?: Record<string, string|undefined>, socket?: { remoteAddress?: string } }} req
+ * @param {{ key: string, limit: number, windowMs: number }} opts
+ * @returns {{ allowed: boolean, remaining: number, retryAfterSec: number }}
+ */
+export function checkRateLimit(req, opts) {
+  const key = opts?.key || "default";
+  const limit = Number.isFinite(opts?.limit) ? opts.limit : 60;
+  const windowMs = Number.isFinite(opts?.windowMs) ? opts.windowMs : 60_000;
+  const ip = resolveClientIp(req);
+  const storeKey = `${key}:${ip}`;
+  const now = Date.now();
+
+  const entries = rateLimitStore.get(storeKey) || [];
+  const fresh = entries.filter((ts) => now - ts < windowMs);
+
+  if (fresh.length >= limit) {
+    const oldest = fresh[0];
+    const retryAfterSec = Math.max(
+      1,
+      Math.ceil((oldest + windowMs - now) / 1000)
+    );
+    rateLimitStore.set(storeKey, fresh);
+    return { allowed: false, remaining: 0, retryAfterSec };
+  }
+
+  fresh.push(now);
+  rateLimitStore.set(storeKey, fresh);
+  return {
+    allowed: true,
+    remaining: Math.max(0, limit - fresh.length),
+    retryAfterSec: 0,
+  };
+}
+
+/**
+ * Clear the in-memory rate-limit store. Intended for tests only.
+ * @internal
+ */
+export function _resetRateLimitStore() {
+  rateLimitStore.clear();
+}
+
+/**
+ * Enforce an allowed-methods list. Returns 405 with an Allow header on
+ * mismatch. The caller should early-return when this returns true.
+ *
+ * @param {{ method?: string }} req
+ * @param {{ setHeader: (name: string, value: string) => void, status: (code: number) => any }} res
+ * @param {string[]} methods uppercase HTTP methods, e.g. ['POST']
+ * @returns {boolean}
+ */
+export function requireMethod(req, res, methods) {
+  const allowed = Array.isArray(methods) ? methods : [];
+  if (allowed.includes(req?.method || "")) return false;
+
+  res.setHeader("Allow", allowed.join(", "));
+  res.status(405).json({ error: "Method not allowed" });
+  return true;
+}
+
+const ENV_VAR_NAMES = [
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "GMAIL_APP_PASSWORD",
+  "GOOGLE_WALLET_PRIVATE_KEY",
+];
+
+const SECRET_PATTERNS = [
+  /Bearer\s+[A-Za-z0-9_\-.]+/gi,
+  /sk-[A-Za-z0-9_\-]{20,}/g,
+  /AIza[0-9A-Za-z_\-]{20,}/g,
+];
+
+/**
+ * Convert an error-like value to a client-safe string. Redacts common
+ * vendor secrets and literal env var names. Never leaks stack traces.
+ *
+ * @param {unknown} err
+ * @returns {string}
+ */
+export function stripSecretsFromError(err) {
+  if (err === null || err === undefined) return "Internal error";
+
+  let message;
+  if (typeof err === "string") {
+    message = err;
+  } else if (err instanceof Error) {
+    message = err.message || "";
+  } else if (typeof err === "object") {
+    message = typeof err.message === "string" ? err.message : "";
+  } else {
+    message = String(err);
+  }
+
+  if (!message) return "Internal error";
+
+  let out = message;
+  for (const name of ENV_VAR_NAMES) {
+    out = out.split(name).join("[redacted]");
+  }
+  for (const pattern of SECRET_PATTERNS) {
+    out = out.replace(pattern, "[redacted]");
+  }
+  if (!out.trim()) return "Internal error";
+  return out;
+}

--- a/docs/OPEN_SOURCE_SECRET_AUDIT.md
+++ b/docs/OPEN_SOURCE_SECRET_AUDIT.md
@@ -59,3 +59,23 @@ These values are intentionally public client config when used correctly:
 3. Run `npm run security:audit`.
 4. Rewrite git history with `npm run security:rewrite-history`.
 5. Force-push the rewritten repo and have collaborators re-clone.
+
+## Endpoint-Level Hardening
+
+Server-side secret storage is necessary but not sufficient. Serverless endpoints that call vendor APIs using server-held credentials must also enforce:
+
+- Origin allowlist (rejects third-party browser callers)
+- Method guard (405 on anything but the expected verb)
+- Per-IP rate limit (caps abuse and vendor credit burn)
+- Error redaction (no env var names, bearer tokens, or provider keys echoed back)
+
+These are implemented in `api/shared/security.js` and applied to:
+
+- `api/generate-investor-profile.js` (OpenAI GPT-4o)
+- `api/enrich-preferences.js` (OpenAI chat completions)
+- `api/send-email-notification.js` (Gmail SMTP)
+
+`api/gemini-ephemeral-token.js` is rearchitected separately on the broker track.
+`api/google-wallet-pass.js` uses its own `GOOGLE_WALLET_ALLOWED_ORIGINS` allowlist and is unchanged.
+
+The per-instance rate limiter is best-effort. For durable cross-instance rate limiting, see the existing `hushh_ai_rate_limits` Supabase table referenced in `api/delete-account-service.js`.

--- a/tests/apiSecurity.test.ts
+++ b/tests/apiSecurity.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  _getClientId,
   _resetRateLimitStore,
   applyCors,
   checkRateLimit,
@@ -8,12 +9,14 @@ import {
   stripSecretsFromError,
 } from "../api/shared/security.js";
 
+const { mockCreateTransport } = vi.hoisted(() => ({
+  mockCreateTransport: vi.fn(() => ({
+    sendMail: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
 vi.mock("nodemailer", () => ({
-  default: {
-    createTransport: vi.fn(() => ({
-      sendMail: vi.fn().mockResolvedValue(undefined),
-    })),
-  },
+  default: { createTransport: mockCreateTransport },
 }));
 
 vi.mock("@supabase/supabase-js", () => {
@@ -108,15 +111,16 @@ describe("applyCors", () => {
     vi.unstubAllEnvs();
   });
 
-  it("does not set Access-Control-Allow-Origin for an unknown origin", () => {
+  it("rejects POST from unknown origin with 403 and done:true", () => {
     const { req, res } = createMockReqRes({
       method: "POST",
       headers: { origin: "https://evil.example.com" },
     });
 
-    const handled = applyCors(req, res);
+    const cors = applyCors(req, res);
 
-    expect(handled).toBe(false);
+    expect(cors.done).toBe(true);
+    expect(res.statusCode).toBe(403);
     expect(res.headers["access-control-allow-origin"]).toBeUndefined();
   });
 
@@ -126,9 +130,9 @@ describe("applyCors", () => {
       headers: { origin: "https://hushhtech.com" },
     });
 
-    const handled = applyCors(req, res);
+    const cors = applyCors(req, res);
 
-    expect(handled).toBe(false);
+    expect(cors.done).toBe(false);
     expect(res.headers["access-control-allow-origin"]).toBe(
       "https://hushhtech.com"
     );
@@ -141,18 +145,19 @@ describe("applyCors", () => {
       headers: { origin: "https://hushhtech.com" },
     });
 
-    const handled = applyCors(req, res);
+    const cors = applyCors(req, res);
 
-    expect(handled).toBe(true);
+    expect(cors.done).toBe(true);
     expect(res.statusCode).toBe(204);
   });
 
-  it("returns false and sets no CORS origin when no origin header is present", () => {
+  it("rejects POST without Origin header with 403", () => {
     const { req, res } = createMockReqRes({ method: "POST" });
 
-    const handled = applyCors(req, res);
+    const cors = applyCors(req, res);
 
-    expect(handled).toBe(false);
+    expect(cors.done).toBe(true);
+    expect(res.statusCode).toBe(403);
     expect(res.headers["access-control-allow-origin"]).toBeUndefined();
   });
 
@@ -164,9 +169,9 @@ describe("applyCors", () => {
       headers: { origin: "http://localhost:5173" },
     });
 
-    const handled = applyCors(req, res);
+    const cors = applyCors(req, res);
 
-    expect(handled).toBe(false);
+    expect(cors.done).toBe(false);
     expect(res.headers["access-control-allow-origin"]).toBe(
       "http://localhost:5173"
     );
@@ -183,9 +188,9 @@ describe("applyCors", () => {
       headers: { origin: "https://bar.example.com" },
     });
 
-    const handled = applyCors(req, res);
+    const cors = applyCors(req, res);
 
-    expect(handled).toBe(false);
+    expect(cors.done).toBe(false);
     expect(res.headers["access-control-allow-origin"]).toBe(
       "https://bar.example.com"
     );
@@ -359,6 +364,16 @@ describe("stripSecretsFromError", () => {
 
     expect(out).toContain("[redacted]");
     expect(out).not.toContain("OPENAI_API_KEY");
+  });
+
+  it("redacts query-string secret params but preserves unrelated params", () => {
+    const url =
+      "Error fetching https://api.example.com/foo?api_key=AIzaSyDONTLEAKME&userId=42";
+    const out = stripSecretsFromError(url);
+
+    expect(out).not.toContain("AIzaSyDONTLEAKME");
+    expect(out).toContain("api_key=[redacted]");
+    expect(out).toContain("userId=42");
   });
 });
 
@@ -623,5 +638,366 @@ describe("send-email-notification security envelope", () => {
     }
 
     expect(lastStatus).toBe(429);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _getClientId — trusted IP extraction
+// ---------------------------------------------------------------------------
+
+describe("_getClientId (trusted IP extraction)", () => {
+  it("takes the rightmost X-Forwarded-For entry, not the leftmost", () => {
+    const { req: spoofed } = createMockReqRes({
+      headers: { "x-forwarded-for": "1.2.3.4, 10.0.0.1" },
+    });
+    const { req: rotated } = createMockReqRes({
+      headers: { "x-forwarded-for": "5.6.7.8, 10.0.0.1" },
+    });
+    // Same rightmost IP → same client id regardless of spoofed leftmost
+    expect(_getClientId(spoofed)).toBe(_getClientId(rotated));
+  });
+
+  it("produces different ids when rightmost IPs differ", () => {
+    const { req: a } = createMockReqRes({
+      headers: { "x-forwarded-for": "10.0.0.1" },
+    });
+    const { req: b } = createMockReqRes({
+      headers: { "x-forwarded-for": "10.0.0.2" },
+    });
+    expect(_getClientId(a)).not.toBe(_getClientId(b));
+  });
+
+  it("attacker rotating leftmost entry does not change client id when rightmost is constant", () => {
+    const { req: v1 } = createMockReqRes({
+      headers: { "x-forwarded-for": "attacker-v1, 10.0.0.1" },
+    });
+    const { req: v2 } = createMockReqRes({
+      headers: { "x-forwarded-for": "attacker-v2, 10.0.0.1" },
+    });
+    expect(_getClientId(v1)).toBe(_getClientId(v2));
+  });
+
+  it("falls back to x-real-ip when x-forwarded-for is absent", () => {
+    const { req: a } = createMockReqRes({
+      headers: { "x-real-ip": "192.168.1.10" },
+    });
+    const { req: b } = createMockReqRes({
+      headers: { "x-real-ip": "192.168.1.11" },
+    });
+    expect(_getClientId(a)).not.toBe(_getClientId(b));
+  });
+
+  it("falls back to socket.remoteAddress when xff and x-real-ip are both absent", () => {
+    const id = _getClientId({
+      headers: {},
+      socket: { remoteAddress: "10.1.2.3" },
+    } as FakeReq);
+    expect(typeof id).toBe("string");
+    expect(id).toHaveLength(16);
+  });
+
+  it("handles whitespace-only x-forwarded-for by falling through to x-real-ip", () => {
+    const { req } = createMockReqRes({
+      headers: { "x-forwarded-for": "  ", "x-real-ip": "203.0.113.99" },
+    });
+    const { req: baseline } = createMockReqRes({
+      headers: { "x-real-ip": "203.0.113.99" },
+    });
+    expect(_getClientId(req)).toBe(_getClientId(baseline));
+  });
+
+  it("produces different ids for different User-Agent strings with the same IP", () => {
+    const { req: a } = createMockReqRes({
+      headers: {
+        "x-forwarded-for": "10.0.0.1",
+        "user-agent": "Mozilla/5.0",
+      },
+    });
+    const { req: b } = createMockReqRes({
+      headers: {
+        "x-forwarded-for": "10.0.0.1",
+        "user-agent": "curl/7.68.0",
+      },
+    });
+    expect(_getClientId(a)).not.toBe(_getClientId(b));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyCors fail-closed contract
+// ---------------------------------------------------------------------------
+
+describe("applyCors fail-closed contract", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_ALLOWED_ORIGINS", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects POST with blocked origin (403, done:true)", () => {
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://evil.example.com" },
+    });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(true);
+    expect(cors.allowed).toBe(false);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects POST with missing Origin (403, done:true)", () => {
+    const { req, res } = createMockReqRes({ method: "POST" });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(true);
+    expect(cors.allowed).toBe(false);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects OPTIONS with missing Origin (400)", () => {
+    const { req, res } = createMockReqRes({ method: "OPTIONS" });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(true);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects OPTIONS with blocked origin (403, not 204)", () => {
+    const { req, res } = createMockReqRes({
+      method: "OPTIONS",
+      headers: { origin: "https://evil.example.com" },
+    });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(true);
+    expect(res.statusCode).toBe(403);
+    expect(res.statusCode).not.toBe(204);
+  });
+
+  it("rejects GET with blocked origin (403)", () => {
+    const { req, res } = createMockReqRes({
+      method: "GET",
+      headers: { origin: "https://evil.example.com" },
+    });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(true);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("allows GET with no Origin through without ACAO header", () => {
+    const { req, res } = createMockReqRes({ method: "GET" });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(false);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("allows POST with an allowed origin through and sets ACAO header", () => {
+    vi.stubEnv("API_ALLOWED_ORIGINS", "https://hushhtech.com");
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://hushhtech.com" },
+    });
+    const cors = applyCors(req, res);
+    expect(cors.done).toBe(false);
+    expect(cors.allowed).toBe(true);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://hushhtech.com"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkRateLimit global cap
+// ---------------------------------------------------------------------------
+
+describe("checkRateLimit global cap", () => {
+  beforeEach(() => {
+    _resetRateLimitStore();
+  });
+
+  it("fires global cap even when each individual IP is under its per-client limit", () => {
+    const opts = {
+      key: "global-test",
+      limit: 100,
+      windowMs: 60_000,
+      globalCap: 5,
+    };
+    for (let i = 0; i < 5; i++) {
+      const { req } = createMockReqRes({
+        headers: { "x-forwarded-for": `unique-${i}` },
+      });
+      expect(checkRateLimit(req, opts).allowed).toBe(true);
+    }
+    const { req: overflow } = createMockReqRes({
+      headers: { "x-forwarded-for": "unique-overflow" },
+    });
+    const blocked = checkRateLimit(overflow, opts);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.reason).toBe("global");
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("two clients with different rightmost IPs get independent per-client buckets", () => {
+    const opts = { key: "isolation-test", limit: 3, windowMs: 60_000 };
+    const { req: a } = createMockReqRes({
+      headers: { "x-forwarded-for": "10.0.0.1" },
+    });
+    const { req: b } = createMockReqRes({
+      headers: { "x-forwarded-for": "10.0.0.2" },
+    });
+    for (let i = 0; i < 3; i++) checkRateLimit(a, opts);
+    expect(checkRateLimit(a, opts).allowed).toBe(false);
+    expect(checkRateLimit(b, opts).allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security property tests (fail-closed behavior)
+// Prove that vendor mocks are NEVER called on rejected paths.
+// ---------------------------------------------------------------------------
+
+describe("Security property tests (fail-closed behavior)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetRateLimitStore();
+    vi.unstubAllEnvs();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_ALLOWED_ORIGINS", "https://hushhtech.com");
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-not-real");
+    vi.stubEnv("GMAIL_USER", "test@hushhtech.com");
+    vi.stubEnv("GMAIL_APP_PASSWORD", "app-pass");
+    vi.stubEnv("SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "svc-key");
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: "{}" } }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    mockCreateTransport.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  describe("generate-investor-profile security envelope", () => {
+    it("blocks POST from disallowed origin with 403 and does not call OpenAI", async () => {
+      const { default: handler } = await import(
+        "../api/generate-investor-profile.js"
+      );
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: { origin: "https://evil.example.com" },
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("blocks POST with missing Origin with 403 and does not call OpenAI", async () => {
+      const { default: handler } = await import(
+        "../api/generate-investor-profile.js"
+      );
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("spoofed leftmost X-Forwarded-For does not reset the rate-limit bucket", async () => {
+      const { default: handler } = await import(
+        "../api/generate-investor-profile.js"
+      );
+      // Fill the per-client bucket for rightmost 10.0.0.1; attacker rotates leftmost
+      for (let i = 0; i < 10; i++) {
+        const { req, res } = createMockReqRes({
+          method: "POST",
+          headers: {
+            origin: "https://hushhtech.com",
+            "x-forwarded-for": `attacker-${i}, 10.0.0.1`,
+          },
+          body: {},
+        });
+        await handler(req, res);
+      }
+      fetchMock.mockClear();
+      // 11th request rotates leftmost again; rightmost still 10.0.0.1
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: {
+          origin: "https://hushhtech.com",
+          "x-forwarded-for": "attacker-rotated, 10.0.0.1",
+        },
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(429);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enrich-preferences security envelope", () => {
+    it("blocks POST from disallowed origin with 403 and does not call OpenAI", async () => {
+      const { default: handler } = await import(
+        "../api/enrich-preferences.js"
+      );
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: { origin: "https://evil.example.com" },
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("blocks POST with missing Origin with 403 and does not call OpenAI", async () => {
+      const { default: handler } = await import(
+        "../api/enrich-preferences.js"
+      );
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("send-email-notification security envelope", () => {
+    it("blocks POST from disallowed origin with 403 and does not call nodemailer", async () => {
+      const { default: handler } = await import(
+        "../api/send-email-notification.js"
+      );
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: { origin: "https://evil.example.com" },
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(mockCreateTransport).not.toHaveBeenCalled();
+    });
+
+    it("blocks POST with missing Origin with 403 and does not call nodemailer", async () => {
+      const { default: handler } = await import(
+        "../api/send-email-notification.js"
+      );
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        body: {},
+      });
+      await handler(req, res);
+      expect(res.statusCode).toBe(403);
+      expect(mockCreateTransport).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/apiSecurity.test.ts
+++ b/tests/apiSecurity.test.ts
@@ -1,0 +1,627 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  _resetRateLimitStore,
+  applyCors,
+  checkRateLimit,
+  requireMethod,
+  stripSecretsFromError,
+} from "../api/shared/security.js";
+
+vi.mock("nodemailer", () => ({
+  default: {
+    createTransport: vi.fn(() => ({
+      sendMail: vi.fn().mockResolvedValue(undefined),
+    })),
+  },
+}));
+
+vi.mock("@supabase/supabase-js", () => {
+  const client: Record<string, unknown> = {};
+  client.from = vi.fn(() => client);
+  client.select = vi.fn(() => client);
+  client.eq = vi.fn(() => client);
+  client.maybeSingle = vi.fn(() =>
+    Promise.resolve({ data: null, error: null })
+  );
+
+  return {
+    createClient: vi.fn(() => client),
+  };
+});
+
+type FakeRes = {
+  status(code: number): FakeRes;
+  json(payload: unknown): FakeRes;
+  setHeader(name: string, value: string | number): void;
+  end(): FakeRes;
+  readonly statusCode: number;
+  readonly body: unknown;
+  readonly headers: Record<string, string>;
+  readonly ended: boolean;
+};
+
+type FakeReq = {
+  method: string;
+  headers: Record<string, string>;
+  socket: { remoteAddress: string };
+  body?: unknown;
+};
+
+function createMockReqRes(
+  overrides: Partial<FakeReq> = {}
+): { req: FakeReq; res: FakeRes } {
+  const headers: Record<string, string> = {};
+  let statusCode = 200;
+  let body: unknown;
+  let ended = false;
+
+  const res: FakeRes = {
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      body = payload;
+      ended = true;
+      return res;
+    },
+    setHeader(name: string, value: string | number) {
+      headers[name.toLowerCase()] = String(value);
+    },
+    end() {
+      ended = true;
+      return res;
+    },
+    get statusCode() {
+      return statusCode;
+    },
+    get body() {
+      return body;
+    },
+    get headers() {
+      return headers;
+    },
+    get ended() {
+      return ended;
+    },
+  };
+
+  const req: FakeReq = {
+    method: "GET",
+    headers: {},
+    socket: { remoteAddress: "203.0.113.7" },
+    ...overrides,
+  };
+
+  return { req, res };
+}
+
+describe("applyCors", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_ALLOWED_ORIGINS", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does not set Access-Control-Allow-Origin for an unknown origin", () => {
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://evil.example.com" },
+    });
+
+    const handled = applyCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("echoes the origin and sets Vary when it is on the default allowlist", () => {
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    const handled = applyCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://hushhtech.com"
+    );
+    expect(res.headers["vary"]).toBe("Origin");
+  });
+
+  it("returns 204 on OPTIONS preflight from an allowed origin", () => {
+    const { req, res } = createMockReqRes({
+      method: "OPTIONS",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    const handled = applyCors(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns false and sets no CORS origin when no origin header is present", () => {
+    const { req, res } = createMockReqRes({ method: "POST" });
+
+    const handled = applyCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("allows localhost when NODE_ENV is not production", () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "http://localhost:5173" },
+    });
+
+    const handled = applyCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "http://localhost:5173"
+    );
+  });
+
+  it("respects an API_ALLOWED_ORIGINS CSV override", () => {
+    vi.stubEnv(
+      "API_ALLOWED_ORIGINS",
+      "https://foo.example.com, https://bar.example.com"
+    );
+
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://bar.example.com" },
+    });
+
+    const handled = applyCors(req, res);
+
+    expect(handled).toBe(false);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://bar.example.com"
+    );
+  });
+});
+
+describe("checkRateLimit", () => {
+  beforeEach(() => {
+    _resetRateLimitStore();
+  });
+
+  it("allows calls under the limit and decrements remaining", () => {
+    const { req } = createMockReqRes({
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+
+    const first = checkRateLimit(req, {
+      key: "test",
+      limit: 3,
+      windowMs: 60_000,
+    });
+    const second = checkRateLimit(req, {
+      key: "test",
+      limit: 3,
+      windowMs: 60_000,
+    });
+
+    expect(first.allowed).toBe(true);
+    expect(second.allowed).toBe(true);
+    expect(first.remaining).toBeGreaterThan(second.remaining);
+  });
+
+  it("blocks the (limit+1)th call and reports a positive retryAfterSec", () => {
+    const { req } = createMockReqRes({
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+
+    for (let i = 0; i < 3; i++) {
+      checkRateLimit(req, { key: "test", limit: 3, windowMs: 60_000 });
+    }
+    const blocked = checkRateLimit(req, {
+      key: "test",
+      limit: 3,
+      windowMs: 60_000,
+    });
+
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("scopes limits per IP", () => {
+    const { req: a } = createMockReqRes({
+      headers: { "x-forwarded-for": "1.1.1.1" },
+    });
+    const { req: b } = createMockReqRes({
+      headers: { "x-forwarded-for": "2.2.2.2" },
+    });
+
+    for (let i = 0; i < 3; i++) {
+      checkRateLimit(a, { key: "test", limit: 3, windowMs: 60_000 });
+    }
+    const aBlocked = checkRateLimit(a, {
+      key: "test",
+      limit: 3,
+      windowMs: 60_000,
+    });
+    const bAllowed = checkRateLimit(b, {
+      key: "test",
+      limit: 3,
+      windowMs: 60_000,
+    });
+
+    expect(aBlocked.allowed).toBe(false);
+    expect(bAllowed.allowed).toBe(true);
+  });
+
+  it("scopes limits per key namespace", () => {
+    const { req } = createMockReqRes({
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+
+    for (let i = 0; i < 3; i++) {
+      checkRateLimit(req, { key: "alpha", limit: 3, windowMs: 60_000 });
+    }
+    const alphaBlocked = checkRateLimit(req, {
+      key: "alpha",
+      limit: 3,
+      windowMs: 60_000,
+    });
+    const betaAllowed = checkRateLimit(req, {
+      key: "beta",
+      limit: 3,
+      windowMs: 60_000,
+    });
+
+    expect(alphaBlocked.allowed).toBe(false);
+    expect(betaAllowed.allowed).toBe(true);
+  });
+});
+
+describe("requireMethod", () => {
+  it("returns 405 with an Allow header when the method is not permitted", () => {
+    const { req, res } = createMockReqRes({ method: "GET" });
+
+    const stopped = requireMethod(req, res, ["POST"]);
+
+    expect(stopped).toBe(true);
+    expect(res.statusCode).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+    expect(res.body).toEqual({ error: "Method not allowed" });
+  });
+
+  it("returns false and writes no response when the method is permitted", () => {
+    const { req, res } = createMockReqRes({ method: "POST" });
+
+    const stopped = requireMethod(req, res, ["POST"]);
+
+    expect(stopped).toBe(false);
+    expect(res.ended).toBe(false);
+  });
+});
+
+describe("stripSecretsFromError", () => {
+  it("redacts OpenAI-style keys", () => {
+    // Assembled at runtime so the literal never appears whole in source
+    const fakeOpenAIKey = 'sk' + '-proj-' + 'abcdefghijklmnopqrst1234';
+    const out = stripSecretsFromError(
+      new Error("upstream error: " + fakeOpenAIKey)
+    );
+
+    expect(out).toContain("[redacted]");
+    expect(out).not.toContain(fakeOpenAIKey);
+  });
+
+  it("redacts Google API keys", () => {
+    // Assembled at runtime so the literal never appears whole in source
+    const fakeGoogleKey = 'AI' + 'za' + 'Sy' + 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456';
+    const out = stripSecretsFromError(
+      "failed with " + fakeGoogleKey
+    );
+
+    expect(out).toContain("[redacted]");
+    expect(out).not.toContain(fakeGoogleKey);
+  });
+
+  it("redacts generic Bearer tokens", () => {
+    // Assembled at runtime so the literal never appears whole in source
+    const fakeBearerToken = 'Bearer ' + 'ey' + 'JhbGciOi-abc.def';
+    const out = stripSecretsFromError(
+      "got response: " + fakeBearerToken
+    );
+
+    expect(out).toContain("[redacted]");
+    expect(out).not.toMatch(/Bearer\s+eyJ/);
+  });
+
+  it("returns plain strings without known secret patterns unchanged", () => {
+    expect(stripSecretsFromError("connection refused")).toBe(
+      "connection refused"
+    );
+  });
+
+  it("returns 'Internal error' for null or undefined input", () => {
+    expect(stripSecretsFromError(null)).toBe("Internal error");
+    expect(stripSecretsFromError(undefined)).toBe("Internal error");
+  });
+
+  it("redacts literal env var names", () => {
+    const out = stripSecretsFromError("OPENAI_API_KEY missing");
+
+    expect(out).toContain("[redacted]");
+    expect(out).not.toContain("OPENAI_API_KEY");
+  });
+});
+
+describe("generate-investor-profile security envelope", () => {
+  beforeEach(() => {
+    _resetRateLimitStore();
+    vi.unstubAllEnvs();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_ALLOWED_ORIGINS", "https://hushhtech.com");
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-fake-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "mock",
+        json: async () => ({}),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("does not set Access-Control-Allow-Origin for a blocked origin", async () => {
+    const { default: handler } = await import(
+      "../api/generate-investor-profile.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://evil.example.com" },
+      body: {},
+    });
+
+    await handler(req, res);
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("returns 204 for an OPTIONS preflight from an allowed origin", async () => {
+    const { default: handler } = await import(
+      "../api/generate-investor-profile.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "OPTIONS",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 405 with Allow: POST for a GET request", async () => {
+    const { default: handler } = await import(
+      "../api/generate-investor-profile.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "GET",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+  });
+
+  it("returns 429 after exceeding the per-IP rate limit", async () => {
+    const { default: handler } = await import(
+      "../api/generate-investor-profile.js"
+    );
+
+    let lastStatus = 0;
+    for (let i = 0; i < 11; i++) {
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: {
+          origin: "https://hushhtech.com",
+          "x-forwarded-for": "9.9.9.9",
+        },
+        body: {},
+      });
+      await handler(req, res);
+      lastStatus = res.statusCode;
+    }
+
+    expect(lastStatus).toBe(429);
+  });
+});
+
+describe("enrich-preferences security envelope", () => {
+  beforeEach(() => {
+    _resetRateLimitStore();
+    vi.unstubAllEnvs();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_ALLOWED_ORIGINS", "https://hushhtech.com");
+    vi.stubEnv("OPENAI_API_KEY", "sk-test-fake-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => "mock",
+        json: async () => ({}),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("does not set Access-Control-Allow-Origin for a blocked origin", async () => {
+    const { default: handler } = await import(
+      "../api/enrich-preferences.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://evil.example.com" },
+      body: {},
+    });
+
+    await handler(req, res);
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("returns 204 for an OPTIONS preflight from an allowed origin", async () => {
+    const { default: handler } = await import(
+      "../api/enrich-preferences.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "OPTIONS",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 405 with Allow: POST for a GET request", async () => {
+    const { default: handler } = await import(
+      "../api/enrich-preferences.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "GET",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+  });
+
+  it("returns 429 after exceeding the per-IP rate limit", async () => {
+    const { default: handler } = await import(
+      "../api/enrich-preferences.js"
+    );
+
+    let lastStatus = 0;
+    for (let i = 0; i < 11; i++) {
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: {
+          origin: "https://hushhtech.com",
+          "x-forwarded-for": "8.8.8.8",
+        },
+        body: {},
+      });
+      await handler(req, res);
+      lastStatus = res.statusCode;
+    }
+
+    expect(lastStatus).toBe(429);
+  });
+});
+
+describe("send-email-notification security envelope", () => {
+  beforeEach(() => {
+    _resetRateLimitStore();
+    vi.unstubAllEnvs();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("API_ALLOWED_ORIGINS", "https://hushhtech.com");
+    vi.stubEnv("GMAIL_USER", "test@hushhtech.com");
+    vi.stubEnv("GMAIL_APP_PASSWORD", "app-pass");
+    vi.stubEnv("SUPABASE_URL", "https://example.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "svc-key");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not set Access-Control-Allow-Origin for a blocked origin", async () => {
+    const { default: handler } = await import(
+      "../api/send-email-notification.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "POST",
+      headers: { origin: "https://evil.example.com" },
+      body: {},
+    });
+
+    await handler(req, res);
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("returns 204 for an OPTIONS preflight from an allowed origin", async () => {
+    const { default: handler } = await import(
+      "../api/send-email-notification.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "OPTIONS",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(204);
+  });
+
+  it("returns 405 with Allow: POST for a GET request", async () => {
+    const { default: handler } = await import(
+      "../api/send-email-notification.js"
+    );
+    const { req, res } = createMockReqRes({
+      method: "GET",
+      headers: { origin: "https://hushhtech.com" },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.headers["allow"]).toBe("POST");
+  });
+
+  it("returns 429 after exceeding the per-IP rate limit", async () => {
+    const { default: handler } = await import(
+      "../api/send-email-notification.js"
+    );
+
+    let lastStatus = 0;
+    for (let i = 0; i < 6; i++) {
+      const { req, res } = createMockReqRes({
+        method: "POST",
+        headers: {
+          origin: "https://hushhtech.com",
+          "x-forwarded-for": "7.7.7.7",
+        },
+        body: {},
+      });
+      await handler(req, res);
+      lastStatus = res.statusCode;
+    }
+
+    expect(lastStatus).toBe(429);
+  });
+});


### PR DESCRIPTION
### **User description**
I found and closed a live API-abuse vector: three Hushh serverless endpoints were acting as open proxies to the company's OpenAI and Gmail credentials, with wildcard CORS and no rate limit. Any third-party script could drain OpenAI credits or send Gmail as Hushh.

## What I found

Three serverless endpoints in `api/` act as open proxies to server-held vendor credentials with no access control:

- `api/generate-investor-profile.js` — calls OpenAI GPT-4o behind `Access-Control-Allow-Origin: '*'` combined with `Access-Control-Allow-Credentials: 'true'` (an invalid combination per spec, and a real abuse vector). No rate limit.
- `api/enrich-preferences.js` — calls `https://api.openai.com/v1/chat/completions` with `Bearer ${OPENAI_API_KEY}`. No origin check, no rate limit.
- `api/send-email-notification.js` — sends Gmail via nodemailer using `GMAIL_USER` / `GMAIL_APP_PASSWORD`. Wildcard CORS, no rate limit.

Any third-party site or bot can POST to these endpoints and drain OpenAI credits or trigger Gmail sends from Hushh's account — risking vendor credit exhaustion, Gmail rate-limit/suspension, and sender reputation damage.

## Why it matters

`docs/OPEN_SOURCE_SECRET_AUDIT.md` correctly lists `OPENAI_API_KEY` and vendor credentials as must-stay-server-side. But server-side storage is necessary, not sufficient — the endpoints *using* those credentials must also gate who can call them. Today they don't.

I also noticed `api/send-email-notification.js` defines a `corsHeaders` constant at the top of the file but never actually applies it to the response — the headers were dead code. This PR fixes both the structural issue and that dead code bug simultaneously.

## What I changed

**New file — `api/shared/security.js`** (zero new npm dependencies, vanilla Node):
- `applyCors(req, res)` — reads `API_ALLOWED_ORIGINS` env var (CSV), echoes matching origin back with `Vary: Origin`, auto-allows localhost in non-production. Handles OPTIONS preflight → 204. Follows the existing pattern from `api/google-wallet-pass.js`.
- `checkRateLimit(req, opts)` — per-IP sliding window limiter, best-effort per-instance. Exports `_resetRateLimitStore()` for clean test isolation.
- `requireMethod(req, res, methods)` — 405 + `Allow` header on method mismatch.
- `stripSecretsFromError(err)` — redacts bearer tokens, OpenAI keys (`sk-...`), Google API keys (`AIza...`), and env var name literals from error responses before they leave the server.

**Modified endpoints** — security envelope applied, business logic untouched:
- `api/generate-investor-profile.js`: removed invalid wildcard+credentials CORS combo, added `applyCors` + rate limit (10 req/min/IP) + method guard + safe error path.
- `api/enrich-preferences.js`: added `applyCors` + rate limit (10 req/min/IP) + method guard + safe error path.
- `api/send-email-notification.js`: removed dead `corsHeaders` constant, added `applyCors` + rate limit (5 req/min/IP, tighter because Gmail abuse is high-impact) + method guard + safe error path.

**New test file — `tests/apiSecurity.test.ts`** (30 tests):
- `applyCors`: allowed origin → echoed header + Vary, blocked origin → no header, missing origin → pass-through, OPTIONS preflight → 204, localhost in dev.
- `checkRateLimit`: under limit → allowed + remaining count, at limit → 429 data + retry-after, IP isolation, key namespace isolation.
- `requireMethod`: wrong verb → 405 + Allow header, correct verb → pass-through.
- `stripSecretsFromError`: OpenAI key redaction, Google key redaction, Bearer token redaction, safe strings pass through, null/undefined → 'Internal error'. Fixtures are runtime-assembled so they exercise the regex without matching secret-scanner patterns.
- One envelope-shape test per refactored endpoint (blocked origin, preflight, wrong method, rate limit trigger).

**Docs + config:**
- `.env.local.example`: added `API_ALLOWED_ORIGINS` with comment.
- `docs/OPEN_SOURCE_SECRET_AUDIT.md`: added "Endpoint-Level Hardening" section documenting the helper, covered endpoints, and noting that the per-instance limiter defers to `hushh_ai_rate_limits` Supabase table for durable cross-instance enforcement.
- `.gitleaks.toml`: narrow allowlist for `tests/apiSecurity.test.ts` so the repo's own secret scanner doesn't flag the redaction-test fixtures.

## How I validated

- `npm run test` → 307 passed, 42 skipped (30 new tests in `apiSecurity.test.ts`, all green).
- `npx vite build` → clean build (the chunk-size warning pre-exists this PR).
- Verified no CORS header is set for blocked origins.
- Verified allowed-origin `OPTIONS` returns 204 with echoed origin + `Vary: Origin`.
- Verified wrong-method requests return 405 with `Allow` header.
- Verified 6th rapid request from same IP returns 429 with `Retry-After` for the email endpoint.

## Scope notes

- Does **not** overlap with PR #713 (that fixes client-bundle `VITE_GEMINI_API_KEY` — a different layer).
- `api/gemini-ephemeral-token.js` is **out of scope** — it is being rearchitected into a server broker separately (branch `codex/open-source-hardening`).
- `api/google-wallet-pass.js` already has its own `GOOGLE_WALLET_ALLOWED_ORIGINS` allowlist and is unchanged. Our helper follows that same pattern.
- `api/public-investor-profile.js` is intentionally public — unchanged.

## Operational impact

- **Production hosts** (`hushhtech.com`, `hushh-tech.vercel.app`): no behavior change — both remain in the default allowlist.
- **Legitimate UI flows**: well under the rate limits (onboarding calls each endpoint once per session).
- **Third-party or bot callers**: will now receive a blocked CORS response or 429. No known legitimate external integrations exist for these endpoints.
- If any future integration needs cross-origin access, add its origin to `API_ALLOWED_ORIGINS` in GCP Secret Manager / Vercel env.

Closes #805


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Secures three API endpoints with a shared security module.

- Adds origin allowlist (CORS), per-IP rate limiting, and method guards.

- Redacts secrets from error messages to prevent leaks.

- **Impact**: Requires new `API_ALLOWED_ORIGINS` environment variable.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Client
      A["Browser/Bot Request"]
  end

  subgraph "Serverless Function"
      B["API Endpoint Handler"]
      C{"Security Envelope<br>(CORS, Rate Limit, Method Guard)"}
      D["Vendor API Call<br>(OpenAI/Gmail)"]
      E["4xx Error Response"]
  end

  A --> B
  B --> C
  C -- "Request Allowed" --> D
  C -- "Request Blocked" --> E
  D --> A
  E --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>security.js</strong><dd><code>Adds shared helpers for CORS, rate limiting, and error redaction.</code></dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-ab6a357be516140a043763668a943f987b984d33e7eabc8ed84ecbcd3dc7dea4">+246/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>enrich-preferences.js</strong><dd><code>Applies security envelope: CORS, rate limit, and error redaction.</code></dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-3a884e3bd15bd92c1e5a3e83c6262c129765f80fa3ca50c0718638766d2310f8">+22/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>apiSecurity.test.ts</strong><dd><code>Adds comprehensive tests for new security helpers and endpoints.</code></dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-210958af8868ed46cbd3805e9ce9cfe5dbcc16ff7263ffbe4291fad3eb9994b6">+1003/-0</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>generate-investor-profile.js</strong><dd><code>Replaces insecure CORS with a security envelope (CORS, rate limit).</code></dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-b6780eb506ddf0df69dabce0669fe2542419282ecc20cdffc203fc8d0a99036b">+22/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>send-email-notification.js</strong><dd><code>Removes dead code and applies security envelope (CORS, rate limit).</code></dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-7ac359d6dfb82f4969a47e2db7bcb135aba212e22b413703d8b0044454787434">+20/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>.env.local.example</strong><dd><code>Adds `API_ALLOWED_ORIGINS` environment variable for CORS policy.</code></dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-51db1e9260201708554a6d042039c4cd3366a090e6d2c3c59f281b22740dc7d6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>.gitleaks.toml</strong><dd><code>Excludes new security test file from gitleaks scans.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-f40ac94aac00bf364ae4ebef5689f7a2b61d63788030902c529d48d6d7d30ffc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>OPEN_SOURCE_SECRET_AUDIT.md</strong><dd><code>Documents the new endpoint-level hardening strategy.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/806/files#diff-9f2183e27dab66efcb6ff54fb7e716948c67f3cba548ee2be40d908bef900dda">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
