### PR TITLE
fix(api): accept raw JSON bodies in wallet pass proxies

### DIFF
--- a/api/google-wallet-pass.js
+++ b/api/google-wallet-pass.js
@@ -18,7 +18,7 @@ const resolvePayload = (body) => {
   if (!body) return null;
   if (typeof body === "string") {
     try {
-      return JSON.parse(body);
+      return resolvePayload(JSON.parse(body));
     } catch {
       return null;
     }

--- a/api/google-wallet-pass.js
+++ b/api/google-wallet-pass.js
@@ -16,6 +16,13 @@ let upstreamAvailabilityCache = null;
 
 const resolvePayload = (body) => {
   if (!body) return null;
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return null;
+    }
+  }
   if (typeof body.payload === "string") {
     try {
       return JSON.parse(body.payload);

--- a/api/google-wallet-pass.js
+++ b/api/google-wallet-pass.js
@@ -17,11 +17,21 @@ let upstreamAvailabilityCache = null;
 const resolvePayload = (body) => {
   if (!body) return null;
   if (typeof body === "string") {
-    try {
-      return resolvePayload(JSON.parse(body));
-    } catch {
+    let payload = body;
+
+    while (typeof payload === "string") {
+      try {
+        payload = JSON.parse(payload);
+      } catch {
+        return null;
+      }
+    }
+
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
       return null;
     }
+
+    body = payload;
   }
   if (typeof body.payload === "string") {
     try {

--- a/api/google-wallet-pass.js
+++ b/api/google-wallet-pass.js
@@ -11,6 +11,7 @@ const GOOGLE_WALLET_SCOPE =
   "https://www.googleapis.com/auth/wallet_object.issuer";
 const GOOGLE_WALLET_UNAVAILABLE_MESSAGE =
   "Google Wallet is temporarily unavailable while we finish the wallet issuer setup.";
+const MAX_UNWRAP_DEPTH = 5;
 
 let upstreamAvailabilityCache = null;
 
@@ -18,8 +19,13 @@ const resolvePayload = (body) => {
   if (!body) return null;
   if (typeof body === "string") {
     let payload = body;
+    let unwrapCount = 0;
 
     while (typeof payload === "string") {
+      if (unwrapCount++ >= MAX_UNWRAP_DEPTH) {
+        return null;
+      }
+
       try {
         payload = JSON.parse(payload);
       } catch {

--- a/api/wallet-pass.js
+++ b/api/wallet-pass.js
@@ -3,6 +3,13 @@ const UPSTREAM_APPLE_WALLET_ENDPOINT =
 
 const resolvePayload = (body) => {
   if (!body) return null;
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return null;
+    }
+  }
   if (typeof body.payload === "string") {
     try {
       return JSON.parse(body.payload);

--- a/api/wallet-pass.js
+++ b/api/wallet-pass.js
@@ -4,11 +4,21 @@ const UPSTREAM_APPLE_WALLET_ENDPOINT =
 const resolvePayload = (body) => {
   if (!body) return null;
   if (typeof body === "string") {
-    try {
-      return resolvePayload(JSON.parse(body));
-    } catch {
+    let payload = body;
+
+    while (typeof payload === "string") {
+      try {
+        payload = JSON.parse(payload);
+      } catch {
+        return null;
+      }
+    }
+
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
       return null;
     }
+
+    body = payload;
   }
   if (typeof body.payload === "string") {
     try {

--- a/api/wallet-pass.js
+++ b/api/wallet-pass.js
@@ -5,7 +5,7 @@ const resolvePayload = (body) => {
   if (!body) return null;
   if (typeof body === "string") {
     try {
-      return JSON.parse(body);
+      return resolvePayload(JSON.parse(body));
     } catch {
       return null;
     }

--- a/api/wallet-pass.js
+++ b/api/wallet-pass.js
@@ -1,12 +1,18 @@
 const UPSTREAM_APPLE_WALLET_ENDPOINT =
   "https://hushh-wallet.vercel.app/api/passes/universal/create";
+const MAX_UNWRAP_DEPTH = 5;
 
 const resolvePayload = (body) => {
   if (!body) return null;
   if (typeof body === "string") {
     let payload = body;
+    let unwrapCount = 0;
 
     while (typeof payload === "string") {
+      if (unwrapCount++ >= MAX_UNWRAP_DEPTH) {
+        return null;
+      }
+
       try {
         payload = JSON.parse(payload);
       } catch {

--- a/tests/walletApiRoutes.test.ts
+++ b/tests/walletApiRoutes.test.ts
@@ -420,4 +420,48 @@ describe("wallet proxy routes", () => {
       saveUrl: "https://pay.google.com/gp/v/save/nested-raw-json",
     });
   });
+
+  it("fails closed when Apple wallet payload unwrapping exceeds the maximum depth", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    let nestedBody = JSON.stringify({ passType: "storeCard", memberId: "too-deep" });
+    for (let index = 0; index < 6; index += 1) {
+      nestedBody = JSON.stringify(nestedBody);
+    }
+
+    const req = {
+      method: "POST",
+      body: nestedBody,
+    };
+    const res = createResponse();
+
+    await walletPassHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid wallet pass payload" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Google wallet payload unwrapping exceeds the maximum depth", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    let nestedBody = JSON.stringify({ passType: "storeCard", memberId: "too-deep" });
+    for (let index = 0; index < 6; index += 1) {
+      nestedBody = JSON.stringify(nestedBody);
+    }
+
+    const req = {
+      method: "POST",
+      body: nestedBody,
+    };
+    const res = createResponse();
+
+    await googleWalletPassHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid wallet pass payload" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/walletApiRoutes.test.ts
+++ b/tests/walletApiRoutes.test.ts
@@ -368,4 +368,56 @@ describe("wallet proxy routes", () => {
     expect(res.body).toEqual({ error: "Invalid wallet pass payload" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("fails closed when the wallet proxy receives JSON primitives", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: JSON.stringify(true),
+    };
+    const res = createResponse();
+
+    await walletPassHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid wallet pass payload" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("unwraps nested raw JSON strings without recursion for the Google Wallet proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ saveUrl: "https://pay.google.com/gp/v/save/nested-raw-json" }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const nestedBody = JSON.stringify(
+      JSON.stringify({
+        payload: JSON.stringify({ passType: "storeCard", memberId: "nested-raw-json" }),
+      })
+    );
+    const req = {
+      method: "POST",
+      body: nestedBody,
+    };
+    const res = createResponse();
+
+    await googleWalletPassHandler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hushh-wallet.vercel.app/api/passes/google/create",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ passType: "storeCard", memberId: "nested-raw-json" }),
+      })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      saveUrl: "https://pay.google.com/gp/v/save/nested-raw-json",
+    });
+  });
 });

--- a/tests/walletApiRoutes.test.ts
+++ b/tests/walletApiRoutes.test.ts
@@ -104,6 +104,36 @@ describe("wallet proxy routes", () => {
     expect(Buffer.isBuffer(res.body)).toBe(true);
   });
 
+  it("accepts raw JSON string bodies for the Apple Wallet proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({
+        "content-type": "application/vnd.apple.pkpass",
+      }),
+      arrayBuffer: async () => new TextEncoder().encode("pkpass").buffer,
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: JSON.stringify({ passType: "storeCard", memberId: "raw-json" }),
+    };
+    const res = createResponse();
+
+    await walletPassHandler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hushh-wallet.vercel.app/api/passes/universal/create",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ passType: "storeCard", memberId: "raw-json" }),
+      })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+  });
+
   it("returns Google Wallet save URLs from the same-origin proxy", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -131,6 +161,36 @@ describe("wallet proxy routes", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       saveUrl: "https://pay.google.com/gp/v/save/test",
+    });
+  });
+
+  it("accepts raw JSON string bodies for the Google Wallet proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ saveUrl: "https://pay.google.com/gp/v/save/raw-json" }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: JSON.stringify({ passType: "storeCard", memberId: "raw-json" }),
+    };
+    const res = createResponse();
+
+    await googleWalletPassHandler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hushh-wallet.vercel.app/api/passes/google/create",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ passType: "storeCard", memberId: "raw-json" }),
+      })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      saveUrl: "https://pay.google.com/gp/v/save/raw-json",
     });
   });
 
