### PR TITLE
fix(plaid): route signal reports through Supabase functions endpoints

### DIFF
--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -459,7 +459,7 @@ export const signalDecisionReport = async (params: {
   amountInstantlyAvailable?: number;
 }) => {
   const token = await getUserAccessToken();
-  const res = await fetch(`${SUPABASE_URL}/signal-decision-report`, {
+  const res = await fetch(`${SUPABASE_FUNCTIONS_URL}/signal-decision-report`, {
     method: 'POST', headers: getHeaders(token),
     body: JSON.stringify({
       client_transaction_id: params.clientTransactionId,
@@ -484,7 +484,7 @@ export const signalReturnReport = async (params: {
   returnedAt?: string;
 }) => {
   const token = await getUserAccessToken();
-  const res = await fetch(`${SUPABASE_URL}/signal-return-report`, {
+  const res = await fetch(`${SUPABASE_FUNCTIONS_URL}/signal-return-report`, {
     method: 'POST', headers: getHeaders(token),
     body: JSON.stringify({
       client_transaction_id: params.clientTransactionId,

--- a/tests/plaidSignalEndpoints.test.ts
+++ b/tests/plaidSignalEndpoints.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/auth/session", () => ({
+  getAuthenticatedSession: vi.fn().mockResolvedValue({
+    access_token: "test-access-token",
+  }),
+}));
+
+vi.mock("../src/resources/config/config", () => ({
+  default: {
+    supabaseClient: {
+      auth: {},
+    },
+  },
+}));
+
+import {
+  signalDecisionReport,
+  signalReturnReport,
+} from "../src/services/plaid/plaidService";
+
+describe("plaid signal endpoint construction", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubEnv("VITE_SUPABASE_URL", "https://example.supabase.co");
+  });
+
+  it("signalDecisionReport uses SUPABASE_FUNCTIONS_URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ request_id: "req-1" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await signalDecisionReport({
+      clientTransactionId: "txn-123",
+      initiated: true,
+    });
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/functions/v1/signal-decision-report");
+    expect(options).toEqual(
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+
+  it("signalReturnReport uses SUPABASE_FUNCTIONS_URL", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ request_id: "req-2" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await signalReturnReport({
+      clientTransactionId: "txn-123",
+      returnCode: "R01",
+    });
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toContain("/functions/v1/signal-return-report");
+    expect(options).toEqual(
+      expect.objectContaining({
+        method: "POST",
+      })
+    );
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary

* what changed:

  * Updated Plaid Signal report helpers to use `SUPABASE_FUNCTIONS_URL` instead of `SUPABASE_URL` for:

    * `signalDecisionReport`
    * `signalReturnReport`

* why it changed:

  * These helpers were routing requests through the project root URL instead of Supabase Edge Function endpoints, which would cause incorrect endpoint resolution once Signal reporting flows are enabled.

* risk area touched:

  * `api`

## Validation

* [x] commits are signed off with DCO (`git commit -s`)
* [ ] `npm run test`
* [x] `npx tsc --noEmit`
* [ ] `npm run build:web`
* [ ] `npm run env:check`
* [ ] `npm run lint:ci`
* [x] relevant route or smoke checks
* [ ] security checks when secrets, auth, infra, or deploy paths changed

Additional notes:

* `npm run lint:ci` could not be executed locally on Windows because the script requires a bash/WSL environment.
* Verified endpoint construction manually in `plaidService.ts`.

## Notes

* deployment impact:

  * No deployment or infrastructure changes. Low-risk endpoint correction within existing Plaid service helpers.

* migration or env requirements:

  * None.

* follow-up work if any:

  * Optional future integration/runtime tests once Signal reporting flows are wired into active UI or API paths.

* reviewer callouts or CODEOWNERS you expect to review this:

  * Plaid/service integration maintainers or default CODEOWNERS for `src/services/plaid/`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Corrects Plaid signal report API endpoints.

- Replaces `SUPABASE_URL` with `SUPABASE_FUNCTIONS_URL`.

- Adds tests to verify the new endpoint URLs.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph Before
        A["Plaid Service"] -- "calls" --> B["SUPABASE_URL/..."];
    end
    subgraph After
        C["Plaid Service"] -- "calls" --> D["SUPABASE_FUNCTIONS_URL/..."];
    end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plaidService.ts</strong><dd><code>Correct Plaid signal report endpoint URLs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/plaid/plaidService.ts

<ul><li>Updates <code>signalDecisionReport</code> to use <code>SUPABASE_FUNCTIONS_URL</code>.<br> <li> Updates <code>signalReturnReport</code> to use <code>SUPABASE_FUNCTIONS_URL</code>.<br> <li> Routes requests to Supabase Edge Functions instead of the project <br>root.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/858/files#diff-c1eea5b8c160cc1ef48d1be506addb285b47fc56b3754ae1d72cd03984924038">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plaidSignalEndpoints.test.ts</strong><dd><code>Add tests for Plaid signal endpoint construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/plaidSignalEndpoints.test.ts

<ul><li>Adds a new test suite for Plaid signal endpoints.<br> <li> Verifies <code>signalDecisionReport</code> calls the correct function URL.<br> <li> Verifies <code>signalReturnReport</code> calls the correct function URL.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/858/files#diff-df0ab7539e1c851c8d6048727aed0f0d22fe0256b8dbfa95a1c17f48c15688dd">+69/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
