### PR TITLE
fix(plaid): correct Edge Function URLs and surface upsert errors

### DIFF
--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -345,7 +345,10 @@ export const saveFinancialDataToSupabase = async (
       fetch_errors: Object.keys(errors).length > 0 ? errors : null,
       updated_at: new Date().toISOString(),
     }, { onConflict: 'user_id' });
-    if (upsertError) console.error('[Plaid] ❌ DB upsert failed:', upsertError.message);
+    if (upsertError) {
+      console.error('[Plaid] ❌ DB upsert failed:', upsertError.message);
+      throw upsertError;
+    }
 
     console.log('[Plaid] ✅ Data saved to Supabase');
   } catch (err) {

--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -320,7 +320,7 @@ export const saveFinancialDataToSupabase = async (
     if (data.authNumbers?.error) errors.auth = data.authNumbers.error;
     if (data.identityMatch?.error) errors.identity_match = data.identityMatch.error;
 
-    await supabase.from('user_financial_data').upsert({
+    const { error: upsertError } = await supabase.from('user_financial_data').upsert({
       user_id: userId,
       plaid_item_id: itemId || null,
       plaid_access_token: accessToken || null,
@@ -345,6 +345,7 @@ export const saveFinancialDataToSupabase = async (
       fetch_errors: Object.keys(errors).length > 0 ? errors : null,
       updated_at: new Date().toISOString(),
     }, { onConflict: 'user_id' });
+    if (upsertError) console.error('[Plaid] ❌ DB upsert failed:', upsertError.message);
 
     console.log('[Plaid] ✅ Data saved to Supabase');
   } catch (err) {
@@ -459,7 +460,7 @@ export const signalDecisionReport = async (params: {
   amountInstantlyAvailable?: number;
 }) => {
   const token = await getUserAccessToken();
-  const res = await fetch(`${SUPABASE_URL}/signal-decision-report`, {
+  const res = await fetch(`${getFunctionsUrl()}/signal-decision-report`, {
     method: 'POST', headers: getHeaders(token),
     body: JSON.stringify({
       client_transaction_id: params.clientTransactionId,
@@ -484,7 +485,7 @@ export const signalReturnReport = async (params: {
   returnedAt?: string;
 }) => {
   const token = await getUserAccessToken();
-  const res = await fetch(`${SUPABASE_URL}/signal-return-report`, {
+  const res = await fetch(`${getFunctionsUrl()}/signal-return-report`, {
     method: 'POST', headers: getHeaders(token),
     body: JSON.stringify({
       client_transaction_id: params.clientTransactionId,
@@ -530,7 +531,7 @@ export const createSandboxTestItem = async (
   institutionId = 'ins_109508',
 ): Promise<SandboxTestResult> => {
   const token = await getUserAccessToken();
-  const res = await fetch(`${SUPABASE_URL}/sandbox-create-test-item`, {
+  const res = await fetch(`${getFunctionsUrl()}/sandbox-create-test-item`, {
     method: 'POST',
     headers: getHeaders(token),
     body: JSON.stringify({ userId, institutionId }),

--- a/src/services/plaid/plaidService.ts
+++ b/src/services/plaid/plaidService.ts
@@ -14,7 +14,7 @@ export type ProductFetchStatus = 'idle' | 'loading' | 'success' | 'unavailable' 
 
 export interface ProductResult {
   available: boolean;
-  data: any | null;
+  data: unknown | null;
   error: string | null;
   reason: 'not_supported' | 'error' | null;
 }
@@ -43,7 +43,7 @@ const SUPABASE_FUNCTIONS_URL = `${SUPABASE_URL}/functions/v1`;
 
 const getAnonKey = (): string => {
   try {
-    // @ts-ignore
+    // @ts-expect-error meta.env is not fully typed
     return import.meta.env?.VITE_SUPABASE_ANON_KEY || '';
   } catch { return ''; }
 };
@@ -84,7 +84,7 @@ export const createLinkToken = async (
   console.log('[Plaid:createLinkToken] 🚀 Starting...', { userId: userId?.slice(0, 8), userEmail, redirectUri, receivedRedirectUri: receivedRedirectUri?.slice(0, 50) });
   const token = await getUserAccessToken();
   console.log('[Plaid:createLinkToken] Auth token:', token ? `${token.slice(0, 20)}...` : 'MISSING');
-  const body: Record<string, any> = { userId, userEmail };
+  const body: Record<string, unknown> = { userId, userEmail };
   if (redirectUri) body.redirectUri = redirectUri;
   if (receivedRedirectUri) body.receivedRedirectUri = receivedRedirectUri;
 
@@ -143,8 +143,9 @@ export const fetchAuthNumbers = async (accessToken: string) => {
       accounts: Array<{ account_id: string; name: string; subtype: string; type: string }>;
       numbers: { ach: Array<{ account: string; routing: string; wire_routing: string; account_id: string }> };
     };
-  } catch (e: any) {
-    console.error('[Plaid] Auth numbers fetch failed:', e.message);
+  } catch (e: unknown) {
+    const err = e as Error;
+    console.error('[Plaid] Auth numbers fetch failed:', err.message);
     return null;
   }
 };
@@ -163,8 +164,9 @@ const fetchBalance = async (accessToken: string, userId: string): Promise<Produc
       return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
     return { available: true, data: await res.json(), error: null, reason: null };
-  } catch (e: any) {
-    return { available: false, data: null, error: e.message, reason: 'error' };
+  } catch (e: unknown) {
+    const err = e as Error;
+    return { available: false, data: null, error: err.message, reason: 'error' };
   }
 };
 
@@ -184,8 +186,9 @@ const fetchAssets = async (accessToken: string, userId: string): Promise<Product
     const data = await res.json();
     if (data.status === 'pending') return { available: false, data, error: null, reason: null };
     return { available: true, data, error: null, reason: null };
-  } catch (e: any) {
-    return { available: false, data: null, error: e.message, reason: 'error' };
+  } catch (e: unknown) {
+    const err = e as Error;
+    return { available: false, data: null, error: err.message, reason: 'error' };
   }
 };
 
@@ -204,8 +207,9 @@ const fetchInvestments = async (accessToken: string, userId: string): Promise<Pr
       return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
     return { available: true, data: await res.json(), error: null, reason: null };
-  } catch (e: any) {
-    return { available: false, data: null, error: e.message, reason: 'error' };
+  } catch (e: unknown) {
+    const err = e as Error;
+    return { available: false, data: null, error: err.message, reason: 'error' };
   }
 };
 
@@ -223,15 +227,16 @@ const fetchIdentity = async (accessToken: string): Promise<ProductResult> => {
       return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
     return { available: true, data: await res.json(), error: null, reason: null };
-  } catch (e: any) {
-    return { available: false, data: null, error: e.message, reason: 'error' };
+  } catch (e: unknown) {
+    const err = e as Error;
+    return { available: false, data: null, error: err.message, reason: 'error' };
   }
 };
 
 /** Match user identity against bank account owner data */
 export const fetchIdentityMatch = async (
   accessToken: string,
-  userData?: { legal_name?: string; phone_number?: string; email_address?: string; address?: any },
+  userData?: { legal_name?: string; phone_number?: string; email_address?: string; address?: unknown },
 ): Promise<ProductResult> => {
   try {
     const token = await getUserAccessToken();
@@ -245,8 +250,9 @@ export const fetchIdentityMatch = async (
       return { available: false, data: null, error: err.error || 'Failed', reason: 'error' };
     }
     return { available: true, data: await res.json(), error: null, reason: null };
-  } catch (e: any) {
-    return { available: false, data: null, error: e.message, reason: 'error' };
+  } catch (e: unknown) {
+    const err = e as Error;
+    return { available: false, data: null, error: err.message, reason: 'error' };
   }
 };
 
@@ -256,8 +262,9 @@ const fetchAuth = async (accessToken: string): Promise<ProductResult> => {
     const data = await fetchAuthNumbers(accessToken);
     if (!data) return { available: false, data: null, error: null, reason: 'not_supported' };
     return { available: true, data, error: null, reason: null };
-  } catch (e: any) {
-    return { available: false, data: null, error: e.message, reason: 'error' };
+  } catch (e: unknown) {
+    const err = e as Error;
+    return { available: false, data: null, error: err.message, reason: 'error' };
   }
 };
 
@@ -299,7 +306,7 @@ export const checkAssetReport = async (assetReportToken: string, userId: string)
     body: JSON.stringify({ assetReportToken, userId, action: 'get' }),
   });
   if (!res.ok) throw new Error('Failed to check asset report');
-  return res.json() as Promise<{ status: 'complete' | 'pending'; data?: any }>;
+  return res.json() as Promise<{ status: 'complete' | 'pending'; data?: unknown }>;
 };
 
 /** Save financial data to Supabase */
@@ -402,9 +409,10 @@ export const signalPrepare = async (accessToken: string) => {
     }
     console.log('[Plaid] ✅ Signal prepared for Item');
     return { success: true, ...(await res.json()) };
-  } catch (e: any) {
-    console.warn('[Plaid] Signal prepare error:', e.message);
-    return { success: false, error: e.message };
+  } catch (e: unknown) {
+    const err = e as Error;
+    console.warn('[Plaid] Signal prepare error:', err.message);
+    return { success: false, error: err.message };
   }
 };
 
@@ -418,7 +426,7 @@ export const signalEvaluate = async (params: {
   isRecurring?: boolean;
   defaultPaymentMethod?: 'SAME_DAY_ACH' | 'STANDARD_ACH' | 'MULTIPLE_PAYMENT_METHODS';
   rulesetKey?: string;
-  user?: { name?: { given_name?: string; family_name?: string }; phone_number?: string; email_address?: string; address?: any };
+  user?: { name?: { given_name?: string; family_name?: string }; phone_number?: string; email_address?: string; address?: unknown };
   device?: { ip_address?: string; user_agent?: string };
 }) => {
   const token = await getUserAccessToken();
@@ -446,9 +454,9 @@ export const signalEvaluate = async (params: {
       customer_initiated_return_risk: { score: number; risk_tier: number };
       bank_initiated_return_risk: { score: number; risk_tier: number };
     };
-    core_attributes: Record<string, any>;
-    ruleset?: { ruleset_key: string; result: 'ACCEPT' | 'REROUTE' | 'REVIEW'; triggered_rule_details?: any };
-    warnings: any[];
+    core_attributes: Record<string, unknown>;
+    ruleset?: { ruleset_key: string; result: 'ACCEPT' | 'REROUTE' | 'REVIEW'; triggered_rule_details?: unknown };
+    warnings: unknown[];
     request_id: string;
   }>;
 };


### PR DESCRIPTION
### **User description**
## Summary
- `signalDecisionReport`, `signalReturnReport`, and `createSandboxTestItem` were calling `${SUPABASE_URL}/...` (the raw Supabase REST root) instead of `${getFunctionsUrl()}/...` (which appends `/functions/v1`) — all three endpoints were returning 404 on every call
- `saveFinancialDataToSupabase` was `await`-ing the Supabase `upsert()` but discarding its return value; RLS violations, schema errors, or network failures silently dropped user financial data with no log output

## Validation
- [x] `npm run build` passes (277 vitest tests + vite build)
- [x] `npm run lint:ci` passes on all governed surfaces
- [ ] Smoke: trigger `signalDecisionReport` in Plaid sandbox and verify it no longer returns 404

## Notes
- Touches only `src/services/plaid/plaidService.ts` — 5 line changes, no conflict with PR-1 (different file)
- No env vars, migrations, or deployment changes required
- Reviewer callout: `getFunctionsUrl()` throws if `VITE_SUPABASE_URL` is missing — ensure all environments have this set


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Corrects Plaid Edge Function URLs to prevent 404 errors.

- Surfaces database upsert errors to prevent silent data loss.

- Improves TypeScript types and error handling patterns.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph "Before"
        A["Plaid Service"] -- "Calls wrong URL (404)" --> B["Supabase Edge Function"]
        C["Plaid Service"] -- "Ignores upsert errors" --> D["Supabase DB"]
    end
    subgraph "After"
        E["Plaid Service"] -- "Calls correct URL" --> F["Supabase Edge Function"]
        G["Plaid Service"] -- "Handles upsert errors" --> H["Supabase DB"]
    end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plaidService.ts</strong><dd><code>Fix incorrect Plaid API URLs and add error handling for DB upserts</code></dd></summary>
<hr>

src/services/plaid/plaidService.ts

<ul><li>Corrects the API endpoint URLs for <code>signalDecisionReport</code>, <br><code>signalReturnReport</code>, and <code>createSandboxTestItem</code> to use <br><code>getFunctionsUrl()</code>.<br> <li> Adds error handling for the Supabase <code>upsert</code> operation in <br><code>saveFinancialDataToSupabase</code> to throw on failure.<br> <li> Replaces <code>any</code> with <code>unknown</code> for improved type safety in function <br>signatures and <code>catch</code> blocks.<br> <li> Replaces <code>@ts-ignore</code> with <code>@ts-expect-error</code> for better type checking <br>practices.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/936/files#diff-c1eea5b8c160cc1ef48d1be506addb285b47fc56b3754ae1d72cd03984924038">+42/-30</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
