### PR TITLE
fix(route): correct career privacy policy path and add redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,7 +178,11 @@ function App() {
             <Route path="/career" element={<Career />} />
             <Route path="/career/*" element={<Career />} />
             <Route path='/privacy-policy' element={<PrivacyPolicy />} />
-            <Route path='/carrer-privacy-policy' element={<CareersPrivacyPolicy />} />
+            <Route path='/career-privacy-policy' element={<CareersPrivacyPolicy />} />
+            <Route
+              path='/carrer-privacy-policy'
+              element={<Navigate to='/career-privacy-policy' replace />}
+            />
             <Route path="/community" element={
               <CommunityPage />
             } />

--- a/src/auth/routePolicy.ts
+++ b/src/auth/routePolicy.ts
@@ -15,7 +15,7 @@ export const PUBLIC_MARKETING_ROUTE_PREFIXES = [
   "/metrics",
   "/privacy-policy",
   "/faq",
-  "/carrer-privacy-policy",
+  "/career-privacy-policy",
   "/california-privacy-policy",
   "/eu-uk-jobs-privacy-policy",
   "/investor-guide",

--- a/src/auth/routePolicy.ts
+++ b/src/auth/routePolicy.ts
@@ -15,6 +15,7 @@ export const PUBLIC_MARKETING_ROUTE_PREFIXES = [
   "/metrics",
   "/privacy-policy",
   "/faq",
+  "/carrer-privacy-policy",
   "/career-privacy-policy",
   "/california-privacy-policy",
   "/eu-uk-jobs-privacy-policy",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -161,7 +161,7 @@ export default function Footer() {
               California Privacy Policy
             </a>
             <a 
-              href="/carrer-privacy-policy" 
+              href="/career-privacy-policy" 
               className="py-2 text-gray-300 hover:text-white text-base font-medium flex items-center justify-between group"
             >
               Careers Site Privacy Notice


### PR DESCRIPTION
### **User description**
## Summary

* what changed:

  * Corrected route path from `/carrer-privacy-policy` → `/career-privacy-policy` in `App.tsx`
  * Added backward-compatible redirect from old typo route to new canonical route
  * Updated all internal references (Footer and routePolicy) to use the correct path

* why it changed:

  * The existing typo caused inconsistent routing and potential broken links
  * Ensures correct URL structure for users, SEO, and caching behavior
  * Maintains backward compatibility so existing links do not break

* risk area touched: `ui`

## Validation

* [x] commits are signed off with DCO (`git commit -s`)
* [x] `npm run test`
* [x] `npx tsc --noEmit`
* [x] `npm run build:web`
* [x] `npm run env:check`
* [ ] `npm run lint:ci` (skipped — bash not available on Windows)
* [x] relevant route or smoke checks
* [ ] security checks when secrets, auth, infra, or deploy paths changed (not applicable)

## Notes

* deployment impact: none (frontend route fix only)
* migration or env requirements: none
* follow-up work if any: none required — all known references updated


___

### **PR Type**
Bug fix


___

### **Description**
- Corrects a typo in the career privacy policy URL.

- Adds a redirect from the old, incorrect URL to the new one.

- Updates internal links and route policies to use the correct path.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["/carrer-privacy-policy (Old URL)"] -->|Redirects to| B["/career-privacy-policy (New URL)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Correct route path and add redirect for careers privacy policy</code></dd></summary>
<hr>

src/App.tsx

<ul><li>Corrected the route path for the careers privacy policy from <br><code>/carrer-privacy-policy</code> to <code>/career-privacy-policy</code>.<br> <li> Added a new route to redirect traffic from the old, misspelled path to <br>the new, correct one.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/895/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Footer.tsx</strong><dd><code>Update footer link to correct career privacy policy URL</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/components/Footer.tsx

<ul><li>Updated the <code>href</code> for the "Careers Site Privacy Notice" link to point <br>to the correct <code>/career-privacy-policy</code> URL.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/895/files#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>routePolicy.ts</strong><dd><code>Update public route policy for new and legacy paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/auth/routePolicy.ts

<ul><li>Added the new <code>/career-privacy-policy</code> path to the list of public <br>marketing routes.<br> <li> The old <code>/carrer-privacy-policy</code> path is kept to ensure the redirect <br>mechanism works as intended.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/895/files#diff-c5a19f773431a78d1b7ffedf997be402548f065c980d99fb03c376c0b0289ea5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
