### PR TITLE
fix(functions): remove unused recencyScore computation

### DIFF
--- a/supabase/functions/kyc-agent-a2a-protocol/index.ts
+++ b/supabase/functions/kyc-agent-a2a-protocol/index.ts
@@ -90,14 +90,14 @@ interface A2AMessage {
     message?: string;
     requirements?: string[];
     required_fields?: string[];
-    input_data?: Record<string, any>;
+    input_data?: Record<string, unknown>;
     progress?: number;
     estimated_time?: string;
     log?: string;
     trust_score?: number;
     risk_band?: A2ARiskBand;
     available_data?: string[];
-    data?: Record<string, any>;
+    data?: Record<string, unknown>;
     action?: string;
     target?: string;
     public_key?: string;
@@ -751,9 +751,7 @@ async function runA2AConversation(request: KycRequest): Promise<{
   const messages: A2AMessage[] = [];
   const taskId = generateTaskId();
   let sequence = 0;
-  let foundUser: DatabaseUser | null;
-  let trustScore: number;
-  let riskBand: A2ARiskBand;
+
 
   // Parse subject name
   const nameParts = request.subject.trim().split(/\s+/);
@@ -804,7 +802,7 @@ async function runA2AConversation(request: KycRequest): Promise<{
   // Bank Agent provides identifier data
   // ==============================
   sequence++;
-  const inputData: Record<string, any> = {};
+  const inputData: Record<string, unknown> = {};
   if (request.phoneNumber) {
     inputData.phone_number = `${request.phoneCountryCode || '+1'}${request.phoneNumber}`;
     inputData.country_code = request.phoneCountryCode || '+1';
@@ -997,11 +995,11 @@ async function runA2AConversation(request: KycRequest): Promise<{
   // SEQUENCE 7: TASK_RESULT
   // Return verification result with trust score
   // ==============================
-  foundUser = matchResult.user;
+  const foundUser = matchResult.user;
   
   if (matchResult.type === 'PERFECT_MATCH' && foundUser) {
-    trustScore = calculateTrustScore(foundUser);
-    riskBand = calculateRiskBand(trustScore);
+    const trustScore = calculateTrustScore(foundUser);
+    const riskBand = calculateRiskBand(trustScore);
 
     sequence++;
     messages.push({

--- a/supabase/functions/kyc-agent-a2a-protocol/index.ts
+++ b/supabase/functions/kyc-agent-a2a-protocol/index.ts
@@ -348,10 +348,6 @@ const reflectOnResponse = (
   
   // Check 3: If phone was WRONG, are we hinting at the correct value?
   if (matchResult?.mismatchedFields.includes('phone') && providedPhone) {
-    // Make sure we're not giving hints about what the correct phone should be
-    const phoneDigits = providedPhone.replace(/\D/g, '');
-    const storedDigits = matchResult.user?.phone_number?.replace(/\D/g, '') || '';
-    
     // Check if we're showing which digits are wrong (that would be a leak)
     if (draftResponse.includes('first digit') || 
         draftResponse.includes('last digit') ||
@@ -413,7 +409,7 @@ interface RoutingResult {
 /**
  * ROUTING: Smart intent detection and routing
  */
-const routeRequest = (body: Record<string, any>): RoutingResult => {
+const routeRequest = (body: Record<string, unknown>): RoutingResult => {
   const intentFromBody = (body.intent || body.payload?.intent || '').toLowerCase();
   const message = (body.message || body.query || '').toLowerCase();
   
@@ -722,7 +718,7 @@ const generateChallengeMessage = (
   matchResult: MatchResult,
   subjectName: string
 ): string => {
-  const { mismatchedFields, matchedFields, confidence } = matchResult;
+  const { mismatchedFields, confidence } = matchResult;
   
   let message = `I found a KYC record for "${subjectName}" with ${(confidence * 100).toFixed(0)}% name confidence. `;
   
@@ -742,49 +738,6 @@ const generateChallengeMessage = (
 };
 
 // ============================================================================
-// DATABASE QUERY FUNCTIONS
-// ============================================================================
-
-async function searchByName(firstName: string, lastName: string): Promise<DatabaseUser | null> {
-  console.log(`[A2A TOOL] searchByName: ${firstName} ${lastName}`);
-  
-  const { data, error } = await supabase
-    .from('onboarding_data')
-    .select('*')
-    .ilike('legal_first_name', `%${firstName}%`)
-    .ilike('legal_last_name', `%${lastName}%`)
-    .limit(1);
-  
-  if (error || !data || data.length === 0) {
-    // Also check investor_profiles
-    const { data: profileData } = await supabase
-      .from('investor_profiles')
-      .select('*')
-      .ilike('name', `%${firstName}%${lastName}%`)
-      .limit(1);
-    
-    if (!profileData || profileData.length === 0) return null;
-    return profileData[0] as DatabaseUser;
-  }
-  
-  return data[0] as DatabaseUser;
-}
-
-async function searchByPhone(phoneNumber: string): Promise<DatabaseUser | null> {
-  const cleanPhone = phoneNumber.replace(/\D/g, '');
-  console.log(`[A2A TOOL] searchByPhone: ${cleanPhone}`);
-  
-  const { data } = await supabase
-    .from('onboarding_data')
-    .select('*')
-    .eq('phone_number', cleanPhone)
-    .limit(1);
-  
-  if (!data || data.length === 0) return null;
-  return data[0] as DatabaseUser;
-}
-
-// ============================================================================
 // A2A PROTOCOL CONVERSATION ENGINE
 // ============================================================================
 
@@ -798,9 +751,9 @@ async function runA2AConversation(request: KycRequest): Promise<{
   const messages: A2AMessage[] = [];
   const taskId = generateTaskId();
   let sequence = 0;
-  let foundUser: DatabaseUser | null = null;
-  let trustScore = 0;
-  let riskBand: A2ARiskBand = 'HIGH';
+  let foundUser: DatabaseUser | null;
+  let trustScore: number;
+  let riskBand: A2ARiskBand;
 
   // Parse subject name
   const nameParts = request.subject.trim().split(/\s+/);


### PR DESCRIPTION
### **User description**
## Summary
- The variable `recencyScore` was being computed but never utilized anywhere in the prompt generation logic.
- This creates dead code and triggers a `no-unused-vars` CI failure.
- Removed the computation entirely to optimize performance and pass the linter.


## Validation

- [ ] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [ ] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed

## Notes

- deployment impact:
- migration or env requirements:
- follow-up work if any:
- reviewer callouts or CODEOWNERS you expect to review this:


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removes unused functions and variables.

- Resolves multiple linting errors.

- Improves type safety by replacing `any` with `unknown`.

- Refactors variable scope for better readability.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Remove dead code and fix linting issues in the KYC agent</code>&nbsp; </dd></summary>
<hr>

supabase/functions/kyc-agent-a2a-protocol/index.ts

<ul><li>Removed the unused <code>searchByName</code> and <code>searchByPhone</code> functions.<br> <li> Deleted several unused variables to resolve <code>no-unused-vars</code> lint <br>errors.<br> <li> Replaced <code>any</code> with <code>unknown</code> for improved type safety.<br> <li> Scoped variables like <code>foundUser</code> and <code>trustScore</code> more locally with <br><code>const</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/hushh-labs/hushh_Tech_website/pull/946/files#diff-fcb4c5deb845003f6ffa0e26f150c6ac0533019379b5617c7e6ec47f4663aa60">+9/-58</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

custom_model_max_tokens: 1048576
ai_timeout: 480
max_model_tokens: 128000
model: vertex_ai/gemini-2.5-pro
fallback_models: ['vertex_ai/gemini-2.5-flash', 'gpt-5']
git_provider: github
publish_output: True
publish_output_progress: True
verbosity_level: 0
use_extra_bad_extensions: False
log_level: DEBUG
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
disable_auto_feedback: False
custom_reasoning_model: False
response_language: en-US
max_description_tokens: 500
max_commits_tokens: 500
model_token_count_estimate_factor: 0.3
patch_extension_skip_types: ['.md', '.txt']
allow_dynamic_context: True
max_extra_lines_before_dynamic_context: 10
patch_extra_lines_before: 5
patch_extra_lines_after: 1
cli_mode: False
output_relevant_configurations: True
large_patch_policy: clip
duplicate_prompt_examples: False
seed: -1
temperature: 0.2
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_auto_command: True
enable_ai_metadata: False
reasoning_effort: medium
enable_claude_extended_thinking: False
extended_thinking_budget_tokens: 2048
extended_thinking_max_output_tokens: 4096
extract_issue_from_branch: True
branch_issue_regex: 
enable_custom_labels: False

```

**[pr_description]**
```yaml

publish_labels: False
add_original_user_description: True
generate_ai_title: False
use_bullet_points: True
extra_instructions: Keep summaries brief and reviewer-friendly.
Highlight deploy, auth, API, security, and environment impacts explicitly when present.
Do not replace a strong human-written PR title with a weaker generic one.

enable_pr_type: True
final_update_message: False
enable_help_text: False
enable_help_comment: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 6
inline_file_summary: False
use_description_markers: False
enable_large_pr_handling: True
include_generated_by_header: True
max_ai_calls: 4
async_ai_calls: True

```
</details>
