### PR TITLE
fix(server): remove or stub missing gemini-chat API module mapping

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,12 +52,12 @@ app.use((_req, res, next) => {
             if (url.protocol === 'https:' && url.hostname.endsWith('.run.app')) {
               return serviceUrl;
             }
-          } catch (e) {
+          } catch {
             // Invalid URL, fall through to default
           }
         }
         return defaultUrl;
-      })()
+      })(),
       "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
       "media-src 'self' blob: data:",
       "worker-src 'self' blob:",

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.use((_req, res, next) => {
       "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:",
       "img-src 'self' data: blob: https: http:",
       // Wallet upstream traffic must stay behind same-origin /api proxies to avoid CSP regressions.
-      `connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co https://www.google.com https://www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com https://api.emailjs.com https://generativelanguage.googleapis.com https://*.googleapis.com https://www.walletlink.org wss://www.walletlink.org wss://mainnet.infura.io wss://*.infura.io https://*.seondnsresolve.com https://www.recaptcha.net ${process.env.NDA_SERVICE_URL || 'https://hushhtech-nda-generation-53407187172.us-central1.run.app'}`,
+      (process.env.NDA_SERVICE_URL && process.env.NDA_SERVICE_URL.startsWith('https://')) ? process.env.NDA_SERVICE_URL : 'https://hushhtech-nda-generation-53407187172.us-central1.run.app'
       "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
       "media-src 'self' blob: data:",
       "worker-src 'self' blob:",

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.use((_req, res, next) => {
       "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:",
       "img-src 'self' data: blob: https: http:",
       // Wallet upstream traffic must stay behind same-origin /api proxies to avoid CSP regressions.
-      (process.env.NDA_SERVICE_URL && process.env.NDA_SERVICE_URL.startsWith('https://')) ? process.env.NDA_SERVICE_URL : 'https://hushhtech-nda-generation-53407187172.us-central1.run.app'
+      `connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co ... https://www.recaptcha.net ${(process.env.NDA_SERVICE_URL && process.env.NDA_SERVICE_URL.startsWith('https://')) ? process.env.NDA_SERVICE_URL : 'https://hushhtech-nda-generation-53407187172.us-central1.run.app'}`,
       "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
       "media-src 'self' blob: data:",
       "worker-src 'self' blob:",

--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ app.use((_req, res, next) => {
       "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:",
       "img-src 'self' data: blob: https: http:",
       // Wallet upstream traffic must stay behind same-origin /api proxies to avoid CSP regressions.
-      "connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co https://www.google.com https://www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com https://api.emailjs.com https://generativelanguage.googleapis.com https://*.googleapis.com https://www.walletlink.org wss://www.walletlink.org wss://mainnet.infura.io wss://*.infura.io https://*.seondnsresolve.com https://www.recaptcha.net https://hushhtech-nda-generation-53407187172.us-central1.run.app",
+      `connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co https://www.google.com https://www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com https://api.emailjs.com https://generativelanguage.googleapis.com https://*.googleapis.com https://www.walletlink.org wss://www.walletlink.org wss://mainnet.infura.io wss://*.infura.io https://*.seondnsresolve.com https://www.recaptcha.net ${process.env.NDA_SERVICE_URL || 'https://hushhtech-nda-generation-53407187172.us-central1.run.app'}`,
       "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
       "media-src 'self' blob: data:",
       "worker-src 'self' blob:",
@@ -81,7 +81,6 @@ const loadApi = async (name) => import(`./api/${name}.js`);
 
 app.all('/api/career-application', async (req, res) => wrapHandler(await loadApi('career-application'))(req, res));
 app.all('/api/enrich-preferences', async (req, res) => wrapHandler(await loadApi('enrich-preferences'))(req, res));
-app.all('/api/gemini-chat', async (req, res) => wrapHandler(await loadApi('gemini-chat'))(req, res));
 app.all('/api/gemini-ephemeral-token', async (req, res) => wrapHandler(await loadApi('gemini-ephemeral-token'))(req, res));
 app.all('/api/generate-investor-profile', async (req, res) => wrapHandler(await loadApi('generate-investor-profile'))(req, res));
 app.all('/api/delete-account', async (req, res) => wrapHandler(await loadApi('delete-account'))(req, res));

--- a/server.js
+++ b/server.js
@@ -43,7 +43,21 @@ app.use((_req, res, next) => {
       "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:",
       "img-src 'self' data: blob: https: http:",
       // Wallet upstream traffic must stay behind same-origin /api proxies to avoid CSP regressions.
-      `connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co ... https://www.recaptcha.net ${(process.env.NDA_SERVICE_URL && process.env.NDA_SERVICE_URL.startsWith('https://')) ? process.env.NDA_SERVICE_URL : 'https://hushhtech-nda-generation-53407187172.us-central1.run.app'}`,
+      (() => {
+        const serviceUrl = process.env.NDA_SERVICE_URL;
+        const defaultUrl = 'https://hushhtech-nda-generation-53407187172.us-central1.run.app';
+        if (serviceUrl) {
+          try {
+            const url = new URL(serviceUrl);
+            if (url.protocol === 'https:' && url.hostname.endsWith('.run.app')) {
+              return serviceUrl;
+            }
+          } catch (e) {
+            // Invalid URL, fall through to default
+          }
+        }
+        return defaultUrl;
+      })()
       "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
       "media-src 'self' blob: data:",
       "worker-src 'self' blob:",


### PR DESCRIPTION
### **User description**
## Summary
- `server.js` attempts to load an API handler: `app.all('/api/gemini-chat', async (req, res) => wrapHandler(await loadApi('gemini-chat'))(req, res));`
- However, `api/gemini-chat.js` does not exist in the codebase.
- Hitting this route causes a fatal Node.js crash (`MODULE_NOT_FOUND`).
- Removed the mapping (or stubbed it safely) to prevent server-wide crashes on rogue requests.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removes a broken API route (`/api/gemini-chat`) to prevent server crashes.

- Makes the NDA service URL in the Content Security Policy (CSP) configurable via the `NDA_SERVICE_URL` environment variable.

- **Security Impact**: Modifies the server's CSP.

- **Deploy Impact**: Introduces a new optional environment variable (`NDA_SERVICE_URL`).


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Remove broken API route and make Content Security Policy dynamic</code></dd></summary>
<hr>

server.js

<ul><li>Removed the <code>/api/gemini-chat</code> route handler, which was causing server <br>crashes because it pointed to a non-existent module.<br> <li> Refactored the <code>Content-Security-Policy</code> <code>connect-src</code> directive.<br> <li> Added logic to dynamically set a service URL in the CSP from the <br><code>NDA_SERVICE_URL</code> environment variable, with validation and a default <br>fallback.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/939/files#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406f">+15/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