@@ -209,5 +269,22 @@ describe("wallet proxy routes", () => {
       detail:
         "Google Wallet is temporarily unavailable while we finish the wallet issuer setup.",
     });
+  });
+
+  it("fails closed when the wallet proxy receives malformed JSON strings", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: "{invalid-json}",
+    };
+    const res = createResponse();
+
+    await walletPassHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid wallet pass payload" });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/walletApiRoutes.test.ts
+++ b/tests/walletApiRoutes.test.ts
@@ -134,6 +134,38 @@ describe("wallet proxy routes", () => {
     expect(Buffer.isBuffer(res.body)).toBe(true);
   });
 
+  it("accepts wrapped raw JSON string payload bodies for the Apple Wallet proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({
+        "content-type": "application/vnd.apple.pkpass",
+      }),
+      arrayBuffer: async () => new TextEncoder().encode("pkpass").buffer,
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: JSON.stringify({
+        payload: JSON.stringify({ passType: "storeCard", memberId: "wrapped-raw-json" }),
+      }),
+    };
+    const res = createResponse();
+
+    await walletPassHandler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hushh-wallet.vercel.app/api/passes/universal/create",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ passType: "storeCard", memberId: "wrapped-raw-json" }),
+      })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+  });
+
   it("returns Google Wallet save URLs from the same-origin proxy", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -191,6 +223,38 @@ describe("wallet proxy routes", () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       saveUrl: "https://pay.google.com/gp/v/save/raw-json",
+    });
+  });
+
+  it("accepts wrapped raw JSON string payload bodies for the Google Wallet proxy", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ saveUrl: "https://pay.google.com/gp/v/save/wrapped-raw-json" }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: JSON.stringify({
+        payload: JSON.stringify({ passType: "storeCard", memberId: "wrapped-raw-json" }),
+      }),
+    };
+    const res = createResponse();
+
+    await googleWalletPassHandler(req, res);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hushh-wallet.vercel.app/api/passes/google/create",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ passType: "storeCard", memberId: "wrapped-raw-json" }),
+      })
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      saveUrl: "https://pay.google.com/gp/v/save/wrapped-raw-json",
     });
   });
 
