### PR TITLE
[security] fix: replace insecure btoa() with AES-256-GCM encryption for bank account numbers

### DIFF
--- a/src/pages/fix: DCO sign-off
+++ b/src/pages/fix: DCO sign-off
@@ -1,0 +1,1 @@
+DCO sign-off commit

--- a/src/pages/onboarding/step-9/logic.ts
+++ b/src/pages/onboarding/step-9/logic.ts
@@ -2,6 +2,7 @@
  * Step 13 — All Business Logic
  * Bank details form, Plaid auto-fill, validation, Supabase upsert
  */
+import { encryptSensitiveData } from '../../../utils/cryptoUtils';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import config from '../../../resources/config/config';
@@ -580,7 +581,8 @@ export const useStep13Logic = (): Step13Logic => {
       return;
     }
 
-    const encryptedAccountNumber = btoa(accountNumber);
+    // NEW - SECURE
+     const encryptedAccountNumber = await encryptSensitiveData(accountNumber);
 
     const { error: upsertError } = await upsertOnboardingData(user.id, {
       bank_name: bankName.trim(),

--- a/src/utils/cryptoUtils.ts
+++ b/src/utils/cryptoUtils.ts
@@ -1,0 +1,37 @@
+/**
+ * AES-256-GCM encryption utility
+ * Replaces insecure btoa() encoding in onboarding step 13
+ */
+
+const getEncryptionKey = async (): Promise<CryptoKey> => {
+  const rawKey = import.meta.env.VITE_ENCRYPTION_KEY;
+
+  if (!rawKey) {
+    throw new Error(
+      '[cryptoUtils] VITE_ENCRYPTION_KEY is not set. ' +
+      'Refusing to encrypt sensitive data with a fallback key.'
+    );
+  }
+
+  const keyBytes = new TextEncoder().encode(rawKey.padEnd(32, '0').slice(0, 32));
+  return crypto.subtle.importKey('raw', keyBytes, 'AES-GCM', false, ['encrypt']);
+};
+
+export const encryptSensitiveData = async (plaintext: string): Promise<string> => {
+  const key = await getEncryptionKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encoded = new TextEncoder().encode(plaintext);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    encoded
+  );
+
+  const combined = new Uint8Array(iv.length + ciphertext.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ciphertext), iv.length);
+
+  return btoa(String.fromCharCode(...combined));
+};
+

--- a/src/utils/cryptoUtils.ts
+++ b/src/utils/cryptoUtils.ts
@@ -35,3 +35,5 @@ export const encryptSensitiveData = async (plaintext: string): Promise<string> =
   return btoa(String.fromCharCode(...combined));
 };
 
+
+


### PR DESCRIPTION
## Summary
- what changed: Replaced insecure `btoa()` with AES-256-GCM encryption in `src/pages/onboarding/step-9/logic.ts`. Created `src/utils/cryptoUtils.ts`.
- why it changed: `btoa()` is reversible instantly — not encryption. Bank account numbers are sensitive financial PII.
- linked issue: #964
- acceptance criteria covered: Bank account numbers encrypted with AES-256-GCM. Error thrown if key missing.
- risk area touched: `security` | `data` | `auth`
- reviewer focus: `src/utils/cryptoUtils.ts` and single line change in `logic.ts`

## Validation
- [x] commits are signed off with DCO
- ran: manual testing of form submission flow
- did not run: `npm run test` | `npm run build:web`
- reviewer should verify: `atob()` cannot decode the new encrypted output

## Notes
- deployment impact: `VITE_ENCRYPTION_KEY` must be set in production
- migration or env requirements: Add `VITE_ENCRYPTION_KEY` to environment
- rollback or release notes: none
- follow-up work if any: Move encryption to Supabase Edge Function
- reviewer callouts or CODEOWNERS you expect to review this: @ankitkumarsingh1702