### PR TITLE
fix(nda): prevent duplicate NDA submissions

### DIFF
--- a/src/components/NDARequestModal.tsx
+++ b/src/components/NDARequestModal.tsx
@@ -146,17 +146,10 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
     if (isSubmittingRef.current || isSubmitting) {
       return;
     }
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
 
-    // Ensure Step 1 was valid (though goToStep should have caught this)
-    if (!validateStep1() && currentStep === 1) { // Should not happen if goToStep(2) was used
-        toast({ title: "Error", description: "Please complete investor profile first.", status: "error" });
-        setCurrentStep(1); // Force back to step 1
-        return;
-    }
-    if (!ndaConfirmed || !ndaTermsAccepted) {
-        toast({ title: "NDA Acceptance Required", description: "Please confirm and accept NDA terms.", status: "warning" });
-        return;
-    }
+    
 
     console.log("Submitting NDA Request with metadata:", metadata);
     const formattedMetadata = { ...metadata };
@@ -170,9 +163,19 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
         formattedMetadata.contact_person_telephone
       );
     }
-    isSubmittingRef.current = true;
-    setIsSubmitting(true);
+    
     try {
+      
+      // Ensure Step 1 was valid (though goToStep should have caught this)
+    if (!validateStep1() && currentStep === 1) { // Should not happen if goToStep(2) was used
+        toast({ title: "Error", description: "Please complete investor profile first.", status: "error" });
+        setCurrentStep(1); // Force back to step 1
+        return;
+    }
+    if (!ndaConfirmed || !ndaTermsAccepted) {
+        toast({ title: "NDA Acceptance Required", description: "Please confirm and accept NDA terms.", status: "warning" });
+        return;
+    }
       const resData = await requestFileAccess(session.access_token, {
         investorType,
         metadata: JSON.stringify(formattedMetadata),

--- a/src/components/NDARequestModal.tsx
+++ b/src/components/NDARequestModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Box,
   Container,
@@ -65,6 +65,8 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
   const [formErrors, setFormErrors] = useState<any>({});
   const [ndaConfirmed, setNdaConfirmed] = useState(false);
   const [ndaTermsAccepted, setNdaTermsAccepted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isSubmittingRef = useRef(false);
   const [showNdaDocModal, setShowNdaDocModal] = useState(false);
   const toast = useToast();
 
@@ -141,6 +143,10 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
   };
 
   const handleSubmit = async () => {
+    if (isSubmittingRef.current || isSubmitting) {
+      return;
+    }
+
     // Ensure Step 1 was valid (though goToStep should have caught this)
     if (!validateStep1() && currentStep === 1) { // Should not happen if goToStep(2) was used
         toast({ title: "Error", description: "Please complete investor profile first.", status: "error" });
@@ -164,6 +170,8 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
         formattedMetadata.contact_person_telephone
       );
     }
+    isSubmittingRef.current = true;
+    setIsSubmitting(true);
     try {
       const resData = await requestFileAccess(session.access_token, {
         investorType,
@@ -214,6 +222,9 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
         duration: 4000,
         isClosable: true,
       });
+    } finally {
+      isSubmittingRef.current = false;
+      setIsSubmitting(false);
     }
   };
 
@@ -560,7 +571,7 @@ const InvestorProfilePage: React.FC<NDARequestModalProps> = ({
           <Button onClick={() => goToStep(1)} size="md" width="40%" py={6} borderRadius="md" bg="transparent" color="black" border="1px solid">
             Back to Profile
           </Button>
-          <Button onClick={handleSubmit} background="linear-gradient(to right, #00A9E0, #6DD3EF)" _hover={{ background: "linear-gradient(to right, #0AADBC, #1CADBC)" }} color={'white'} size="md" width="60%" py={6} borderRadius="md" isDisabled={!ndaConfirmed || !ndaTermsAccepted}>
+          <Button onClick={handleSubmit} background="linear-gradient(to right, #00A9E0, #6DD3EF)" _hover={{ background: "linear-gradient(to right, #0AADBC, #1CADBC)" }} color={'white'} size="md" width="60%" py={6} borderRadius="md" isDisabled={!ndaConfirmed || !ndaTermsAccepted || isSubmitting}>
             Submit NDA & Investor Profile
           </Button>
         </HStack>

--- a/tests/ndaRequestModal.test.ts
+++ b/tests/ndaRequestModal.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ChakraProvider } from "@chakra-ui/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import theme from "../src/theme";
+
+const requestFileAccessMock = vi.fn();
+
+vi.mock("../src/services/access/accessControlApi", () => ({
+  requestFileAccess: (...args: unknown[]) => requestFileAccessMock(...args),
+}));
+
+vi.mock("react-phone-input-2", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value?: string;
+    onChange: (value: string) => void;
+  }) =>
+    React.createElement("input", {
+      "data-testid": "phone-input",
+      value: value || "",
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+        onChange(event.target.value),
+    }),
+}));
+
+import NDARequestModal from "../src/components/NDARequestModal";
+
+describe("NDARequestModal duplicate submit guard", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const flush = async () => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  const setInputValue = async (selector: string, value: string) => {
+    const input = container.querySelector(selector) as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value"
+      )?.set;
+      valueSetter?.call(input, value);
+      input!.dispatchEvent(new Event("input", { bubbles: true }));
+      input!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+  };
+
+  const clickButtonByText = async (text: string) => {
+    const button = Array.from(container.querySelectorAll("button")).find((candidate) =>
+      candidate.textContent?.includes(text)
+    ) as HTMLButtonElement | undefined;
+    expect(button).toBeTruthy();
+    await act(async () => {
+      button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("calls requestFileAccess only once while a submit is pending", async () => {
+    let resolveRequest: ((value: string) => void) | null = null;
+    requestFileAccessMock.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          ChakraProvider,
+          { theme },
+          React.createElement(NDARequestModal, {
+            session: { access_token: "token-123" },
+            onSubmit: vi.fn(),
+            isOpen: true,
+          })
+        )
+      );
+    });
+    await flush();
+
+    await setInputValue('input[placeholder="Enter your full name"]', "Jane Doe");
+    await setInputValue(
+      'input[placeholder="Enter your state for taxation"]',
+      "California"
+    );
+    await setInputValue('input[placeholder="Enter your city for taxation"]', "San Jose");
+    await setInputValue(
+      'input[placeholder="Enter your country for taxation"]',
+      "United States"
+    );
+    await setInputValue('input[placeholder="Enter your address"]', "1 Main Street");
+    await setInputValue(
+      'input[placeholder="Enter your legal email"]',
+      "jane@example.com"
+    );
+    await setInputValue('input[data-testid="phone-input"]', "1234567890");
+
+    await clickButtonByText("Continue to NDA Review");
+    await flush();
+    expect(container.textContent).toContain("Review and Sign Non-Disclosure Agreement");
+
+    const ndaCheckboxes = container.querySelectorAll(
+      'input[type="checkbox"]'
+    ) as NodeListOf<HTMLInputElement>;
+    expect(ndaCheckboxes.length).toBeGreaterThanOrEqual(2);
+    await act(async () => {
+      ndaCheckboxes[0].click();
+      ndaCheckboxes[1].click();
+    });
+    await flush();
+
+    const submitButton = Array.from(container.querySelectorAll("button")).find(
+      (candidate) =>
+        candidate.textContent?.includes("Submit NDA & Investor Profile")
+    ) as HTMLButtonElement | undefined;
+    expect(submitButton).toBeTruthy();
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(requestFileAccessMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRequest?.("Pending");
+      await Promise.resolve();
+    });
+  });
+});


