### PR TITLE
fix: harden sanitizeInternalRedirect against header-injection bypasses

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -2,7 +2,14 @@ export const DEFAULT_AUTH_REDIRECT = "/hushh-user-profile";
 
 /**
  * Only allow same-origin, app-internal redirects.
- * External URLs, protocol-relative URLs, and malformed values fall back.
+ *
+ * Rejects:
+ *  - External URLs (http://, https://, //)
+ *  - Protocol-relative URLs
+ *  - Paths containing encoded newlines (%0a, %0d) or null bytes (%00)
+ *    which can be used to inject headers in some server configurations.
+ *  - Paths that resolve to a different origin after URL parsing.
+ *  - Values longer than 2 048 characters (prevents log-flooding).
  */
 export function sanitizeInternalRedirect(
   value: string | null | undefined,
@@ -11,7 +18,18 @@ export function sanitizeInternalRedirect(
   if (!value) return fallback;
 
   const candidate = value.trim();
+
+  // Hard length cap — prevents log-flooding and header-size attacks.
+  if (candidate.length > 2048) return fallback;
+
+  // Must start with a single slash (not //).
   if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    return fallback;
+  }
+
+  // Reject encoded control characters that can be used for header injection
+  // or open-redirect bypasses (%00 null, %0a LF, %0d CR).
+  if (/%(00|0a|0d)/i.test(candidate)) {
     return fallback;
   }
 
@@ -21,7 +39,9 @@ export function sanitizeInternalRedirect(
       return fallback;
     }
 
-    return `${url.pathname}${url.search}${url.hash}` || fallback;
+    // Reconstruct from the parsed URL to normalise any encoded sequences.
+    const normalised = `${url.pathname}${url.search}${url.hash}`;
+    return normalised || fallback;
   } catch {
     return fallback;
   }

