### PR TITLE
feat(kyc): add client-side validation layer to eliminate silent failures in KYC onboarding flow

### DIFF
--- a/src/utils/kycValidator.ts
+++ b/src/utils/kycValidator.ts
@@ -1,0 +1,159 @@
+import { parsePhoneNumberFromString } from 'libphonenumber-js'
+
+export interface KYCValidationError {
+    field: string
+    message: string
+}
+
+export interface KYCValidationResult {
+    valid: boolean
+    errors: KYCValidationError[]
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function isBlank(value: unknown): boolean {
+    return value === undefined || value === null || String(value).trim() === ''
+}
+
+// ── individual validators ─────────────────────────────────────────────────────
+
+export function validateRequired(
+    field: string,
+    value: unknown,
+    label: string
+): KYCValidationError | null {
+    if (isBlank(value)) {
+        return { field, message: `${label} is required` }
+    }
+    return null
+}
+
+export function validateEmail(email: unknown): KYCValidationError | null {
+    if (isBlank(email)) {
+        return { field: 'email', message: 'Email address is required' }
+    }
+    const RFC_EMAIL =
+        /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/
+    if (!RFC_EMAIL.test(String(email).trim())) {
+        return { field: 'email', message: 'Enter a valid email address' }
+    }
+    return null
+}
+
+export function validatePhone(
+    phone: unknown,
+    countryCode: string = 'IN'
+): KYCValidationError | null {
+    if (isBlank(phone)) {
+        return { field: 'phone', message: 'Phone number is required' }
+    }
+    const parsed = parsePhoneNumberFromString(String(phone), countryCode as any)
+    if (!parsed || !parsed.isValid()) {
+        return { field: 'phone', message: 'Enter a valid phone number' }
+    }
+    return null
+}
+
+export function validatePAN(pan: unknown): KYCValidationError | null {
+    if (isBlank(pan)) {
+        return { field: 'pan', message: 'PAN number is required' }
+    }
+    const PAN_REGEX = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/
+    if (!PAN_REGEX.test(String(pan).trim().toUpperCase())) {
+        return {
+            field: 'pan',
+            message: 'Enter a valid PAN number (e.g. ABCDE1234F)',
+        }
+    }
+    return null
+}
+
+export function validateAadhaar(aadhaar: unknown): KYCValidationError | null {
+    if (isBlank(aadhaar)) {
+        return { field: 'aadhaar', message: 'Aadhaar number is required' }
+    }
+    const cleaned = String(aadhaar).replace(/\s/g, '')
+    const AADHAAR_REGEX = /^[2-9]{1}[0-9]{11}$/
+    if (!AADHAAR_REGEX.test(cleaned)) {
+        return {
+            field: 'aadhaar',
+            message: 'Enter a valid 12-digit Aadhaar number',
+        }
+    }
+    return null
+}
+
+export function validateDOB(dob: unknown): KYCValidationError | null {
+    if (isBlank(dob)) {
+        return { field: 'dob', message: 'Date of birth is required' }
+    }
+    const date = new Date(String(dob))
+    if (isNaN(date.getTime())) {
+        return { field: 'dob', message: 'Enter a valid date of birth' }
+    }
+    const today = new Date()
+    const age =
+        today.getFullYear() -
+        date.getFullYear() -
+        (today < new Date(today.getFullYear(), date.getMonth(), date.getDate())
+            ? 1
+            : 0)
+    if (age < 18) {
+        return {
+            field: 'dob',
+            message: 'You must be at least 18 years old to complete KYC',
+        }
+    }
+    return null
+}
+
+export function validateFullName(name: unknown): KYCValidationError | null {
+    if (isBlank(name)) {
+        return { field: 'fullName', message: 'Full name is required' }
+    }
+    if (String(name).trim().length < 2) {
+        return { field: 'fullName', message: 'Enter your full name' }
+    }
+    return null
+}
+
+// ── step-level validators ────────────────────────────────────────────────────
+
+export function validateKYCStep1(data: {
+    fullName?: unknown
+    email?: unknown
+    phone?: unknown
+}): KYCValidationResult {
+    const errors: KYCValidationError[] = []
+
+    const nameErr = validateFullName(data.fullName)
+    if (nameErr) errors.push(nameErr)
+
+    const emailErr = validateEmail(data.email)
+    if (emailErr) errors.push(emailErr)
+
+    const phoneErr = validatePhone(data.phone)
+    if (phoneErr) errors.push(phoneErr)
+
+    return { valid: errors.length === 0, errors }
+}
+
+export function validateKYCStep2(data: {
+    dob?: unknown
+    pan?: unknown
+    aadhaar?: unknown
+}): KYCValidationResult {
+    const errors: KYCValidationError[] = []
+
+    const dobErr = validateDOB(data.dob)
+    if (dobErr) errors.push(dobErr)
+
+    const panErr = validatePAN(data.pan)
+    if (panErr) errors.push(panErr)
+
+    const aadhaarErr = validateAadhaar(data.aadhaar)
+    if (aadhaarErr) errors.push(aadhaarErr)
+
+    return { valid: errors.length === 0, errors }
+}

--- a/src/utils/kycValidator.ts
+++ b/src/utils/kycValidator.ts
@@ -1,4 +1,4 @@
-import { parsePhoneNumberFromString } from 'libphonenumber-js'
+import { parsePhoneNumberFromString, type CountryCode } from 'libphonenumber-js'
 
 export interface KYCValidationError {
     field: string
@@ -33,8 +33,7 @@ export function validateEmail(email: unknown): KYCValidationError | null {
     if (isBlank(email)) {
         return { field: 'email', message: 'Email address is required' }
     }
-    const RFC_EMAIL =
-        /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/
+    const RFC_EMAIL = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
     if (!RFC_EMAIL.test(String(email).trim())) {
         return { field: 'email', message: 'Enter a valid email address' }
     }
@@ -43,12 +42,12 @@ export function validateEmail(email: unknown): KYCValidationError | null {
 
 export function validatePhone(
     phone: unknown,
-    countryCode: string = 'IN'
+    countryCode: CountryCode = 'IN'
 ): KYCValidationError | null {
     if (isBlank(phone)) {
         return { field: 'phone', message: 'Phone number is required' }
     }
-    const parsed = parsePhoneNumberFromString(String(phone), countryCode as any)
+    const parsed = parsePhoneNumberFromString(String(phone), countryCode)
     if (!parsed || !parsed.isValid()) {
         return { field: 'phone', message: 'Enter a valid phone number' }
     }
@@ -88,17 +87,20 @@ export function validateDOB(dob: unknown): KYCValidationError | null {
     if (isBlank(dob)) {
         return { field: 'dob', message: 'Date of birth is required' }
     }
-    const date = new Date(String(dob))
+    const dobString = String(dob)
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dobString)) {
+        return { field: 'dob', message: 'Enter a valid date in YYYY-MM-DD format' }
+    }
+    const date = new Date(dobString)
     if (isNaN(date.getTime())) {
         return { field: 'dob', message: 'Enter a valid date of birth' }
     }
     const today = new Date()
-    const age =
-        today.getFullYear() -
-        date.getFullYear() -
-        (today < new Date(today.getFullYear(), date.getMonth(), date.getDate())
-            ? 1
-            : 0)
+    let age = today.getUTCFullYear() - date.getUTCFullYear()
+    const monthDiff = today.getUTCMonth() - date.getUTCMonth()
+    if (monthDiff < 0 || (monthDiff === 0 && today.getUTCDate() < date.getUTCDate())) {
+        age--
+    }
     if (age < 18) {
         return {
             field: 'dob',

--- a/tests/kyc-validation.test.ts
+++ b/tests/kyc-validation.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import {
+    validateEmail,
+    validatePhone,
+    validatePAN,
+    validateAadhaar,
+    validateDOB,
+    validateFullName,
+    validateKYCStep1,
+    validateKYCStep2,
+} from '../src/utils/kycValidator'
+
+describe('KYC Validation — kycValidator', () => {
+
+    // ── email ──────────────────────────────────────────────────────────────────
+    describe('validateEmail', () => {
+        it('passes a valid email', () => {
+            expect(validateEmail('user@example.com')).toBeNull()
+        })
+        it('fails an empty email', () => {
+            expect(validateEmail('')?.field).toBe('email')
+        })
+        it('fails a malformed email', () => {
+            expect(validateEmail('not-an-email')?.field).toBe('email')
+        })
+    })
+
+    // ── phone ──────────────────────────────────────────────────────────────────
+    describe('validatePhone', () => {
+        it('passes a valid Indian phone number', () => {
+            expect(validatePhone('+919876543210', 'IN')).toBeNull()
+        })
+        it('fails an empty phone', () => {
+            expect(validatePhone('')?.field).toBe('phone')
+        })
+        it('fails an invalid phone number', () => {
+            expect(validatePhone('12345', 'IN')?.field).toBe('phone')
+        })
+    })
+
+    // ── PAN ───────────────────────────────────────────────────────────────────
+    describe('validatePAN', () => {
+        it('passes a valid PAN', () => {
+            expect(validatePAN('ABCDE1234F')).toBeNull()
+        })
+        it('fails an empty PAN', () => {
+            expect(validatePAN('')?.field).toBe('pan')
+        })
+        it('fails an invalid PAN format', () => {
+            expect(validatePAN('1234ABCDEF')?.field).toBe('pan')
+        })
+    })
+
+    // ── Aadhaar ───────────────────────────────────────────────────────────────
+    describe('validateAadhaar', () => {
+        it('passes a valid Aadhaar', () => {
+            expect(validateAadhaar('234567890123')).toBeNull()
+        })
+        it('fails an empty Aadhaar', () => {
+            expect(validateAadhaar('')?.field).toBe('aadhaar')
+        })
+        it('fails a short Aadhaar', () => {
+            expect(validateAadhaar('12345')?.field).toBe('aadhaar')
+        })
+    })
+
+    // ── DOB ───────────────────────────────────────────────────────────────────
+    describe('validateDOB', () => {
+        it('passes an adult DOB', () => {
+            expect(validateDOB('1995-06-15')).toBeNull()
+        })
+        it('fails an empty DOB', () => {
+            expect(validateDOB('')?.field).toBe('dob')
+        })
+        it('fails an underage DOB', () => {
+            expect(validateDOB('2015-01-01')?.message).toContain('18')
+        })
+    })
+
+    // ── Full name ─────────────────────────────────────────────────────────────
+    describe('validateFullName', () => {
+        it('passes a valid name', () => {
+            expect(validateFullName('Shiva Ganesh')).toBeNull()
+        })
+        it('fails an empty name', () => {
+            expect(validateFullName('')?.field).toBe('fullName')
+        })
+    })
+
+    // ── step-level validators ─────────────────────────────────────────────────
+    describe('validateKYCStep1', () => {
+        it('passes when all step-1 fields are valid', () => {
+            const result = validateKYCStep1({
+                fullName: 'Shiva Ganesh',
+                email: 'shiva@example.com',
+                phone: '+919876543210',
+            })
+            expect(result.valid).toBe(true)
+            expect(result.errors).toHaveLength(0)
+        })
+        it('collects all errors when step-1 fields are empty', () => {
+            const result = validateKYCStep1({})
+            expect(result.valid).toBe(false)
+            expect(result.errors.length).toBeGreaterThanOrEqual(3)
+        })
+    })
+
+    describe('validateKYCStep2', () => {
+        it('passes when all step-2 fields are valid', () => {
+            const result = validateKYCStep2({
+                dob: '1995-06-15',
+                pan: 'ABCDE1234F',
+                aadhaar: '234567890123',
+            })
+            expect(result.valid).toBe(true)
+            expect(result.errors).toHaveLength(0)
+        })
+        it('fails when step-2 fields are empty', () => {
+            const result = validateKYCStep2({})
+            expect(result.valid).toBe(false)
+            expect(result.errors.length).toBeGreaterThanOrEqual(3)
+        })
+    })
+})


### PR DESCRIPTION
### **User description**
Summary

**What changed:** Added a typed `kycValidator` utility module and a full unit test suite covering all KYC input fields.

**Why it matters:** The KYC onboarding flow currently has no client-side validation. Users can submit empty fields, malformed emails, invalid phone numbers, or incorrect PAN/Aadhaar formats with zero feedback — errors only surface after a server round-trip or fail silently. This directly causes broken onboarding state and investor drop-off. The Hushh product team has explicitly identified KYC completion as one of Kai's biggest pain points.

Changes

- `src/utils/kycValidator.ts` — reusable, typed validation functions for:
  - Required field checks
  - Email (RFC-compliant regex)
  - Phone number (using `libphonenumber-js` — already a project dependency)
  - PAN card format (`ABCDE1234F` pattern)
  - Aadhaar number (12-digit, starts with 2–9)
  - Date of birth with 18+ age enforcement
  - Full name
  - Step-level validators: `validateKYCStep1` and `validateKYCStep2`

- `tests/kyc-validation.test.ts` — 21 unit tests covering:
  - Valid inputs pass cleanly
  - Empty/missing fields return correct error with correct `field` key
  - Malformed email, invalid phone, wrong PAN format, underage DOB all caught
  - Step-level aggregation collects all errors at once

Validation

- [x] `npm run test -- tests/kyc-validation.test.ts` — **21/21 tests pass**
- [x] `npm ci` — clean install succeeds
- [x] No secrets, tokens, or `.env` files committed
- [x] No direct push to `main` — topic branch used
- [x] `libphonenumber-js` was already a listed dependency — no new packages added

Test Output

✓ tests/kyc-validation.test.ts (21)
✓ validateEmail (3)
✓ validatePhone (3)
✓ validatePAN (3)
✓ validateAadhaar (3)
✓ validateDOB (3)
✓ validateFullName (2)
✓ validateKYCStep1 (2)
✓ validateKYCStep2 (2)
Tests: 21 passed

Linked Issue

Relates to #448 — the KYC scrolling fix addressed layout but left the root validation problem unresolved. This PR addresses the underlying UX gap.

Notes

- The validator is intentionally decoupled from any UI component so it can be imported into any KYC step without refactoring existing components
- Each validator returns `null` on success or a typed `KYCValidationError` with `field` and `message` — easy to wire into any form state manager


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adds a client-side validation layer for the KYC flow.

- Includes validators for email, phone, PAN, Aadhaar, DOB, and name.

- Provides immediate user feedback to prevent silent failures.

- Adds a comprehensive unit test suite for all new logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Input (name, email, etc.)"] --> B["Step-level Validator (e.g., validateKYCStep1)"];
  B --> C["Individual Field Validators (e.g., validateEmail)"];
  C --> D["Validation Result (valid/invalid + errors)"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kycValidator.ts</strong><dd><code>Implement client-side validation logic for KYC fields</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/kycValidator.ts

<ul><li>Introduces a new utility module for client-side KYC validation.<br> <li> Adds individual validation functions for fields like <code>email</code>, <code>phone</code>, <br><code>pan</code>, <code>aadhaar</code>, and <code>dob</code>.<br> <li> Implements step-level validators (<code>validateKYCStep1</code>, <code>validateKYCStep2</code>) <br>that aggregate errors.<br> <li> Defines typed interfaces for validation results to ensure clear error <br>handling.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/863/files#diff-60d4120af627d6edaced0820fa1b04c4ac0b7dced26025e8e3a99cdb254a00d3">+161/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kyc-validation.test.ts</strong><dd><code>Add unit tests for the new KYC validation utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/kyc-validation.test.ts

<ul><li>Adds a new test suite using <code>vitest</code> for the <code>kycValidator</code> module.<br> <li> Includes unit tests for each validation function, covering valid, <br>invalid, and empty inputs.<br> <li> Verifies that step-level validators correctly aggregate multiple <br>errors.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/863/files#diff-05af83e92ce61431b2e6e1dfe970ab887d8faf2c500ed9a59ea2971ddd3941fe">+124/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
