### PR TITLE
fix: move wallet model out of api path

### DIFF
--- a/src/services/walletPass.ts
+++ b/src/services/walletPass.ts
@@ -1,7 +1,7 @@
 import {
   buildGoldPassPayload as buildSharedGoldPassPayload,
   buildWalletCardContent,
-} from "../../api/shared/walletPassModel.js";
+} from "../shared/walletPassModel";
 
 const HUSHH_WALLET_ENDPOINT = "/api/wallet-pass";
 const HUSHH_GOOGLE_WALLET_ENDPOINT = "/api/google-wallet-pass";

--- a/src/shared/walletPassModel.ts
+++ b/src/shared/walletPassModel.ts
@@ -102,9 +102,8 @@ const buildPublicProfileUrl = (input?: WalletPassModelInput) =>
 const buildMembershipId = (input?: WalletPassModelInput) =>
   getTrimmedString(input?.slug) ||
   getTrimmedString(input?.userId) ||
-  (getTrimmedString(input?.email)
-    ? getTrimmedString(input?.email).split("@")[0]
-    : "hushh-investor");
+  getTrimmedString(input?.email).split("@")[0] ||
+  "hushh-investor";
 
 export const buildWalletCardContent = (
   input: WalletPassModelInput = {}

--- a/src/shared/walletPassModel.ts
+++ b/src/shared/walletPassModel.ts
@@ -232,7 +232,9 @@ export const buildWalletCardContentFromPayload = (
     membershipId: getWalletPayloadFieldValue(
       payload?.auxiliaryFields,
       "memberId",
-      passUrl
+      passUrl === DEFAULT_WALLET_ROOT_URL
+        ? "hushh-investor"
+        : passUrl.split("/").pop() || "hushh-investor"
     ),
     email: getWalletPayloadFieldValue(payload?.auxiliaryFields, "email", "\u2014"),
     profileUrl: passUrl !== DEFAULT_WALLET_ROOT_URL ? passUrl : null,

--- a/src/shared/walletPassModel.ts
+++ b/src/shared/walletPassModel.ts
@@ -1,0 +1,241 @@
+export const DEFAULT_WALLET_ROOT_URL = "https://hushhtech.com";
+export const WALLET_CARD_BADGE_TEXT = "HUSHH GOLD";
+export const WALLET_CARD_TITLE = "Hushh Gold Investor Pass";
+export const WALLET_CARD_ORGANIZATION_NAME = "Hushh Technologies";
+export const WALLET_CARD_ORGANIZATION_FALLBACK = "Hushh";
+export const WALLET_CARD_STATUS = "Gold Member";
+
+export interface WalletPassModelInput {
+  name?: string | null;
+  email?: string | null;
+  organisation?: string | null;
+  slug?: string | null;
+  userId?: string | null;
+  investmentAmount?: number | null;
+}
+
+export interface WalletPassField {
+  key: string;
+  label: string;
+  value: string;
+  textAlignment: "PKTextAlignmentLeft";
+}
+
+export interface GoldPassPayload {
+  type: "storeCard";
+  passType: "storeCard";
+  description: string;
+  organizationName: string;
+  logoText: string;
+  backgroundColor: string;
+  foregroundColor: string;
+  labelColor: string;
+  headerFields: WalletPassField[];
+  primaryFields: WalletPassField[];
+  secondaryFields: WalletPassField[];
+  auxiliaryFields: WalletPassField[];
+  barcode: {
+    message: string;
+    format: "PKBarcodeFormatQR";
+    altText: string;
+  };
+  webServiceURL: string;
+}
+
+export interface WalletCardContent {
+  badgeText: string;
+  title: string;
+  status: string;
+  holderName: string;
+  organizationName: string;
+  investmentClass: string;
+  investmentLabel: string;
+  membershipId: string;
+  email: string;
+  profileUrl: string | null;
+  passUrl: string;
+}
+
+const getTrimmedString = (value: unknown) =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : "";
+
+export const getWalletPayloadFieldValue = (
+  fields: unknown,
+  key: string,
+  fallback = ""
+) => {
+  if (!Array.isArray(fields)) {
+    return fallback;
+  }
+
+  const field = fields.find((item) => item?.key === key);
+  const value = getTrimmedString(field?.value);
+  return value || fallback;
+};
+
+export const getWalletInvestmentClass = (amount: unknown) => {
+  if (typeof amount !== "number" || Number.isNaN(amount)) {
+    return "Class C";
+  }
+
+  if (amount >= 5_000_000) return "Class A";
+  if (amount >= 2_000_000) return "Class B";
+  return "Class C";
+};
+
+const normalizeInvestmentClass = (value: unknown) => {
+  const normalizedValue = getTrimmedString(value).replace(/^Investor\s*-\s*/i, "");
+  return normalizedValue || "Class C";
+};
+
+const buildInvestmentLabel = (investmentClass: string) =>
+  `Investor - ${investmentClass}`;
+
+const getDisplayValue = (value: unknown, fallback: string) =>
+  getTrimmedString(value) || fallback;
+
+const buildPublicProfileUrl = (input?: WalletPassModelInput) =>
+  getTrimmedString(input?.slug)
+    ? `${DEFAULT_WALLET_ROOT_URL}/investor/${getTrimmedString(input?.slug)}`
+    : null;
+
+const buildMembershipId = (input?: WalletPassModelInput) =>
+  getTrimmedString(input?.slug) ||
+  getTrimmedString(input?.userId) ||
+  (getTrimmedString(input?.email)
+    ? getTrimmedString(input?.email).split("@")[0]
+    : "hushh-investor");
+
+export const buildWalletCardContent = (
+  input: WalletPassModelInput = {}
+): WalletCardContent => {
+  const profileUrl = buildPublicProfileUrl(input);
+  const investmentClass = getWalletInvestmentClass(input.investmentAmount);
+
+  return {
+    badgeText: WALLET_CARD_BADGE_TEXT,
+    title: WALLET_CARD_TITLE,
+    status: WALLET_CARD_STATUS,
+    holderName: getDisplayValue(input.name, "Hushh Investor"),
+    organizationName: getDisplayValue(
+      input.organisation,
+      WALLET_CARD_ORGANIZATION_FALLBACK
+    ),
+    investmentClass,
+    investmentLabel: buildInvestmentLabel(investmentClass),
+    membershipId: buildMembershipId(input),
+    email: getDisplayValue(input.email, "\u2014"),
+    profileUrl,
+    passUrl: profileUrl || DEFAULT_WALLET_ROOT_URL,
+  };
+};
+
+export const buildGoldPassPayload = (
+  input: WalletPassModelInput = {}
+): GoldPassPayload => {
+  const content = buildWalletCardContent(input);
+
+  return {
+    type: "storeCard",
+    passType: "storeCard",
+    description: content.title,
+    organizationName: WALLET_CARD_ORGANIZATION_NAME,
+    logoText: "hushh Gold Pass",
+    backgroundColor: "rgb(212, 175, 55)",
+    foregroundColor: "rgb(12, 12, 12)",
+    labelColor: "rgb(32, 32, 32)",
+    headerFields: [
+      {
+        key: "status",
+        label: "Status",
+        value: content.status,
+        textAlignment: "PKTextAlignmentLeft",
+      },
+      {
+        key: "org",
+        label: "Organization",
+        value: content.organizationName,
+        textAlignment: "PKTextAlignmentLeft",
+      },
+    ],
+    primaryFields: [
+      {
+        key: "investor",
+        label: "Holder",
+        value: content.holderName,
+        textAlignment: "PKTextAlignmentLeft",
+      },
+    ],
+    secondaryFields: [
+      {
+        key: "class",
+        label: "Investor",
+        value: content.investmentLabel,
+        textAlignment: "PKTextAlignmentLeft",
+      },
+    ],
+    auxiliaryFields: [
+      {
+        key: "email",
+        label: "Email",
+        value: content.email,
+        textAlignment: "PKTextAlignmentLeft",
+      },
+      {
+        key: "memberId",
+        label: "Membership ID",
+        value: content.membershipId,
+        textAlignment: "PKTextAlignmentLeft",
+      },
+    ],
+    barcode: {
+      message: content.passUrl,
+      format: "PKBarcodeFormatQR",
+      altText: "Hushh Gold Pass QR",
+    },
+    webServiceURL: content.passUrl,
+  };
+};
+
+export const buildWalletCardContentFromPayload = (
+  payload: Partial<GoldPassPayload> = {}
+): WalletCardContent => {
+  const passUrl =
+    getTrimmedString(payload?.barcode?.message) || DEFAULT_WALLET_ROOT_URL;
+  const investmentLabel = getWalletPayloadFieldValue(
+    payload?.secondaryFields,
+    "class",
+    buildInvestmentLabel("Class C")
+  );
+
+  return {
+    badgeText: WALLET_CARD_BADGE_TEXT,
+    title: getTrimmedString(payload?.description) || WALLET_CARD_TITLE,
+    status: getWalletPayloadFieldValue(
+      payload?.headerFields,
+      "status",
+      WALLET_CARD_STATUS
+    ),
+    holderName: getWalletPayloadFieldValue(
+      payload?.primaryFields,
+      "investor",
+      "Hushh Investor"
+    ),
+    organizationName: getWalletPayloadFieldValue(
+      payload?.headerFields,
+      "org",
+      getTrimmedString(payload?.organizationName) ||
+        WALLET_CARD_ORGANIZATION_NAME
+    ),
+    investmentClass: normalizeInvestmentClass(investmentLabel),
+    investmentLabel,
+    membershipId: getWalletPayloadFieldValue(
+      payload?.auxiliaryFields,
+      "memberId",
+      passUrl
+    ),
+    email: getWalletPayloadFieldValue(payload?.auxiliaryFields, "email", "\u2014"),
+    profileUrl: passUrl !== DEFAULT_WALLET_ROOT_URL ? passUrl : null,
+    passUrl,
+  };
+};

--- a/tests/walletPass.test.ts
+++ b/tests/walletPass.test.ts
@@ -17,7 +17,7 @@ import {
   isAppleWalletSupported,
   requestGoogleWalletPass,
 } from "../src/services/walletPass";
-import { buildWalletCardContentFromPayload } from "../api/shared/walletPassModel.js";
+import { buildWalletCardContentFromPayload } from "../src/shared/walletPassModel";
 
 describe("wallet pass service", () => {
   beforeEach(() => {


### PR DESCRIPTION
### **User description**

GitHub Profile: https://github.com/Krishwall
Track Chosen: hushhTech
Issue / Problem Statement: Fixes #772 — Vite dev server throwing 500 due to incorrect frontend import path
Pull Request Link: https://github.com/hushh-labs/hushh_Tech_website/pull/879


## Summary

- what changed:
  - Added a typed frontend-safe wallet model module at `src/shared/walletPassModel.ts`.
  - Updated `src/services/walletPass.ts` to import wallet model helpers from `src/shared` instead of `api/shared`.
  - Updated wallet service tests to use the new shared frontend module.
- why it changed:
  - Fixes #772 by preventing Vite from resolving the frontend wallet model import as `/api/shared/walletPassModel.js`, which was intercepted by the dev API proxy and caused 500/404 failures.
  - Resolves the TypeScript implicit `any` issue from importing a JavaScript module without declarations.
- risk area touched: `ui` | `api`

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [x] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed

Focused checks run:

```bash
npm.cmd test -- --run tests/walletPass.test.ts
npx.cmd tsc --noEmit
npm.cmd test -- --run tests/walletPass.test.ts tests/walletApiRoutes.test.ts tests/googleWalletLocalRoute.test.ts tests/walletPreviewModal.test.ts tests/investorProfileWalletUi.test.ts tests/publicInvestorProfilePage.test.ts

## Notes


- deployment impact: none expected; this changes frontend module resolution and keeps existing API route imports stable.
migration or env requirements: none.
- follow-up work if any: consider consolidating the remaining server-side api/shared/walletPassModel.js copy with the typed shared model in a future refactor.
- reviewer callouts or CODEOWNERS you expect to review this: default CODEOWNERS / @ankitkumarsingh1702.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Moves wallet model from `/api` to `/src/shared`.

- Fixes a Vite dev server proxy bug causing 500 errors.

- Converts the wallet model from JavaScript to TypeScript.

- Updates imports in the wallet service and tests.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph "Before: Incorrect Proxying"
        A["Frontend Component"] -- "import '../../api/shared/...js'" --> B["Vite Dev Server"]
        B -- "resolves to /api/*" --> C{Vite Proxy}
        C -- "forwards to API" --> D["💥 500 Error"]
    end

    subgraph "After: Correct Module Resolution"
        E["Frontend Component"] -- "import '../shared/...ts'" --> F["Vite Dev Server"]
        F -- "resolves as local module" --> G["✅ /src/shared/walletPassModel.ts"]
    end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>walletPass.ts</strong><dd><code>Update wallet service to import from new shared module</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/services/walletPass.ts

<ul><li>Updates the import path for wallet model helpers.<br> <li> The import now points to the new <code>../shared/walletPassModel</code> module <br>instead of the problematic <code>../../api/shared/walletPassModel.js</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/879/files#diff-7b46a254339ea2d3da5192e6532b489e36580a7c9063e17eba4c9b170eb1fcf1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>walletPassModel.ts</strong><dd><code>Create typed TypeScript module for wallet pass logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/shared/walletPassModel.ts

<ul><li>Adds a new TypeScript file containing shared wallet pass logic.<br> <li> Defines interfaces like <code>WalletPassModelInput</code> and <code>GoldPassPayload</code> for <br>type safety.<br> <li> Exports functions to build wallet card content and payloads, <br>previously in a JS file.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/879/files#diff-f28716b80285aa808a557ede6e5e1f10aa460f2853f297b0c7a4b609f8f9d861">+242/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>walletPass.test.ts</strong><dd><code>Update test import path for wallet model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/walletPass.test.ts

<ul><li>Updates the import path for <code>buildWalletCardContentFromPayload</code>.<br> <li> Aligns the test file with the new location of the shared wallet model <br>module.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/879/files#diff-9d0ef68ca4c37d57b99367ee7fd9e1597b27ffe5f7d6b7dc0907c104eedf9d77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
