### PR TITLE
chore: ignore vite cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ private_keys/
 .pre-commit-cache/
 .gitleaks-report.json
 tmp/
+
+.vite-cache/


### PR DESCRIPTION
## Summary

- what changed:
- why it changed:
- risk area touched: `ui` | `api` | `auth` | `deploy` | `security` | `docs`

## Validation

- [ ] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [ ] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed

## Notes

- deployment impact:
- migration or env requirements:
- follow-up work if any:
- reviewer callouts or CODEOWNERS you expect to review this:
