### PR TITLE
fix(tests): resolve 3 pre-existing test failures in authSessionProvider and mainWebRuntime

### DIFF
--- a/tests/authSessionProvider.test.ts
+++ b/tests/authSessionProvider.test.ts
@@ -119,10 +119,29 @@ describe("AuthSessionProvider", () => {
     vi.clearAllMocks();
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
+
+    const storageMock = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+      key: vi.fn().mockReturnValue(null),
+      length: 0,
+    };
+    Object.defineProperty(window, "localStorage", {
+      value: storageMock,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, "sessionStorage", {
+      value: storageMock,
+      writable: true,
+      configurable: true,
+    });
+
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-
     mockOnAuthStateChange.mockImplementation(() => ({
       data: { subscription: { unsubscribe: unsubscribeMock } },
     }));

--- a/tests/mainWebRuntime.test.ts
+++ b/tests/mainWebRuntime.test.ts
@@ -6,6 +6,9 @@ vi.mock("../src/resources/config/config", () => ({
   },
 }));
 
+
+vi.stubEnv("VITE_NDA_GENERATION_URL", "");
+
 import {
   getNdaGenerationUrl,
   getSupabaseRpcUrl,
@@ -15,7 +18,6 @@ import {
 describe("main web runtime helpers", () => {
   it("builds RPC URLs from the active Supabase project", () => {
     const rpcUrl = getSupabaseRpcUrl("check_access_status");
-
     expect(rpcUrl).toContain("ibsisfnjxeowvdtvgzff.supabase.co");
     expect(rpcUrl).not.toContain("gsqmwxqgqrgzhlhmbscg");
     expect(rpcUrl).toContain("/rest/v1/rpc/check_access_status");
@@ -26,10 +28,11 @@ describe("main web runtime helpers", () => {
       "website",
       "market-updates/example.png"
     );
-
     expect(storageUrl).toContain("ibsisfnjxeowvdtvgzff.supabase.co");
     expect(storageUrl).not.toContain("gsqmwxqgqrgzhlhmbscg");
-    expect(storageUrl).toContain("/storage/v1/object/public/website/market-updates/example.png");
+    expect(storageUrl).toContain(
+      "/storage/v1/object/public/website/market-updates/example.png"
+    );
   });
 
   it("keeps the NDA generation service configurable with a Cloud Run default", () => {


### PR DESCRIPTION
### **User description**
Summary

**What changed:** Fixed 3 pre-existing test failures that existed in the 
repo's own CI before this PR. The test suite was reporting 
`2 failed | 46 passed` — now it reports `48 passed | 0 failed`.

Why it matters: Failing tests in CI create noise that masks real 
regressions. These 3 failures were silently blocking the ability to trust 
the test suite as a safety net.

Root Causes Fixed

Fix 1 — `authSessionProvider.test.ts` (2 failing tests)
Problem: `clearLegacyAuthStorage()` in `src/auth/session.ts` calls 
`window.localStorage.removeItem()` and `window.sessionStorage.removeItem()` 
inside a `StorageEvent` handler. jsdom's localStorage implementation does 
not support `.removeItem()` — throwing `TypeError: 
window.localStorage.removeItem is not a function` which caused:
- `broadcast-driven deletion invalidates another tab immediately` → FAIL
- `shows account actions for authenticated users and logout performs a 
  real sign-out` → FAIL

Fix: Added a proper localStorage/sessionStorage stub in `beforeEach` 
using `Object.defineProperty` with `vi.fn()` mocks — matching how jsdom 
expects storage to be overridden in test environments.

Fix 2 — `mainWebRuntime.test.ts` (1 failing test)
Problem: `getNdaGenerationUrl()` reads `import.meta.env.VITE_NDA_GENERATION_URL` 
at runtime. In the test environment, this env var was not explicitly cleared, 
so it was resolving to the Supabase URL instead of the expected Cloud Run 
default (`hushhtech-nda-generation-53407187172.us-central1.run.app`).

Fix: Added `vi.stubEnv("VITE_NDA_GENERATION_URL", "")` before the 
import so the function correctly falls back to the hardcoded Cloud Run 
default, matching what the test expected.

Validation

- [x] Before: `Test Files 2 failed | 46 passed`
- [x] After: `Test Files 48 passed | 0 failed`
- [x] `npm run test` — full suite passes with 0 failures
- [x] No source files changed — only test files fixed
- [x] No secrets or `.env` files committed
- [x] No direct push to `main` — topic branch used

Test Output
Test Files  48 passed | 2 skipped (50)
Tests  277 passed | 42 skipped (319)


___

### **PR Type**
Tests


___

### **Description**
- Fixes three pre-existing test failures.

- Mocks `localStorage` in `authSessionProvider` tests.

- Stubs an environment variable in `mainWebRuntime` tests.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>authSessionProvider.test.ts</strong><dd><code>Mock browser storage to fix test failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/authSessionProvider.test.ts

<ul><li>Mocks <code>window.localStorage</code> and <code>window.sessionStorage</code> in the <code>beforeEach</code> <br>hook.<br> <li> Uses <code>vi.fn()</code> to create stubs for storage methods like <code>removeItem</code>.<br> <li> Fixes test failures caused by jsdom's incomplete storage <br>implementation.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/902/files#diff-2e155dcbac3e44f0162ac16983b143c8eb61b32779ecec8c8fe4c479b82d0679">+20/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mainWebRuntime.test.ts</strong><dd><code>Stub environment variable for runtime helper test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/mainWebRuntime.test.ts

<ul><li>Uses <code>vi.stubEnv</code> to clear the <code>VITE_NDA_GENERATION_URL</code> environment <br>variable.<br> <li> Ensures the <code>getNdaGenerationUrl</code> function is tested against its default <br>value.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/902/files#diff-3a1bd92cd8ac6f4ae9edfb3c59e3484ffd5c7fc7aa00b58152dac23ebf670a5e">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