--- a/tests/securityUtils.test.ts
+++ b/tests/securityUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeInternalRedirect, DEFAULT_AUTH_REDIRECT } from "../src/utils/security";
+
+const FALLBACK = DEFAULT_AUTH_REDIRECT;
+
+describe("sanitizeInternalRedirect — happy paths", () => {
+  it("returns a simple internal path unchanged", () => {
+    expect(sanitizeInternalRedirect("/hushh-user-profile")).toBe("/hushh-user-profile");
+  });
+
+  it("preserves query strings on internal paths", () => {
+    expect(sanitizeInternalRedirect("/onboarding?step=2")).toBe("/onboarding?step=2");
+  });
+
+  it("preserves hash fragments on internal paths", () => {
+    expect(sanitizeInternalRedirect("/profile#section")).toBe("/profile#section");
+  });
+
+  it("returns the fallback for null", () => {
+    expect(sanitizeInternalRedirect(null)).toBe(FALLBACK);
+  });
+
+  it("returns the fallback for undefined", () => {
+    expect(sanitizeInternalRedirect(undefined)).toBe(FALLBACK);
+  });
+
+  it("returns the fallback for an empty string", () => {
+    expect(sanitizeInternalRedirect("")).toBe(FALLBACK);
+  });
+});
+
+describe("sanitizeInternalRedirect — open-redirect rejection", () => {
+  it("rejects an absolute external URL", () => {
+    expect(sanitizeInternalRedirect("https://evil.com/steal")).toBe(FALLBACK);
+  });
+
+  it("rejects a protocol-relative URL", () => {
+    expect(sanitizeInternalRedirect("//evil.com/steal")).toBe(FALLBACK);
+  });
+
+  it("rejects a javascript: URI", () => {
+    expect(sanitizeInternalRedirect("javascript:alert(1)")).toBe(FALLBACK);
+  });
+
+  it("rejects a data: URI", () => {
+    expect(sanitizeInternalRedirect("data:text/html,<script>alert(1)</script>")).toBe(FALLBACK);
+  });
+});
+
+describe("sanitizeInternalRedirect — header-injection rejection", () => {
+  it("rejects a path with an encoded newline (%0a)", () => {
+    expect(sanitizeInternalRedirect("/path%0aSet-Cookie:evil=1")).toBe(FALLBACK);
+  });
+
+  it("rejects a path with an encoded carriage return (%0d)", () => {
+    expect(sanitizeInternalRedirect("/path%0dSet-Cookie:evil=1")).toBe(FALLBACK);
+  });
+
+  it("rejects a path with an encoded null byte (%00)", () => {
+    expect(sanitizeInternalRedirect("/path%00.txt")).toBe(FALLBACK);
+  });
+
+  it("rejects uppercase encoded newline (%0A)", () => {
+    expect(sanitizeInternalRedirect("/path%0ASet-Cookie:evil=1")).toBe(FALLBACK);
+  });
+});
+
+describe("sanitizeInternalRedirect — length cap", () => {
+  it("rejects paths longer than 2048 characters", () => {
+    const longPath = "/" + "a".repeat(2048);
+    expect(sanitizeInternalRedirect(longPath)).toBe(FALLBACK);
+  });
+
+  it("accepts paths exactly at the 2048-character limit", () => {
+    const borderPath = "/" + "a".repeat(2047);
+    expect(sanitizeInternalRedirect(borderPath)).toBe(borderPath);
+  });
+});
+
+describe("sanitizeInternalRedirect — custom fallback", () => {
+  it("uses the provided fallback instead of the default", () => {
+    expect(sanitizeInternalRedirect("https://evil.com", "/login")).toBe("/login");
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: Hardened `sanitizeInternalRedirect` in `src/utils/security.ts` to block encoded newlines (`%0a`, `%0d`) and null bytes (`%00`) in redirect paths, added a 2048-character length cap, and reconstructs the path from the parsed URL to normalise any encoded sequences before returning.
- why it changed: The previous implementation only checked that the path started with `/` and parsed cleanly as a URL. It did not block percent-encoded control characters. A path like `/profile%0aSet-Cookie:evil=1` passes the old check but can be used for HTTP response splitting in some proxy or logging configurations. The 2048-char cap prevents log-flooding. This function is used in the OAuth redirect flow making it a high-value hardening target.
- linked issue: none — identified during security review of the OAuth redirect path, no open issue exists for this
- acceptance criteria covered: Paths with `%0a`, `%0d`, `%00` (any case) are rejected and fall back to the default. Paths over 2048 chars are rejected. External URLs, protocol-relative URLs, and `javascript:` URIs continue to be rejected. Valid internal paths pass through unchanged. 17 tests cover all bypass vectors.
- risk area touched: auth, security
- reviewer focus: Review the regex `/%(00|0a|0d)/i` in `sanitizeInternalRedirect` and confirm it covers the known header-injection vectors. Verify the 2048-char limit does not break any legitimate deep-link redirect paths in the app.
- The function is used in `buildOAuthRedirectTo` and `buildLoginRedirectPath` — both Google and Apple OAuth flows pass through it, making this a critical security boundary.

## Validation

- [x] `npm test` — 17 new tests in `tests/securityUtils.test.ts` all pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint:ci` — no lint violations
- [x] `npm run security:gitleaks` — no secrets detected
- [x] `npm run security:audit` — no new vulnerabilities above baseline
- [x] `npm run env:check` — no new environment variables required
- [ ] `npm run build:web` — not run (utility function, no UI changes)
- [ ] `npm run smoke:ci` — not run locally
- ran: `npm test`, `npx tsc --noEmit`, `npm run lint:ci`, `npm run security:gitleaks`, `npm run security:audit`, `npm run env:check`
- did not run: `npm run build:web` (no UI changes), `npm run smoke:ci` (requires deploy)
- reviewer should verify: Confirm no existing OAuth redirect test cases break. Check that the longest legitimate redirect path in the app is under 2048 characters.

## Notes

- deployment impact: None — pure input-validation tightening. Legitimate redirect paths are unaffected. Only malformed paths with encoded control characters or extreme length are now rejected.
- migration or env requirements: None.
- rollback or release notes: Revert by restoring the previous `sanitizeInternalRedirect` implementation. No data migration needed.
- follow-up work if any: Consider adding a CSP `navigate-to` directive as a defence-in-depth complement to this server-side check.
- reviewer callouts or codeowners you expect to review this: `@ankitkumarsingh1702` — this touches the OAuth redirect path used by both Google and Apple sign-in. Please verify the 17 test cases cover your expected redirect scenarios.
