### PR TITLE
fix: improve responsiveness and scalability of KYC Studio Alpha page

### DIFF
--- a/src/components/a2aPlayground/A2AConversationScreen.tsx
+++ b/src/components/a2aPlayground/A2AConversationScreen.tsx
@@ -506,9 +506,10 @@ const SimplifiedLayout: React.FC<SimplifiedLayoutProps> = ({
     <Box
       minH="100vh"
       bg="gray.900"
-      py={4}
+      py={{ base: 4, md: 8 }}
+      px={{ base: 2, sm: 4, md: 8 }}
     >
-      <Container maxW="6xl">
+      <Container maxW="7xl">
         {/* Header */}
         <VStack spacing={2} mb={4} textAlign="center">
           <HStack>

--- a/src/components/a2aPlayground/A2AConversationScreen.tsx
+++ b/src/components/a2aPlayground/A2AConversationScreen.tsx
@@ -509,7 +509,7 @@ const SimplifiedLayout: React.FC<SimplifiedLayoutProps> = ({
       py={{ base: 4, md: 8 }}
       px={{ base: 2, sm: 4, md: 8 }}
     >
-      <Container maxW="7xl">
+      <Container maxW="7xl" px={0}>
         {/* Header */}
         <VStack spacing={2} mb={4} textAlign="center">
           <HStack>

--- a/src/components/a2aPlayground/A2AResultSummaryScreen.tsx
+++ b/src/components/a2aPlayground/A2AResultSummaryScreen.tsx
@@ -124,10 +124,10 @@ const A2AResultSummaryScreen: React.FC<A2AResultSummaryProps> = ({
     <Box
       minH="100vh"
       bg="white"
-      py={8}
-      px={{ base: 4, md: 8 }}
+      py={{ base: 4, md: 8 }}
+      px={{ base: 4, md: 8, lg: 12 }}
     >
-      <VStack spacing={8} maxW="1200px" mx="auto">
+      <VStack spacing={8} maxW="7xl" mx="auto">
         {/* Header */}
         <VStack spacing={2} textAlign="center" animation={`${fadeIn} 0.5s ease-out`}>
           <Text

--- a/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
+++ b/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
@@ -24,6 +24,8 @@ import {
   Divider,
   Icon,
   Badge,
+  Flex,
+  SimpleGrid,
   InputGroup,
   InputLeftAddon,
 } from '@chakra-ui/react';
@@ -108,9 +110,10 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
     <Box
       minH="100vh"
       bg="white"
-      py={8}
+      py={{ base: 4, md: 8 }}
+      px={{ base: 4, md: 8, lg: 12 }}
     >
-      <Container maxW="lg">
+      <Container maxW="7xl">
         {/* Header */}
         <VStack spacing={2} mb={8} textAlign="center">
           <Badge
@@ -141,7 +144,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
           border="1px solid"
           borderColor="gray.200"
           borderRadius="2xl"
-          p={6}
+          p={{ base: 4, md: 8 }}
           boxShadow="sm"
         >
           <VStack spacing={6} align="stretch">
@@ -199,7 +202,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                 2. User to Verify
               </Text>
 
-              <VStack spacing={4}>
+              <SimpleGrid columns={{ base: 1, md: 2 }} spacing={6}>
                 {/* Full Name */}
                 <FormControl>
                   <FormLabel color="gray.700" fontSize="sm">
@@ -224,7 +227,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                   <FormLabel color="gray.700" fontSize="sm">
                     Phone Number
                   </FormLabel>
-                  <HStack>
+                  <Flex direction={{ base: 'column', sm: 'row' }} gap={2}>
                     <Select
                       value={user.phoneCountryCode}
                       onChange={(e) => setUser({ ...user, phoneCountryCode: e.target.value })}
@@ -232,7 +235,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                       border="1px solid"
                       borderColor="gray.300"
                       color="black"
-                      w="140px"
+                      w={{ base: 'full', sm: '140px' }}
                       _hover={{ borderColor: 'purple.500' }}
                       _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     >
@@ -246,6 +249,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                       ))}
                     </Select>
                     <Input
+                      flex={1}
                       value={user.phoneNumber}
                       onChange={(e) => setUser({ ...user, phoneNumber: e.target.value })}
                       placeholder="Phone number"
@@ -257,7 +261,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                       _hover={{ borderColor: 'purple.500' }}
                       _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     />
-                  </HStack>
+                  </Flex>
                 </FormControl>
 
                 {/* Country */}
@@ -330,7 +334,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                     </Text>
                   </FormControl>
                 )}
-              </VStack>
+              </SimpleGrid>
             </Box>
 
             <Divider borderColor="gray.200" />
@@ -348,7 +352,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                 3. What should agents do?
               </Text>
 
-              <VStack align="stretch" spacing={3}>
+              <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6}>
                 <Checkbox
                   isChecked={operations.verifyKycStatus}
                   onChange={(e) => setOperations({ 
@@ -405,7 +409,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
                     </Text>
                   </VStack>
                 </Checkbox>
-              </VStack>
+              </SimpleGrid>
             </Box>
 
             <Divider borderColor="gray.200" />

--- a/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
+++ b/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
@@ -113,7 +113,7 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
       py={{ base: 4, md: 8 }}
       px={{ base: 4, md: 8, lg: 12 }}
     >
-      <Container maxW="7xl">
+      <Container maxW="7xl" p={0}>
         {/* Header */}
         <VStack spacing={2} mb={8} textAlign="center">
           <Badge

--- a/src/components/a2aPlayground/MissionControlLayout.tsx
+++ b/src/components/a2aPlayground/MissionControlLayout.tsx
@@ -75,38 +75,40 @@ export const MissionControlLayout: React.FC<MissionControlLayoutProps> = ({
       minH="100vh"
       bg="gray.900"
       color="white"
-      p={{ base: 2, md: 4 }}
+      py={{ base: 4, md: 8 }}
+      px={{ base: 4, md: 8, lg: 12 }}
     >
-      {/* Header */}
-      <HStack
-        justify="space-between"
-        mb={4}
-        p={4}
-        bg="blackAlpha.600"
-        borderRadius="lg"
-        border="1px solid"
-        borderColor="gray.700"
-      >
-        <HStack spacing={4}>
-          <Heading size="md" fontFamily="mono" color="green.400">
-            🛡️ MISSION CONTROL
-          </Heading>
-          <Badge colorScheme="green" variant="subtle" fontSize="xs">
-            A2A PROTOCOL v1.0
-          </Badge>
+      <Container maxW="7xl" p={0} h="full">
+        {/* Header */}
+        <HStack
+          justify="space-between"
+          mb={4}
+          p={4}
+          bg="blackAlpha.600"
+          borderRadius="lg"
+          border="1px solid"
+          borderColor="gray.700"
+        >
+          <HStack spacing={4}>
+            <Heading size="md" fontFamily="mono" color="green.400">
+              🛡️ MISSION CONTROL
+            </Heading>
+            <Badge colorScheme="green" variant="subtle" fontSize="xs">
+              A2A PROTOCOL v1.0
+            </Badge>
+          </HStack>
+          <HStack spacing={4}>
+            <EncryptionBadge isActive={isProcessing} />
+            <ConnectionStatus agents={agents} />
+          </HStack>
         </HStack>
-        <HStack spacing={4}>
-          <EncryptionBadge isActive={isProcessing} />
-          <ConnectionStatus agents={agents} />
-        </HStack>
-      </HStack>
 
-      {/* Main 3-pane layout */}
-      <Grid
-        templateColumns={{ base: '1fr', lg: '280px 1fr 320px' }}
-        gap={4}
-        h={{ base: 'auto', lg: 'calc(100vh - 140px)' }}
-      >
+        {/* Main 3-pane layout */}
+        <Grid
+          templateColumns={{ base: '1fr', lg: '280px 1fr 320px' }}
+          gap={4}
+          h={{ base: 'auto', lg: 'calc(100vh - 180px)' }}
+        >
         {/* Left Pane - Agent Network */}
         {!isMobile && (
           <GridItem>
@@ -281,7 +283,8 @@ export const MissionControlLayout: React.FC<MissionControlLayoutProps> = ({
             )}
           </VStack>
         </GridItem>
-      </Grid>
+        </Grid>
+      </Container>
     </Box>
   );
 };

--- a/src/components/a2aPlayground/MissionControlLayout.tsx
+++ b/src/components/a2aPlayground/MissionControlLayout.tsx
@@ -12,6 +12,7 @@ import {
   Heading,
   Badge,
   Divider,
+  Container,
   useBreakpointValue,
 } from '@chakra-ui/react';
 import { AgentThoughtLog } from './AgentThoughtLog';
@@ -75,10 +76,12 @@ export const MissionControlLayout: React.FC<MissionControlLayoutProps> = ({
       minH="100vh"
       bg="gray.900"
       color="white"
+      display="flex"
+      flexDirection="column"
       py={{ base: 4, md: 8 }}
       px={{ base: 4, md: 8, lg: 12 }}
     >
-      <Container maxW="7xl" p={0} h="full">
+      <Container maxW="7xl" p={0} flex="1" display="flex" flexDirection="column">
         {/* Header */}
         <HStack
           justify="space-between"
@@ -107,7 +110,8 @@ export const MissionControlLayout: React.FC<MissionControlLayoutProps> = ({
         <Grid
           templateColumns={{ base: '1fr', lg: '280px 1fr 320px' }}
           gap={4}
-          h={{ base: 'auto', lg: 'calc(100vh - 180px)' }}
+          flex="1"
+          h={{ base: 'auto' }}
         >
         {/* Left Pane - Agent Network */}
         {!isMobile && (


### PR DESCRIPTION
### **User description**
This pull request improves the responsiveness and scalability of the KYC Studio Alpha (Agent-to-Agent KYC Playground) page across all viewports. 

**Key changes include:**
**Responsive Containers:** Replaced fixed width constraints (like max-w-lg) with responsive containers (max-w-7xl) to ensure the layout utilizes available screen space effectively on larger displays.
**Grid Layouts**: Implemented SimpleGrid for form fields and operations. The setup screen now displays user information in a two-column grid on desktop while maintaining a clean vertical stack on mobile.
**Improved Padding:** Added responsive padding utilities (px-4, md:px-8, lg:px-12) across all playground screens (Setup, Conversation, and Result) for consistent spacing.
**Responsive Form Elements:** Updated the phone number input to stack vertically on mobile and horizontally on desktop. Operations checkboxes now utilize a 3-column grid on larger screens.
**Dashboard Optimization:** Enhanced the "Mission Control" layout and the mobile simplified view to ensure a premium, fluid experience across all device sizes.

**Files Modified:**
src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
src/components/a2aPlayground/A2AConversationScreen.tsx
src/components/a2aPlayground/MissionControlLayout.tsx
src/components/a2aPlayground/A2AResultSummaryScreen.tsx
closed #821


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improves responsive layout for KYC Studio pages.

- Replaces single-column stacks with multi-column grids.

- Refactors layout to dynamically fill viewport height.

- Standardizes padding and container widths across screens.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Before
      A["VStack (Single Column)"]
      B["Fixed Width (max-w-lg)"]
      C["Static Height (calc())"]
  end
  subgraph After
      D["SimpleGrid (Multi-Column)"]
      E["Responsive Width (max-w-7xl)"]
      F["Flexible Height (flex: 1)"]
  end
  A -- "Refactored to" --> D
  B -- "Replaced with" --> E
  C -- "Replaced with" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>A2AConversationScreen.tsx</strong><dd><code>Enhance responsive padding and container width for conversation screen</code></dd></summary>
<hr>

src/components/a2aPlayground/A2AConversationScreen.tsx

<ul><li>Implemented responsive horizontal and vertical padding.<br> <li> Increased container <code>maxW</code> from <code>6xl</code> to <code>7xl</code> for wider layouts.<br> <li> Removed container-level padding to prevent double padding issues.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/822/files#diff-9d39ec79959b0902c1dd98821182192c42032668c4515e8d9a1c124a43a51303">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>A2AResultSummaryScreen.tsx</strong><dd><code>Adjust responsive padding and max-width for result screen</code></dd></summary>
<hr>

src/components/a2aPlayground/A2AResultSummaryScreen.tsx

<ul><li>Added responsive padding for large screen breakpoints.<br> <li> Replaced a fixed pixel <code>maxW</code> with the standard Chakra UI token <code>7xl</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/822/files#diff-aaac6c7684e0549815e92b049ec7d596833d593b5e8d128c50b21aee4ef15b03">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>A2AScenarioSetupScreen.tsx</strong><dd><code>Implement responsive grid layout for the scenario setup form</code></dd></summary>
<hr>

src/components/a2aPlayground/A2AScenarioSetupScreen.tsx

<ul><li>Replaced <code>VStack</code> with <code>SimpleGrid</code> to create responsive multi-column form <br>layouts.<br> <li> Made the phone number input stack vertically on mobile and align <br>horizontally on desktop.<br> <li> Increased the main container width from <code>lg</code> to <code>7xl</code> to better utilize <br>screen space.<br> <li> Updated padding to be responsive across different device sizes.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/822/files#diff-12776ccc79da8454deb49b11b526f0931387e016c6d51f1462165456137dd395">+14/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MissionControlLayout.tsx</strong><dd><code>Refactor layout for dynamic height and improved responsiveness</code></dd></summary>
<hr>

src/components/a2aPlayground/MissionControlLayout.tsx

<ul><li>Refactored the layout to use flexbox for dynamic height, removing a <br>brittle <code>calc()</code> value.<br> <li> Wrapped content in a <code>Container</code> to standardize width and structure.<br> <li> Added responsive padding for consistent spacing across breakpoints.<br> <li> Fixed a missing <code>Container</code> import.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/822/files#diff-9caad37d550acd9460f3d9e4b8fd65bf4cf98599da3c19ad1fb870c8653cda78">+37/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
