### PR TITLE
Fix stale auth session revalidation on boot and INITIAL_SESSION

### DIFF
--- a/src/auth/AuthSessionProvider.tsx
+++ b/src/auth/AuthSessionProvider.tsx
@@ -18,7 +18,6 @@ import {
   broadcastAuthEvent,
   clearLegacyAuthStorage,
   clearSupabaseSession,
-  getLocalSession,
   getValidatedSession,
   parseAuthBroadcastEvent,
   startUnifiedOAuth,
@@ -127,16 +126,24 @@ export const AuthSessionProvider: React.FC<{
     return nextSnapshot;
   }, [applySnapshot, clearLocalSession, supabase]);
 
-  // Boot: Instantly resolve from localStorage (no network call).
-  // This eliminates the 'booting' state almost immediately.
-  // onAuthStateChange below handles INITIAL_SESSION for the definitive state.
+  // Boot: Resolve the persisted session immediately and validate it before
+  // trusting it so stale tokens are cleared instead of briefly resurfacing.
+  // onAuthStateChange below handles INITIAL_SESSION with the same validation.
   useEffect(() => {
     const bootFromLocalStorage = async () => {
-      const localSnapshot = await getLocalSession(supabase);
-      applySnapshot(localSnapshot);
+      const settledSnapshot = await getValidatedSession(supabase);
+      if (settledSnapshot.status === "invalidated") {
+        await clearLocalSession(
+          "invalidated",
+          settledSnapshot.reason || "invalid_session"
+        );
+        return;
+      }
+
+      applySnapshot(settledSnapshot);
     };
     void bootFromLocalStorage();
-  }, [applySnapshot, supabase]);
+  }, [applySnapshot, clearLocalSession, supabase]);
 
   useEffect(() => {
     if (!supabase) {
@@ -151,6 +158,21 @@ export const AuthSessionProvider: React.FC<{
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, nextSession) => {
+      if (event === "INITIAL_SESSION") {
+        const settledSnapshot = await getValidatedSession(supabase);
+
+        if (settledSnapshot.status === "invalidated") {
+          await clearLocalSession(
+            "invalidated",
+            settledSnapshot.reason || "invalid_session"
+          );
+          return;
+        }
+
+        applySnapshot(settledSnapshot);
+        return;
+      }
+
       if (event === "SIGNED_OUT" || !nextSession) {
         const pendingState = pendingSignedOutStateRef.current;
         pendingSignedOutStateRef.current = null;

--- a/tests/authSessionProvider.test.ts
+++ b/tests/authSessionProvider.test.ts
@@ -159,8 +159,7 @@ describe("AuthSessionProvider", () => {
     );
   });
 
-  // TODO: Fix race condition — getUser 401 resolves after getSession restores "authenticated"
-  it.skip("invalidates a stale persisted session and clears it locally", async () => {
+  it("invalidates a stale persisted session and clears it locally", async () => {
     mockGetSession.mockResolvedValue({
       data: { session: MOCK_SESSION },
       error: null,
@@ -172,6 +171,49 @@ describe("AuthSessionProvider", () => {
 
     await act(async () => {
       root.render(renderWithProvider(React.createElement(AuthHarness)));
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe(
+      "invalidated"
+    );
+    expect(container.querySelector('[data-testid="reason"]')?.textContent).toBe(
+      "expired"
+    );
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: "local" });
+  });
+
+  it("validates the INITIAL_SESSION auth event before trusting it", async () => {
+    let authStateChangeCallback:
+      | ((event: string, nextSession: typeof MOCK_SESSION | null) => Promise<void> | void)
+      | null = null;
+
+    mockGetSession.mockResolvedValueOnce({
+      data: { session: null },
+      error: null,
+    });
+    mockGetSession.mockResolvedValue({
+      data: { session: MOCK_SESSION },
+      error: null,
+    });
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { status: 401, message: "JWT expired" },
+    });
+    mockOnAuthStateChange.mockImplementation((callback) => {
+      authStateChangeCallback = callback as typeof authStateChangeCallback;
+      return {
+        data: { subscription: { unsubscribe: unsubscribeMock } },
+      };
+    });
+
+    await act(async () => {
+      root.render(renderWithProvider(React.createElement(AuthHarness)));
+    });
+    await flush();
+
+    await act(async () => {
+      await authStateChangeCallback?.("INITIAL_SESSION", MOCK_SESSION);
     });
     await flush();
 


### PR DESCRIPTION
### **User description**
## Summary

- what changed:
- why it changed:
- risk area touched: `ui` | `api` | `auth` | `deploy` | `security` | `docs`

## Validation

- [ ] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed

## Notes

- deployment impact:
- migration or env requirements:
- follow-up work if any:
- reviewer callouts or CODEOWNERS you expect to review this:


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Validates auth sessions on app boot and for `INITIAL_SESSION` events.

- Immediately clears stale sessions to prevent UI flicker.

- **Auth Impact:** Changes how sessions are revalidated on load.

- **Security Impact:** Improves security by promptly invalidating stale tokens.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Session Loading
    A["App Boot / INITIAL_SESSION"]
  end
  B["Get Persisted Session"]
  C{"Validate Session (API call)"}
  D["Apply Valid Session to UI"]
  E["Clear Stale Session Locally"]

  A --> B --> C
  C -- "Valid" --> D
  C -- "Invalid" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AuthSessionProvider.tsx</strong><dd><code>Validate persisted auth sessions on load and `INITIAL_SESSION` event</code></dd></summary>
<hr>

src/auth/AuthSessionProvider.tsx

<ul><li>Validates the persisted session on initial component mount using <br><code>getValidatedSession</code>.<br> <li> Adds a handler for the <code>INITIAL_SESSION</code> event to perform the same <br>validation.<br> <li> If a session is found to be stale, it is cleared immediately instead <br>of being briefly applied.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/892/files#diff-f104f340f890b349eb047e96b873c31a9ca1f8c8a6a46d71e1c9dab593daf851">+29/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authSessionProvider.test.ts</strong><dd><code>Add and enable tests for stale session validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/authSessionProvider.test.ts

<ul><li>Enables a previously skipped test for invalidating stale persisted <br>sessions.<br> <li> Adds a new test case to verify that sessions from the <code>INITIAL_SESSION</code> <br>event are validated before being trusted.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/892/files#diff-2e155dcbac3e44f0162ac16983b143c8eb61b32779ecec8c8fe4c479b82d0679">+44/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