### PR DESCRIPTION
### **User description**
## Summary

* what changed:

  * Added an in-flight submission guard to `NDARequestModal`.
  * Prevented duplicate `requestFileAccess` calls while a submission is pending.
  * Added focused regression coverage for rapid repeated submit attempts.

* why it changed:

  * Multiple rapid clicks on the NDA submit action could trigger duplicate backend requests before React state updates disabled the button.
  * This could lead to duplicate workflows, repeated navigation/toast behavior, and inconsistent request handling.

* risk area touched:

  * `ui`

## Validation

* [x] commits are signed off with DCO (`git commit -s`)
* [x] `npm run test -- tests/ndaRequestModal.test.ts`
* [x] `npx tsc --noEmit`
* [ ] `npm run build:web`
* [ ] `npm run env:check`
* [ ] `npm run lint:ci`
* [x] relevant route or smoke checks
* [ ] security checks when secrets, auth, infra, or deploy paths changed

Additional notes:

* Regression test uses a delayed mocked `requestFileAccess` promise to deterministically verify duplicate submissions are blocked while pending.
* A synchronous ref-based lock is used alongside state to prevent same-render-frame double-click races before React commits disabled state updates.
* `npm run lint:ci` may require a bash/WSL environment locally on Windows.

## Notes

* deployment impact:

  * None. This is a localized concurrency guard for NDA submission flow behavior.

* migration or env requirements:

  * None.

* follow-up work if any:

  * Optional future review of other async form submissions for similar in-flight request protection patterns.

* reviewer callouts or CODEOWNERS you expect to review this:

  * NDA/workflow maintainers or default CODEOWNERS for `NDARequestModal`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Prevents duplicate NDA form submissions on rapid clicks.

- Adds a submission guard using `useState` and `useRef`.

- Disables the submit button while the request is in-flight.

- Includes a new regression test to verify the fix.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User clicks 'Submit'"] --> B{isSubmitting?};
  B -- "No" --> C["Set isSubmitting = true"];
  C --> D["requestFileAccess() API Call"];
  B -- "Yes" --> E["Return (do nothing)"];
  D -- "Finally" --> F["Set isSubmitting = false"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NDARequestModal.tsx</strong><dd><code>Implement submission guard to prevent duplicate requests</code>&nbsp; </dd></summary>
<hr>

src/components/NDARequestModal.tsx

<ul><li>Added <code>isSubmitting</code> state and an <code>isSubmittingRef</code> to act as a submission <br>guard.<br> <li> The <code>handleSubmit</code> function now immediately returns if a submission is <br>already in progress.<br> <li> The submission state is reset within a <code>finally</code> block to ensure the <br>form is usable after success or failure.<br> <li> The "Submit" button is now disabled when <code>isSubmitting</code> is true.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/880/files#diff-dfa07ec29e46c210237f00498e802a1f2689f90f7f67a24177f205721d389053">+25/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ndaRequestModal.test.ts</strong><dd><code>Add regression test for duplicate NDA submission guard</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/ndaRequestModal.test.ts

<ul><li>Added a new test suite for the <code>NDARequestModal</code> component.<br> <li> Mocks the <code>requestFileAccess</code> API to simulate a pending network request.<br> <li> Asserts that multiple rapid clicks on the submit button result in only <br>a single API call.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/880/files#diff-51c02ba5ad1d18775ce58ef73aba10400af2199b5348536f2e1f915466ed274e">+158/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
