### PR TITLE
fix: mask public profile names

### DIFF
--- a/api/public-investor-profile.js
+++ b/api/public-investor-profile.js
@@ -64,6 +64,27 @@ export const maskPublicEmail = (email) => {
   return `${username.slice(0, 1)}***${username.slice(-1)}@${domain}`;
 };
 
+export const maskPublicName = (name) => {
+  if (!name || typeof name !== "string") {
+    return "Public Investor";
+  }
+
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return "Public Investor";
+  }
+
+  if (parts.length === 1) {
+    const [singleName] = parts;
+    return singleName.length <= 2
+      ? `${singleName.slice(0, 1) || "*"}***`
+      : `${singleName.slice(0, 1)}***${singleName.slice(-1)}`;
+  }
+
+  return `${parts[0].slice(0, 1) || "*"}*** ${parts[parts.length - 1]}`;
+};
+
 export const buildPublicInvestorProfilePayload = (
   profileRow,
   onboardingRow = null
@@ -128,7 +149,7 @@ export const buildPublicInvestorProfilePayload = (
     is_confirmed: isConfirmed,
     basic_info: {
       name: isPublicProfileFieldVisible(privacySettings, "basic_info", "name")
-        ? profileRow.name?.trim() || "Public Investor"
+        ? maskPublicName(profileRow.name)
         : "Public Investor",
       email: isPublicProfileFieldVisible(privacySettings, "basic_info", "email")
         ? maskPublicEmail(profileRow.email)

--- a/src/utils/maskSensitiveData.ts
+++ b/src/utils/maskSensitiveData.ts
@@ -51,7 +51,7 @@ export function maskName(name: string): string {
 
   const [firstName] = parts;
   const lastName = parts[parts.length - 1];
-  return `${firstName[0] || '*'}*** ${lastName}`;
+  return `${firstName[0]}*** ${lastName[0]}.`;
 }
 
 export interface MaskedProfileData {

--- a/src/utils/maskSensitiveData.ts
+++ b/src/utils/maskSensitiveData.ts
@@ -30,6 +30,30 @@ export function maskPhone(phoneNumber: string, countryCode: string): string {
   return `${countryCode}-***-${lastFour}`;
 }
 
+export function maskName(name: string): string {
+  if (!name || typeof name !== 'string') return 'Anonymous';
+
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return 'Anonymous';
+  }
+
+  if (parts.length === 1) {
+    const [singleName] = parts;
+    return singleName.length <= 2
+      ? `${singleName[0] || '*'}***`
+      : `${singleName[0]}***${singleName.slice(-1)}`;
+  }
+
+  const [firstName] = parts;
+  const lastName = parts[parts.length - 1];
+  return `${firstName[0] || '*'}*** ${lastName}`;
+}
+
 export interface MaskedProfileData {
   name: string;
   email: string;
@@ -41,7 +65,7 @@ export interface MaskedProfileData {
 
 export function maskProfileData(profileData: any): MaskedProfileData {
   return {
-    name: profileData.name,
+    name: maskName(profileData.name),
     email: maskEmail(profileData.email),
     age: profileData.age,
     phone: maskPhone(profileData.phone_number, profileData.phone_country_code),

--- a/tests/maskSensitiveData.test.ts
+++ b/tests/maskSensitiveData.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  maskEmail,
+  maskName,
+  maskPhone,
+  maskProfileData,
+} from "../src/utils/maskSensitiveData";
+
+describe("maskSensitiveData", () => {
+  it("masks full names in profile data", () => {
+    expect(
+      maskProfileData({
+        name: "John Alexander Doe",
+        email: "john@example.com",
+        age: 34,
+        phone_number: "5551234567",
+        phone_country_code: "+1",
+        organisation: "Hushh",
+        slug: "john-doe",
+      })
+    ).toEqual({
+      name: "J*** Doe",
+      email: "j***n@example.com",
+      age: 34,
+      phone: "+1-***-4567",
+      organisation: "Hushh",
+      slug: "john-doe",
+    });
+  });
+
+  it("masks single-word and short names safely", () => {
+    expect(maskName("Prince")).toBe("P***e");
+    expect(maskName("Al")).toBe("A***");
+    expect(maskName("  ")).toBe("Anonymous");
+  });
+
+  it("keeps existing email and phone masking behavior", () => {
+    expect(maskEmail("ab@example.com")).toBe("a***@example.com");
+    expect(maskPhone("555-1212", "+1")).toBe("+1-***-1212");
+  });
+});

--- a/tests/publicInvestorProfileApiRoute.test.ts
+++ b/tests/publicInvestorProfileApiRoute.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildPublicInvestorProfilePayload,
   maskPublicEmail,
+  maskPublicName,
 } from "../api/public-investor-profile.js";
 
 describe("public investor profile API projection", () => {
@@ -30,7 +31,7 @@ describe("public investor profile API projection", () => {
       slug: "ankit-kumar-singh-2597e6b8",
       is_confirmed: false,
       basic_info: {
-        name: "Ankit Kumar Singh",
+        name: "A*** Singh",
         email: "a***t@hushh.ai",
       },
       investor_profile: null,
@@ -85,6 +86,7 @@ describe("public investor profile API projection", () => {
     );
 
     expect(payload.is_confirmed).toBe(true);
+    expect(payload.basic_info.name).toBe("N*** Meena");
     expect(payload.basic_info.email).toBe("n***h@hushh.ai");
     expect(payload.investor_profile).toEqual({
       primary_goal: {
@@ -106,5 +108,12 @@ describe("public investor profile API projection", () => {
   it("masks short usernames safely", () => {
     expect(maskPublicEmail("ab@example.com")).toBe("a***@example.com");
     expect(maskPublicEmail("abcdef@example.com")).toBe("a***f@example.com");
+  });
+
+  it("masks public names safely", () => {
+    expect(maskPublicName("John Alexander Doe")).toBe("J*** Doe");
+    expect(maskPublicName("Prince")).toBe("P***e");
+    expect(maskPublicName("Al")).toBe("A***");
+    expect(maskPublicName("  ")).toBe("Public Investor");
   });
 });


### PR DESCRIPTION
### **User description**
Submission Details (Hushh Challenge)
GitHub Profile: https://github.com/Krishwall
Track Chosen:  hushhTech
Issue / Problem Statement: Fixes #845 — Public investor profile API was exposing full legal names (PII leak)
Pull Request Link: https://github.com/hushh-labs/hushh_Tech_website/pull/878

## Summary

- what changed:
  - Added public name masking for investor profile API payloads.
  - Added frontend masking utility coverage for profile names.
  - Added regression tests for API-level and utility-level name masking.
- why it changed:
  - Fixes #845 by preventing public investor profile responses from exposing full legal names.
- risk area touched: `api` | `security`

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed

Focused checks run:

```bash
npm.cmd test -- --run tests/maskSensitiveData.test.ts
npm.cmd test -- --run tests/publicInvestorProfileApiRoute.test.ts


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes a PII exposure vulnerability by masking user names.

- Introduces two new name-masking utility functions.

- Updates the public investor profile API to return masked names.

- Adds comprehensive tests for the new masking logic.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Profile Data (DB)"] -- "Full Name" --> B["API Endpoint"];
  C["maskPublicName() utility"]
  B -- "Calls" --> C;
  C -- "Masked Name (e.g., J*** Doe)" --> B;
  B -- "Returns Masked Profile" --> D["Client/Frontend"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maskSensitiveData.ts</strong><dd><code>Introduce a general-purpose name masking utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/maskSensitiveData.ts

<ul><li>Introduces a new <code>maskName</code> utility function to obscure full names.<br> <li> The function masks multi-word names to the format <code>J*** D.</code>.<br> <li> Updates the generic <code>maskProfileData</code> helper to use this new masking <br>logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/878/files#diff-3380dbae00740dc364b1783d7d5d1a17b1d3bdd4c094de7d8f4c7358b7faf4d1">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>maskSensitiveData.test.ts</strong><dd><code>Add unit tests for the new name masking utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/maskSensitiveData.test.ts

<ul><li>Adds a new test suite for the sensitive data masking utilities.<br> <li> Verifies that <code>maskProfileData</code> correctly applies name masking.<br> <li> Includes test cases for single-word, short, and empty names.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/878/files#diff-b330effe0e6ada3a2a705309e6200e0647eb1ad4b5401f0ba47df0a914781e6d">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>publicInvestorProfileApiRoute.test.ts</strong><dd><code>Update API tests to assert name masking is applied</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/publicInvestorProfileApiRoute.test.ts

<ul><li>Updates API test snapshots to expect masked names in payloads.<br> <li> Adds a new test case to validate the behavior of <code>maskPublicName</code> with <br>various inputs.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/878/files#diff-fecf2f542fbcf125730e72df3cd14030c2eda77816bf3244e1ae297a32c341fc">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>public-investor-profile.js</strong><dd><code>Apply name masking to the public investor profile API response</code></dd></summary>
<hr>

api/public-investor-profile.js

<ul><li>Adds a <code>maskPublicName</code> utility specifically for the public API.<br> <li> This function masks multi-word names to the format <code>J*** Doe</code>.<br> <li> Updates <code>buildPublicInvestorProfilePayload</code> to use <code>maskPublicName</code>, <br>fixing the PII leak.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/878/files#diff-82c1f97e1c41fa49f27ece6b8d93be9dc2f20875d3ad54270df3e3730ea7edde">+22/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