@@ -282,6 +346,23 @@ describe("wallet proxy routes", () => {
     const res = createResponse();
 
     await walletPassHandler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid wallet pass payload" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the Google Wallet proxy receives malformed JSON strings", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const req = {
+      method: "POST",
+      body: "{invalid-json}",
+    };
+    const res = createResponse();
+
+    await googleWalletPassHandler(req, res);
 
     expect(res.statusCode).toBe(400);
     expect(res.body).toEqual({ error: "Invalid wallet pass payload" });


### PR DESCRIPTION
### **User description**
## Summary
- updated `api/wallet-pass.js` and `api/google-wallet-pass.js` to accept raw JSON request bodies while preserving existing `{ payload: "..." }` compatibility
- hardened payload resolution by rejecting malformed JSON, invalid primitive payloads, and over-deep nested stringified JSON inputs
- added regression coverage for wrapped raw JSON bodies, malformed input, primitive payload rejection, and maximum unwrap depth handling

## Validation
- [x] commits are signed off with DCO (`git commit -s`)
- [x] `npm exec vitest run tests\walletApiRoutes.test.ts`
- [x] `npx tsc --noEmit`
- [x] `node .\node_modules\eslint\bin\eslint.js api\wallet-pass.js api\google-wallet-pass.js tests\walletApiRoutes.test.ts`

## Notes
- no migration or environment changes required
- no deploy-path changes required
- change is limited to the wallet proxy API routes and their regression tests


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Accept raw JSON bodies in wallet pass proxies.

- Harden payload resolution against invalid/malicious inputs.

- Add extensive tests for new functionality.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Request Body"
      A["Raw JSON String"]
      B["{ payload: 'JSON String' }"]
  end

  subgraph "Proxy API Endpoint"
      C["resolvePayload()"]
  end

  subgraph "Payload Validation"
      D["Unwrap stringified JSON (max 5 times)"]
      E{"Is valid object?"}
  end

  F[Upstream Wallet Service]
  G[("400 Bad Request")]

  A --> C
  B --> C
  C --> D
  D --> E
  E -- Yes --> F
  E -- No --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>walletApiRoutes.test.ts</strong><dd><code>Add extensive tests for wallet proxy payload handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/walletApiRoutes.test.ts

<ul><li>Adds tests for accepting raw and wrapped JSON bodies for both wallet <br>proxies.<br> <li> Adds tests for rejecting malformed JSON and primitive payloads.<br> <li> Adds tests to verify the maximum payload unwrap depth limit is <br>enforced.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/887/files#diff-62b87e3f56431bbb1499a4ebf7977925947e8ce7f34177be0f48a093d3c5459d">+254/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google-wallet-pass.js</strong><dd><code>Harden payload resolution in Google Wallet proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/google-wallet-pass.js

<ul><li>Updates <code>resolvePayload</code> to handle raw JSON string bodies.<br> <li> Iteratively unwraps stringified JSON up to a <code>MAX_UNWRAP_DEPTH</code> of 5.<br> <li> Rejects malformed JSON, primitives, and arrays to harden the endpoint.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/887/files#diff-00d8fef47c813f52e0ebde8c7eb285e8dcaf1e10d5313287762116029797f8de">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wallet-pass.js</strong><dd><code>Harden payload resolution in Apple Wallet proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/wallet-pass.js

<ul><li>Updates <code>resolvePayload</code> to handle raw JSON string bodies.<br> <li> Iteratively unwraps stringified JSON up to a <code>MAX_UNWRAP_DEPTH</code> of 5.<br> <li> Rejects malformed JSON, primitives, and arrays to harden the endpoint.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/887/files#diff-00978435f516ce202b79a790614cc0a0ef3f0dbaa3512bbb6d365a8f3e8188b7">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
