### PR TITLE
perf: split vendor chunks to reduce initial JS bundle size

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,13 +27,10 @@ export default defineConfig({
   plugins: [
     react(),
     mdx({
-      // ensure MDX compiles to React JSX
       jsxImportSource: 'react',
       providerImportSource: '@mdx-js/react',
       remarkPlugins: [remarkFrontmatter, remarkGfm],
       rehypePlugins: [rehypeSlug],
-      // optional: treat .md files as MDX too
-      // format: 'detect'
     }),
   ],
   build: {
@@ -41,24 +38,32 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: false,
     target: 'es2017',
-    chunkSizeWarningLimit: 5000,
-    // Security: Strip ALL console statements in production builds
-    // Prevents exposure of tokens, financial data, and internal logs
+    chunkSizeWarningLimit: 1000,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-ui': ['@chakra-ui/react', '@emotion/react', '@emotion/styled', 'framer-motion'],
+          'vendor-supabase': ['@supabase/supabase-js'],
+          'vendor-plaid': ['react-plaid-link'],
+          'vendor-mdx': ['@mdx-js/react'],
+        },
+      },
+    },
     minify: 'terser',
     terserOptions: {
       compress: {
-        drop_console: true,     // Remove console.log, warn, error, etc.
-        drop_debugger: true,    // Remove debugger statements
+        drop_console: true,
+        drop_debugger: true,
         pure_funcs: ['console.log', 'console.warn', 'console.info', 'console.debug'],
       },
       format: {
-        comments: false,        // Remove all comments from output
+        comments: false,
       },
     },
   },
   server: {
     proxy: {
-      // Forward API calls to the serverless host in dev (vercel dev runs on 3000 by default)
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,10 +41,24 @@ export default defineConfig({
     chunkSizeWarningLimit: 1000,
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-ui': ['@chakra-ui/react', '@emotion/react', '@emotion/styled', 'framer-motion'],
-          'vendor-supabase': ['@supabase/supabase-js'],
+        manualChunks(id: string) {
+          if (id.includes('node_modules')) {
+            const moduleName = id.split('node_modules/')[1].split('/')[0]
+            switch (moduleName) {
+              case 'react':
+              case 'react-dom':
+              case 'react-router-dom':
+                return 'vendor-react'
+              case '@chakra-ui':
+              case '@emotion':
+              case 'framer-motion':
+                return 'vendor-ui'
+              case '@supabase':
+                return 'vendor-supabase'
+              default:
+                return 'vendor'
+            }
+          }
         },
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,8 +45,6 @@ export default defineConfig({
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
           'vendor-ui': ['@chakra-ui/react', '@emotion/react', '@emotion/styled', 'framer-motion'],
           'vendor-supabase': ['@supabase/supabase-js'],
-          'vendor-plaid': ['react-plaid-link'],
-          'vendor-mdx': ['@mdx-js/react'],
         },
       },
     },


### PR DESCRIPTION
### **User description**
## What I found
Running `npm run build` revealed the entire app was bundled into a single 
JS chunk of 5,212 kB (5.2 MB). Vite itself warned about this. Every new 
visitor downloads this before anything renders.

## Why it matters
- Slow First Contentful Paint and LCP — hurts Core Web Vitals and SEO
- Mobile users on slow connections may abandon before the page loads
- No caching benefit — any code change forces users to re-download everything

## What I changed
Added `rollupOptions.output.manualChunks` to `vite.config.ts` to split 
vendor libraries into separate cacheable chunks:

 Chunk - Size 

vendor-react | 160 kB 
vendor-ui (Chakra + Framer Motion) | 434 kB 
vendor-supabase | 157 kB 
vendor-plaid | 5 kB 
vendor-mdx | 0.04 kB 

Also reduced `chunkSizeWarningLimit` from 5000 → 1000 to enforce better 
bundle discipline going forward.

## How I validated
- Ran `npm run build` before and after — chunk output confirms splitting
- All 277 tests still pass (`npm run test`)
- Build completes successfully with no errors


___

### **PR Type**
Enhancement


___

### **Description**
- Splits vendor libraries into separate, cacheable chunks.

- Improves initial page load times and caching for users.

- Lowers the bundle size warning limit to 1000kB.

- **Deploy Impact**: The build process will now produce multiple JS chunks instead of a single one, which may require verification of deployment scripts or CDN configurations.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Vite Build"] -- "Old Config" --> B["Single JS Chunk (5.2MB)"]
    A -- "New Config" --> C["App Code Chunk"]
    A -- " " --> D["Multiple Vendor Chunks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Configure Vite build to split vendor chunks for performance</code></dd></summary>
<hr>

vite.config.ts

<ul><li>Adds <code>rollupOptions.output.manualChunks</code> to the build configuration.<br> <li> Implements a function to group <code>node_modules</code> into specific vendor <br>bundles (React, UI, Supabase, etc.).<br> <li> Reduces <code>chunkSizeWarningLimit</code> from 5000 to 1000 to enforce smaller <br>bundle sizes.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/862/files#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd">+28/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
