### PR TITLE
fix(api): limit unconfirmed public profile exposure

### DIFF
--- a/api/public-investor-profile.js
+++ b/api/public-investor-profile.js
@@ -70,6 +70,7 @@ export const buildPublicInvestorProfilePayload = (
 ) => {
   const privacySettings = profileRow?.privacy_settings || {};
   const isConfirmed = Boolean(profileRow?.user_confirmed);
+  const allowExpandedBasicInfo = isConfirmed;
   const investorProfile =
     isConfirmed && profileRow?.investor_profile && typeof profileRow.investor_profile === "object"
       ? Object.fromEntries(
@@ -133,14 +134,14 @@ export const buildPublicInvestorProfilePayload = (
       email: isPublicProfileFieldVisible(privacySettings, "basic_info", "email")
         ? maskPublicEmail(profileRow.email)
         : null,
-      age: isPublicProfileFieldVisible(privacySettings, "basic_info", "age")
+      age:
+        allowExpandedBasicInfo &&
+        isPublicProfileFieldVisible(privacySettings, "basic_info", "age")
         ? profileRow.age ?? null
         : null,
-      organisation: isPublicProfileFieldVisible(
-        privacySettings,
-        "basic_info",
-        "organisation"
-      )
+      organisation:
+        allowExpandedBasicInfo &&
+        isPublicProfileFieldVisible(privacySettings, "basic_info", "organisation")
         ? profileRow.organisation?.trim() || null
         : null,
     },

--- a/tests/publicInvestorProfileApiRoute.test.ts
+++ b/tests/publicInvestorProfileApiRoute.test.ts
@@ -11,8 +11,8 @@ describe("public investor profile API projection", () => {
       slug: "ankit-kumar-singh-2597e6b8",
       name: "Ankit Kumar Singh",
       email: "ankit@hushh.ai",
-      age: null,
-      organisation: null,
+      age: 29,
+      organisation: "Hushh",
       user_confirmed: false,
       investor_profile: {
         primary_goal: {
@@ -32,6 +32,8 @@ describe("public investor profile API projection", () => {
       basic_info: {
         name: "Ankit Kumar Singh",
         email: "a***t@hushh.ai",
+        age: null,
+        organisation: null,
       },
       investor_profile: null,
       onboarding_data: null,


### PR DESCRIPTION
### **User description**
## Summary
- updated `api/public-investor-profile.js` so `age` and `organisation` are not exposed for unconfirmed public profiles
- updated `tests/publicInvestorProfileApiRoute.test.ts` to verify unconfirmed profiles do not return these fields
- confirmed-profile behavior remains unchanged

## Validation
- [x] commits are signed off with DCO (`git commit -s`)
- [x] `npx tsc --noEmit`
- [x] `npm run lint:ci`
- [x] `npx vitest run tests/publicInvestorProfileApiRoute.test.ts`

## Notes
- no migration or environment changes required
- no deploy configuration changes required
- change is limited to the public investor profile API response for unconfirmed users


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Hide `age` and `organisation` for unconfirmed public profiles.

- This is a security fix to prevent data exposure.

- Update tests to verify the new privacy behavior.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Request for Unconfirmed Profile"] --> B{buildPublicInvestorProfilePayload};
  B -- "isConfirmed = false" --> C["Return basic_info without age/organisation"];
  B -- "isConfirmed = true" --> D["Return basic_info with age/organisation (if public)"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publicInvestorProfileApiRoute.test.ts</strong><dd><code>Update tests to verify unconfirmed profile privacy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/publicInvestorProfileApiRoute.test.ts

<ul><li>Updated the test case for unconfirmed profiles to provide non-null <code>age</code> <br>and <code>organisation</code> as input.<br> <li> Added assertions to verify that <code>age</code> and <code>organisation</code> are <code>null</code> in the <br>API response for these unconfirmed profiles.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/890/files#diff-fecf2f542fbcf125730e72df3cd14030c2eda77816bf3244e1ae297a32c341fc">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>public-investor-profile.js</strong><dd><code>Limit public profile data for unconfirmed users</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/public-investor-profile.js

<ul><li>Introduced a new variable <code>allowExpandedBasicInfo</code> which is true only if <br>a user profile is confirmed.<br> <li> Added a check using this variable to conditionally expose <code>age</code> and <br><code>organisation</code> fields.<br> <li> These fields will now only be returned for confirmed users, preventing <br>data leakage for unconfirmed ones.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/890/files#diff-82c1f97e1c41fa49f27ece6b8d93be9dc2f20875d3ad54270df3e3730ea7edde">+7/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
