### PR TITLE
fix(community): improve desktop responsiveness

### DIFF
--- a/src/pages/community/ui.tsx
+++ b/src/pages/community/ui.tsx
@@ -51,7 +51,7 @@ export default function CommunityPage() {
       />
 
       {/* ═══ Main ═══ */}
-      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-32">
+      <main className="px-6 flex-grow w-full max-w-md md:max-w-2xl lg:max-w-4xl xl:max-w-5xl mx-auto pb-32">
         {/* ── Hero ── */}
         <section className="pt-6 pb-6">
           <div className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-hushh-blue/20 rounded-full mb-6">


### PR DESCRIPTION
## Summary

- What changed: Updated the Community page main content container from a fixed mobile width to responsive desktop breakpoints.
- Why it changed: The Community page was constrained to a narrow mobile layout on desktop, making the page feel cramped on larger screens.
- Linked issue: #768
- Acceptance criteria covered: Community content remains mobile-sized on small screens and expands to wider readable widths on medium, large, and extra-large screens.
- Risk area touched: ui
- Reviewer focus: Verify the PR diff is limited to `src/pages/community/ui.tsx` and only changes layout responsiveness.

## Validation

- [x] `npm run env:check`
- [x] `npm test -- tests/loadingSpinner.test.ts tests/languageSwitcherKeyboard.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint:ci`
- [x] `npm run build:web`
- [x] `npm test`
- Ran: `npm run env:check`, targeted Vitest, `npx tsc --noEmit`, `npm run lint:ci`, `npm run build:web`, and full `npm test`.
- Did not run: browser visual screenshot; this is a one-class responsive container change and production build plus test suite passed.
- Reviewer should verify: GitHub PR Validation and merge queue checks stay green after the maintainer patch.

## Notes

- Deployment impact: none; frontend presentation-only layout change.
- Migration or env requirements: none.
- Rollback or release notes: revert PR #841 if the Community page desktop width needs to return to the previous mobile-constrained layout.
- Reviewer callouts or codeowners you expect to review this: frontend/UI review only; no auth, API, backend, KYC flow, header/footer/nav content, env, deploy, or color-guideline changes.
