### PR TITLE
fix(auth): normalize route casing with lowercase canonical paths and redirects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,6 +81,11 @@ import MetricsPage from './pages/metrics';
 
 const KaiIndiaApp = React.lazy(() => import('./kai-india/pages'));
 
+const RedirectWithQuery = ({ to }: { to: string }) => {
+  const location = useLocation();
+  return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
+};
+
 // Content wrapper component that applies conditional margin
 const ContentWrapper = ({ children }: { children: ReactNode }) => {
   const location = useLocation();
@@ -167,9 +172,9 @@ function App() {
             <Route path="/signup" element={<SignupPage />} />
             <Route path="/contact" element={<Contact />} />
 
-            <Route path="/Login" element={<Navigate to="/login" replace />} />
-            <Route path="/Signup" element={<Navigate to="/signup" replace />} />
-            <Route path="/Contact" element={<Navigate to="/contact" replace />} />
+            <Route path="/Login" element={<RedirectWithQuery to="/login" />} />
+            <Route path="/Signup" element={<RedirectWithQuery to="/signup" />} />
+            <Route path="/Contact" element={<RedirectWithQuery to="/contact" />} />
             <Route path="/benefits" element={<BenefitsPage />} />
             <Route path='/services/consumers' element={<Consumers />} />
             <Route path='/services/business' element={<Business />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,12 +163,16 @@ function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/about/leadership" element={<Leadership />} />
             <Route path="/about/philosophy" element={<Philosophy />} />
-            <Route path="/Login" element={<LoginPage />} />
-            <Route path="/Contact" element={<Contact />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="/contact" element={<Contact />} />
+
+            <Route path="/Login" element={<Navigate to="/login" replace />} />
+            <Route path="/Signup" element={<Navigate to="/signup" replace />} />
+            <Route path="/Contact" element={<Navigate to="/contact" replace />} />
             <Route path="/benefits" element={<BenefitsPage />} />
             <Route path='/services/consumers' element={<Consumers />} />
             <Route path='/services/business' element={<Business />} />
-            <Route path='/Signup' element={<SignupPage />} />
             <Route path='/faq' element={<Faq />} />
             <Route path='/profile' element={
               <AuthRequiredRoute>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -275,7 +275,7 @@ export default function Navbar() {
                   </>
                 ) : (
                   <button
-                    onClick={() => navigate('/Login')}
+                    onClick={() => navigate('/login')}
                     className="inline-flex items-center justify-center rounded-full bg-[#2F80ED] px-4 py-2 text-sm font-semibold text-white hover:bg-[#1f6cc7] transition-colors"
                   >
                     {t('nav.login')}
@@ -549,7 +549,7 @@ export default function Navbar() {
                   </button>
                 ) : (
                   <button
-                    onClick={() => handleLinkClick("/Login")}
+                    onClick={() => handleLinkClick("/login")}
                     className="w-full h-[50px] rounded-[12px] bg-[#007AFF] text-white font-semibold text-[17px] active:scale-[0.98] active:opacity-90 transition-all flex items-center justify-center shadow-sm"
                   >
                     {t('nav.login')}


### PR DESCRIPTION
### **User description**
## Summary

* what changed:

  * Added lowercase canonical routes: `/login`, `/signup`, `/contact`
  * Converted uppercase routes into redirects:

    * `/Login` → `/login`
    * `/Signup` → `/signup`
    * `/Contact` → `/contact`
  * Updated Navbar navigation to use lowercase paths

* why it changed:

  * Auth routing logic generates lowercase paths (`/login`)
  * Router previously defined uppercase routes (`/Login`)
  * This mismatch caused broken redirects and failed login navigation

* risk area touched:

  * `auth`

## Validation

* [x] commits are signed off with DCO (`git commit -s`)
* [x] `npm run test`
* [x] `npx tsc --noEmit`
* [x] `npm run build:web`
* [x] `npm run env:check`
* [ ] `npm run lint:ci`
* [x] relevant route or smoke checks
* [ ] security checks when secrets, auth, infra, or deploy paths changed

Manual checks:

* `/login`, `/signup`, `/contact` render correctly
* `/Login`, `/Signup`, `/Contact` redirect to lowercase routes
* Protected routes redirect correctly to `/login`
* Navbar navigation works with updated lowercase paths

## Notes

* deployment impact:

  * None (routing normalization only)

* migration or env requirements:

  * None

* follow-up work if any:

  * Optional: standardize route casing across the codebase

* reviewer callouts or CODEOWNERS you expect to review this:

  * Auth / routing maintainers


___

### **PR Type**
Bug fix


___

### **Description**
- Standardizes auth-related routes to lowercase (e.g., `/login`).

- Redirects old uppercase routes to lowercase, preserving query parameters.

- Updates Navbar login links to use the new lowercase paths.

- Fixes broken redirects and navigation issues in the authentication flow.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User navigates to /Login?foo=bar"] --> B{RedirectWithQuery};
  B -- "Preserves query & hash" --> C["Redirects to /login?foo=bar"];
  C --> D["Renders LoginPage"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Standardize routes to lowercase and add redirects that preserve query </code><br><code>params</code></dd></summary>
<hr>

src/App.tsx

<ul><li>Replaced uppercase routes like <code>/Login</code> with lowercase canonical <br>versions like <code>/login</code>.<br> <li> Introduced a <code>RedirectWithQuery</code> component to redirect from old <br>uppercase paths to the new lowercase ones.<br> <li> The redirect component ensures that URL query parameters and hashes <br>are preserved during redirection.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/874/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2">+12/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Navbar.tsx</strong><dd><code>Update Navbar login links to use lowercase route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Navbar.tsx

<ul><li>Updated <code>onClick</code> handlers for the login button to navigate to <code>/login</code> <br>instead of <code>/Login</code>.<br> <li> Aligns the navigation component with the new lowercase routing <br>convention.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/874/files#diff-a0439d8a2cb6dee715c41a795bb174a2a65ad61704e88691fe5ab2b2bd6f798e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
