### PR TITLE
fix: prevent internal error details leaking to API clients

### DIFF
--- a/api/enrich-preferences.js
+++ b/api/enrich-preferences.js
@@ -1,4 +1,5 @@
 import { parsePhoneNumberFromString } from "libphonenumber-js";
+import { sendSafeError, sendUpstreamError } from "./shared/errorResponse.js";
 
 const REQUIRED_FIELDS = [
   "name",
@@ -222,9 +223,7 @@ Rules:
     if (!aiResponse.ok) {
       const errorText = await aiResponse.text();
       console.error("OpenAI error:", aiResponse.status, errorText);
-      return response
-        .status(502)
-        .json({ error: "OpenAI request failed", detail: errorText || aiResponse.statusText });
+      return sendUpstreamError(response, { upstream: "openai", status: aiResponse.status, body: errorText });
     }
 
     const data = await aiResponse.json();
@@ -250,7 +249,6 @@ Rules:
     return response.status(200).json({ preferences: parsed });
   } catch (error) {
     console.error("Enrichment handler failed:", error);
-    const message = error instanceof Error ? error.message : "Unknown error";
-    return response.status(500).json({ error: message });
+    return sendSafeError(response, error, { context: "enrich-preferences" });
   }
 }

--- a/api/generate-investor-profile.js
+++ b/api/generate-investor-profile.js
@@ -1,3 +1,5 @@
+import { sendSafeError, sendUpstreamError } from './shared/errorResponse.js';
+
 /**
  * Serverless function to generate investor profile using OpenAI GPT-4o API
  * This runs server-side to avoid CORS issues and keep API keys secure
@@ -180,9 +182,7 @@ export default async function handler(req, res) {
     if (!response.ok) {
       const errorText = await response.text();
       console.error('OpenAI API error:', response.status, errorText);
-      return res.status(response.status).json({ 
-        error: `OpenAI API failed: ${errorText}` 
-      });
+      return sendUpstreamError(res, { upstream: 'openai', status: response.status, body: errorText });
     }
 
     const data = await response.json();
@@ -216,8 +216,6 @@ export default async function handler(req, res) {
 
   } catch (error) {
     console.error('Error generating investor profile:', error);
-    return res.status(500).json({ 
-      error: error.message || 'Failed to generate investor profile' 
-    });
+    return sendSafeError(res, error, { context: 'generate-investor-profile' });
   }
 }

--- a/tests/errorResponse.test.js
+++ b/tests/errorResponse.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { sendSafeError, sendUpstreamError } from "../api/shared/errorResponse.js";
+
+function makeRes() {
+  let _status = null;
+  let _body = null;
+  const res = {
+    status(code) { _status = code; return res; },
+    json(data) { _body = data; return res; },
+    get _status() { return _status; },
+    get _body() { return _body; },
+  };
+  return res;
+}
+
+describe("sendSafeError", () => {
+  it("returns the given HTTP status code", () => {
+    const res = makeRes();
+    sendSafeError(res, new Error("db connection refused"), { status: 503 });
+    expect(res._status).toBe(503);
+  });
+
+  it("never includes the raw error message in the response body", () => {
+    const res = makeRes();
+    const secret = "SUPABASE_SERVICE_ROLE_KEY=super_secret_value";
+    sendSafeError(res, new Error(secret), { status: 500 });
+    expect(JSON.stringify(res._body)).not.toContain(secret);
+  });
+
+  it("always includes a correlationId in the response", () => {
+    const res = makeRes();
+    sendSafeError(res, new Error("boom"), { status: 500 });
+    expect(typeof res._body.correlationId).toBe("string");
+    expect(res._body.correlationId.length).toBeGreaterThan(0);
+  });
+
+  it("uses the custom clientMessage when provided", () => {
+    const res = makeRes();
+    sendSafeError(res, new Error("internal"), { status: 400, clientMessage: "Bad input." });
+    expect(res._body.error).toBe("Bad input.");
+  });
+
+  it("falls back to a generic message for unknown status codes", () => {
+    const res = makeRes();
+    sendSafeError(res, new Error("weird"), { status: 418 });
+    expect(typeof res._body.error).toBe("string");
+    expect(res._body.error.length).toBeGreaterThan(0);
+  });
+
+  it("handles non-Error objects without throwing", () => {
+    const res = makeRes();
+    expect(() => sendSafeError(res, { code: "ECONNRESET" }, { status: 500 })).not.toThrow();
+    expect(res._status).toBe(500);
+  });
+});
+
+describe("sendUpstreamError", () => {
+  it("always returns 502 regardless of upstream status", () => {
+    const res = makeRes();
+    sendUpstreamError(res, { upstream: "openai", status: 401, body: "Unauthorized" });
+    expect(res._status).toBe(502);
+  });
+
+  it("does not forward the upstream body to the client", () => {
+    const res = makeRes();
+    const sensitiveBody = '{"error":"invalid_api_key","message":"sk-proj-abc123"}';
+    sendUpstreamError(res, { upstream: "openai", status: 401, body: sensitiveBody });
+    expect(JSON.stringify(res._body)).not.toContain("sk-proj-abc123");
+    expect(JSON.stringify(res._body)).not.toContain("invalid_api_key");
+  });
+
+  it("includes a correlationId", () => {
+    const res = makeRes();
+    sendUpstreamError(res, { upstream: "openai", status: 500, body: "Server Error" });
+    expect(typeof res._body.correlationId).toBe("string");
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: Added `api/shared/errorResponse.js` with `sendSafeError` and `sendUpstreamError` helpers. Patched `enrich-preferences.js` to stop forwarding raw OpenAI error bodies to callers. Patched `generate-investor-profile.js` to stop forwarding `error.message` verbatim in 500 responses. Every error is now logged server-side with a `correlationId` (UUID) and only a safe, opaque message is returned to the client.
- why it changed: `enrich-preferences.js` was returning `{ error: "OpenAI request failed", detail: <raw upstream body> }` — upstream error bodies from OpenAI can contain API key hints, model names, and quota details that should not be visible to callers. `generate-investor-profile.js` was returning `error.message` directly, which could expose internal stack details or configuration errors. This violates the best_practices.md rule: API routes should fail closed and avoid leaking internal errors.
- linked issue: none — identified during security audit of API error paths, no open issue exists for this
- acceptance criteria covered: Raw OpenAI error bodies are never forwarded to clients. `error.message` from caught exceptions is never forwarded. Every error response includes a `correlationId` for server-side tracing. 9 tests verify no secret leakage and correlationId presence.
- risk area touched: api, security
- reviewer focus: Confirm that `sendSafeError` and `sendUpstreamError` in `errorResponse.js` never include the raw `error` argument in the JSON response body. Check that `correlationId` appears in Cloud Run logs for traceability.
- The `correlationId` is a UUID generated per-request and logged server-side with the full error. Clients receive only the safe message and the ID — no internal details.

## Validation

- [x] `npm test` — 9 new tests in `tests/errorResponse.test.js` all pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint:ci` — no lint violations
- [x] `npm run security:gitleaks` — no secrets detected
- [x] `npm run security:audit` — no new vulnerabilities above baseline
- [x] `npm run env:check` — no new environment variables required
- [ ] `npm run build:web` — not run (no frontend changes)
- [ ] `npm run smoke:ci` — not run locally
- ran: `npm test`, `npx tsc --noEmit`, `npm run lint:ci`, `npm run security:gitleaks`, `npm run security:audit`, `npm run env:check`
- did not run: `npm run build:web` (no frontend changes), `npm run smoke:ci` (requires deploy)
- reviewer should verify: Open `api/shared/errorResponse.js` and confirm the `error` parameter is only passed to `console.error`, never serialised into the response JSON. Confirm `correlationId` is a UUID string in every error response.

## Notes

- deployment impact: Error response shape changes from `{ error: <raw message> }` to `{ error: <safe message>, correlationId: <uuid> }`. Clients parsing the raw error string will now receive a generic message. No auth or data paths affected.
- migration or env requirements: None.
- rollback or release notes: Revert by removing the `errorResponse.js` import and restoring the original catch blocks. No data migration needed.
- follow-up work if any: Wire `correlationId` into a Cloud Run structured log field so errors can be searched by ID in Cloud Logging.
- reviewer callouts or codeowners you expect to review this: `@ankitkumarsingh1702` — please confirm the safe message strings in `SAFE_UPSTREAM_MESSAGES` are appropriate for end users.
