### PR TITLE
fix(plaid): clear stale asset polling interval on retry

### DIFF
--- a/src/services/plaid/usePlaidLink.ts
+++ b/src/services/plaid/usePlaidLink.ts
@@ -547,6 +547,10 @@ export const usePlaidLinkHook = (userId: string, userEmail?: string): UsePlaidLi
   }, [ready, open]);
 
   const retry = useCallback(() => {
+    if (assetPollRef.current) {
+      clearInterval(assetPollRef.current);
+      assetPollRef.current = null;
+    }
     clearPersistedState();
     setState(defaultState());
     accessTokenRef.current = null;

--- a/tests/usePlaidLink.retry.test.ts
+++ b/tests/usePlaidLink.retry.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createLinkTokenMock = vi.fn();
+const exchangeTokenMock = vi.fn();
+const fetchAllFinancialDataMock = vi.fn();
+const checkAssetReportMock = vi.fn();
+const saveFinancialDataToSupabaseMock = vi.fn();
+const signalPrepareMock = vi.fn();
+
+vi.mock("../src/services/plaid/plaidService", () => ({
+  createLinkToken: (...args: unknown[]) => createLinkTokenMock(...args),
+  exchangeToken: (...args: unknown[]) => exchangeTokenMock(...args),
+  fetchAllFinancialData: (...args: unknown[]) => fetchAllFinancialDataMock(...args),
+  checkAssetReport: (...args: unknown[]) => checkAssetReportMock(...args),
+  saveFinancialDataToSupabase: (...args: unknown[]) =>
+    saveFinancialDataToSupabaseMock(...args),
+  signalPrepare: (...args: unknown[]) => signalPrepareMock(...args),
+  getProductStatus: (product: { available: boolean; data?: { status?: string } | null }) => {
+    if (product.available) return "success";
+    if (product.data?.status === "pending") return "pending";
+    return "idle";
+  },
+}));
+
+vi.mock("react-plaid-link", () => ({
+  usePlaidLink: ({
+    token,
+    onSuccess,
+  }: {
+    token: string | null;
+    onSuccess: (publicToken: string, metadata: unknown) => void;
+  }) => ({
+    ready: Boolean(token),
+    open: () =>
+      onSuccess("public-token", {
+        institution: { name: "Test Bank", institution_id: "ins_1" },
+      }),
+  }),
+}));
+
+import { usePlaidLinkHook } from "../src/services/plaid/usePlaidLink";
+
+function HookHarness() {
+  const { openPlaidLink, retry } = usePlaidLinkHook("user-123", "test@hushh.ai");
+
+  return React.createElement(
+    "div",
+    null,
+    React.createElement(
+      "button",
+      { type: "button", "data-testid": "open", onClick: openPlaidLink },
+      "open"
+    ),
+    React.createElement(
+      "button",
+      { type: "button", "data-testid": "retry", onClick: retry },
+      "retry"
+    )
+  );
+}
+
+describe("usePlaidLinkHook retry polling cleanup", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    window.history.replaceState({}, "", "/onboarding/financial-link");
+
+    createLinkTokenMock.mockResolvedValue({
+      link_token: "link-token-123",
+      expiration: "2099-01-01T00:00:00Z",
+    });
+    exchangeTokenMock.mockResolvedValue({
+      access_token: "access-token",
+      item_id: "item-1",
+    });
+    fetchAllFinancialDataMock.mockResolvedValue({
+      status: "partial",
+      balance: { available: true, data: {}, error: null, reason: null },
+      assets: {
+        available: false,
+        data: { status: "pending", asset_report_token: "asset-token" },
+        error: null,
+        reason: null,
+      },
+      investments: { available: false, data: null, error: null, reason: "not_supported" },
+      identity: { available: false, data: null, error: null, reason: "not_supported" },
+      authNumbers: { available: false, data: null, error: null, reason: "not_supported" },
+      identityMatch: { available: false, data: null, error: null, reason: "not_supported" },
+      summary: { products_available: 1, products_total: 6, can_proceed: true },
+    });
+    checkAssetReportMock.mockResolvedValue({
+      status: "pending",
+    });
+    signalPrepareMock.mockResolvedValue({ success: true });
+    saveFinancialDataToSupabaseMock.mockResolvedValue(undefined);
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("stops stale asset polling after retry", async () => {
+    await act(async () => {
+      root.render(React.createElement(HookHarness));
+    });
+    await flush();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flush();
+
+    await act(async () => {
+      container
+        .querySelector('[data-testid="open"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flush();
+    expect(checkAssetReportMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      container
+        .querySelector('[data-testid="retry"]')
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    await act(async () => {
+      vi.advanceTimersByTime(15000);
+    });
+    await flush();
+
+    expect(checkAssetReportMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary

* what changed:

  * Cleared active `assetPollRef` polling interval during `retry()` in `usePlaidLink`.
  * Added focused regression coverage ensuring stale asset polling does not continue after retry flows.

* why it changed:

  * Active Plaid asset polling intervals could survive retry attempts and continue mutating state from previous flows.
  * This could lead to duplicate polling requests, stale asset status updates, and incorrect `productsAvailable` state changes after retry.

* risk area touched:

  * `api`

## Validation

* [x] commits are signed off with DCO (`git commit -s`)
* [x] `npm run test -- tests/usePlaidLink.retry.test.ts`
* [x] `npx tsc --noEmit`
* [ ] `npm run build:web`
* [ ] `npm run env:check`
* [ ] `npm run lint:ci`
* [x] relevant route or smoke checks
* [ ] security checks when secrets, auth, infra, or deploy paths changed

Additional notes:

* Regression test uses fake timers to deterministically verify stale polling stops after retry cleanup.
* `npm run lint:ci` may require a bash/WSL environment locally on Windows.

## Notes

* deployment impact:

  * None. This is a localized polling lifecycle cleanup fix within the Plaid onboarding flow.

* migration or env requirements:

  * None.

* follow-up work if any:

  * Optional future review of other interval/timer-based onboarding flows for stale async cleanup consistency.

* reviewer callouts or CODEOWNERS you expect to review this:

  * Plaid/onboarding maintainers or default CODEOWNERS for `usePlaidLink`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Clears stale Plaid asset polling interval on retry.

- Prevents duplicate requests and incorrect state updates.

- Adds a regression test to verify the fix.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Before
    A["User retries Plaid flow"] --> B{"assetPollRef interval active?"}
    B -- Yes --> C["Interval continues polling (bug)"]
  end
  subgraph After
    A2["User retries Plaid flow"] --> B2{"assetPollRef interval active?"}
    B2 -- Yes --> D["clearInterval(assetPollRef)"] --> E["Polling stops (fixed)"]
  end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePlaidLink.ts</strong><dd><code>Clear asset polling interval on retry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/plaid/usePlaidLink.ts

<ul><li>Adds logic to the <code>retry</code> function to clear any active asset polling <br>interval.<br> <li> Prevents a stale polling timer from a previous attempt from continuing <br>after a retry.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/873/files#diff-2751a10ef3c8e9a7c10b0d1f5fe8d3f1f87a10c698dd2bb4b08bff9a7d14f615">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>usePlaidLink.retry.test.ts</strong><dd><code>Add regression test for retry polling cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/usePlaidLink.retry.test.ts

<ul><li>Adds a new test suite for the <code>usePlaidLinkHook</code> retry behavior.<br> <li> Uses fake timers to simulate the flow and verify that asset polling is <br>correctly stopped after <code>retry()</code> is called.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/873/files#diff-839f57152fe7da1b572d8fe1654311f69a2e461b8fcfa5274970e7737107ed07">+165/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
