### PR TITLE
feat: add reusable loading spinner component (#965)

### DIFF
--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -2,7 +2,9 @@ import { cn } from '../lib/utils'
 
 interface LoadingSpinnerProps {
   size?: 'sm' | 'md' | 'lg'
+  color?: 'blue' | 'slate' | 'white'
   fullPage?: boolean
+  label?: string
 }
 
 const sizeMap = {
@@ -11,25 +13,49 @@ const sizeMap = {
   lg: 'w-14 h-14 border-4',
 }
 
-const LoadingSpinner = ({ size = 'md', fullPage = false }: LoadingSpinnerProps) => {
+const colorMap = {
+  blue: 'border-gray-300 border-t-blue-500',
+  slate: 'border-slate-200 border-t-slate-700',
+  white: 'border-white/40 border-t-white',
+}
+
+const LoadingSpinner = ({
+  size = 'md',
+  color = 'blue',
+  fullPage = false,
+  label = 'Loading',
+}: LoadingSpinnerProps) => {
   const spinner = (
     <div
+      aria-hidden="true"
       className={cn(
-        'rounded-full border-gray-300 border-t-blue-500 animate-spin',
-        sizeMap[size]
+        'rounded-full animate-spin',
+        sizeMap[size],
+        colorMap[color]
       )}
     />
+  )
+
+  const status = (
+    <div
+      className="inline-flex items-center justify-center"
+      role="status"
+      aria-live="polite"
+    >
+      {spinner}
+      <span className="sr-only">{label}</span>
+    </div>
   )
 
   if (fullPage) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/70 backdrop-blur-sm">
-        {spinner}
+        {status}
       </div>
     )
   }
 
-  return spinner
+  return status
 }
 
 export default LoadingSpinner

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,35 @@
+import { cn } from '../lib/utils'
+
+interface LoadingSpinnerProps {
+  size?: 'sm' | 'md' | 'lg'
+  fullPage?: boolean
+}
+
+const sizeMap = {
+  sm: 'w-4 h-4 border-2',
+  md: 'w-8 h-8 border-4',
+  lg: 'w-14 h-14 border-4',
+}
+
+const LoadingSpinner = ({ size = 'md', fullPage = false }: LoadingSpinnerProps) => {
+  const spinner = (
+    <div
+      className={cn(
+        'rounded-full border-gray-300 border-t-blue-500 animate-spin',
+        sizeMap[size]
+      )}
+    />
+  )
+
+  if (fullPage) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-white/70 backdrop-blur-sm">
+        {spinner}
+      </div>
+    )
+  }
+
+  return spinner
+}
+
+export default LoadingSpinner

--- a/tests/loadingSpinner.test.ts
+++ b/tests/loadingSpinner.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import LoadingSpinner from "../src/components/LoadingSpinner";
+
+describe("LoadingSpinner", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function renderSpinner(props?: React.ComponentProps<typeof LoadingSpinner>) {
+    await act(async () => {
+      root.render(React.createElement(LoadingSpinner, props));
+    });
+  }
+
+  it("announces loading state without exposing the decorative spinner", async () => {
+    await renderSpinner({ color: "slate", label: "Loading account data" });
+
+    const status = container.querySelector('[role="status"]');
+    const spinner = status?.querySelector('[aria-hidden="true"]');
+
+    expect(status).not.toBeNull();
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(status?.textContent).toBe("Loading account data");
+    expect(spinner).not.toBeNull();
+    expect(spinner?.className).toContain("border-t-slate-700");
+  });
+
+  it("keeps full-page loading accessible inside the overlay", async () => {
+    await renderSpinner({ fullPage: true });
+
+    const overlay = container.querySelector(".fixed.inset-0");
+    const status = overlay?.querySelector('[role="status"]');
+
+    expect(overlay).not.toBeNull();
+    expect(status).not.toBeNull();
+    expect(status?.textContent).toBe("Loading");
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: Added a reusable `LoadingSpinner` component with `size`, constrained `color`, `fullPage`, and accessible `label` props.
- why it changed: Shared loading UI keeps async states consistent without adding a third-party spinner dependency.
- linked issue: #965
- acceptance criteria covered: Component exists at `src/components/LoadingSpinner.tsx`, accepts size and color props, supports full-page overlay mode, keeps colors constrained to design-token classes, and includes accessibility test coverage.
- risk area touched: `ui`
- reviewer focus: Verify the spinner remains presentation-only, the default brand-blue styling is unchanged, and inline/full-page modes expose a screen-reader loading status.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [x] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [x] `npm run env:check`
- [x] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: `git diff --check`; `npm run env:check`; `npm run lint:ci`; `npx tsc --noEmit`; `npx vitest run tests/loadingSpinner.test.ts`; earlier full `npm test` before the final color-prop patch passed with 280 tests passed and 42 skipped.
- did not run: Local full `npm test` and `npm run build:web` after the final color-prop patch; GitHub Web Validation is the final full-suite build gate for this pushed PR branch.
- reviewer should verify: Confirm `LoadingSpinner` remains a bounded frontend craft component, uses only the approved constrained color tokens, and does not change product, auth, API, KYC, header/footer, legal, env, or deploy behavior.

## Notes

- deployment impact: none
- migration or env requirements: none
- rollback or release notes: revert the loading spinner component commit if this shared component is not desired.
- follow-up work if any: adoption can happen separately in KYC, login, signup, and Supabase-backed loading states.
- reviewer callouts or CODEOWNERS you expect to review this: `ankitkumarsingh1702`

Closes #965