### PR TITLE
feat: add structured JSON request logging for Cloud Run

### DIFF
--- a/api/shared/requestLogger.js
+++ b/api/shared/requestLogger.js
@@ -1,0 +1,67 @@
+/**
+ * Structured request/response logger for Cloud Run.
+ * Emits JSON lines that Cloud Logging parses natively via httpRequest fields.
+ * Sensitive headers (Authorization, Cookie, Set-Cookie) are redacted.
+ */
+
+import { randomUUID } from "node:crypto";
+
+const REDACTED_REQUEST_HEADERS = new Set(["authorization", "cookie", "x-api-key", "x-auth-token"]);
+const REDACTED_RESPONSE_HEADERS = new Set(["set-cookie"]);
+
+function sanitiseHeaders(headers, redactSet) {
+  const out = {};
+  for (const [key, value] of Object.entries(headers ?? {})) {
+    const lower = key.toLowerCase();
+    out[lower] = redactSet.has(lower) ? "[REDACTED]" : (Array.isArray(value) ? value.join(", ") : String(value ?? ""));
+  }
+  return out;
+}
+
+export function getClientIp(req) {
+  const forwarded = req.headers?.["x-forwarded-for"];
+  if (typeof forwarded === "string" && forwarded.trim()) return forwarded.split(",")[0].trim();
+  return req.socket?.remoteAddress ?? req.ip ?? "unknown";
+}
+
+function severityFromStatus(status) {
+  if (status >= 500) return "ERROR";
+  if (status >= 400) return "WARNING";
+  return "INFO";
+}
+
+export function requestLoggerMiddleware(req, res, next) {
+  const startMs = Date.now();
+  const correlationId = randomUUID();
+  req.correlationId = correlationId;
+
+  const originalEnd = res.end.bind(res);
+  res.end = function (...args) {
+    const latencyMs = Date.now() - startMs;
+    const status = res.statusCode ?? 0;
+    process.stdout.write(JSON.stringify({
+      severity: severityFromStatus(status),
+      correlationId,
+      message: `${req.method} ${req.path} ${status} ${latencyMs}ms`,
+      httpRequest: {
+        requestMethod: req.method,
+        requestUrl: req.originalUrl ?? req.url,
+        status,
+        latency: `${(latencyMs / 1000).toFixed(3)}s`,
+        remoteIp: getClientIp(req),
+        userAgent: req.headers?.["user-agent"] ?? "",
+        referer: req.headers?.referer ?? req.headers?.referrer ?? "",
+        protocol: req.protocol ?? "https",
+      },
+      requestHeaders: sanitiseHeaders(req.headers, REDACTED_REQUEST_HEADERS),
+      responseHeaders: sanitiseHeaders(res.getHeaders?.() ?? {}, REDACTED_RESPONSE_HEADERS),
+    }) + "\n");
+    return originalEnd(...args);
+  };
+
+  next();
+}
+
+export function logEvent(severity, message, extra = {}) {
+  process.stdout.write(JSON.stringify({ severity, message, timestamp: new Date().toISOString(), ...extra }) + "\n");
+}

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { requestLoggerMiddleware, logEvent } from './api/shared/requestLogger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -27,6 +28,9 @@ const DIST_DIR = join(__dirname, 'dist');
 // Parse JSON & URL-encoded bodies
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true }));
+
+// Structured JSON request logging — must come before route handlers.
+app.use(requestLoggerMiddleware);
 
 // Global security headers for Cloud Run. This file is the authoritative runtime config.
 app.use((_req, res, next) => {
@@ -161,6 +165,5 @@ app.get('*', (req, res) => {
 // Start Server
 // ---------------------------------------------------------------------------
 app.listen(PORT, '0.0.0.0', () => {
-  console.log(`🚀 Hushh Tech Website running on port ${PORT}`);
-  console.log(`   Environment: ${process.env.NODE_ENV || 'development'}`);
+  logEvent('INFO', 'Hushh Tech Website started', { port: PORT, environment: process.env.NODE_ENV ?? 'development' });
 });

--- a/tests/requestLogger.test.js
+++ b/tests/requestLogger.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { requestLoggerMiddleware, logEvent } from "../api/shared/requestLogger.js";
+
+function makeReq(overrides = {}) {
+  return { method: "GET", path: "/api/test", originalUrl: "/api/test", protocol: "https", headers: { "user-agent": "vitest", "x-forwarded-for": "10.0.0.1" }, socket: { remoteAddress: "127.0.0.1" }, ip: undefined, correlationId: undefined, ...overrides };
+}
+function makeRes(statusCode = 200) {
+  const _headers = {};
+  return { statusCode, end: vi.fn(), getHeaders: () => _headers, setHeader(k, v) { _headers[k] = v; }, _headers };
+}
+
+describe("requestLoggerMiddleware", () => {
+  let spy, lines;
+  beforeEach(() => { lines = []; spy = vi.spyOn(process.stdout, "write").mockImplementation(l => { lines.push(l); return true; }); });
+  afterEach(() => spy.mockRestore());
+
+  it("calls next()", () => { const next = vi.fn(); requestLoggerMiddleware(makeReq(), makeRes(), next); expect(next).toHaveBeenCalledOnce(); });
+  it("attaches correlationId to req", () => { const req = makeReq(); requestLoggerMiddleware(req, makeRes(), vi.fn()); expect(typeof req.correlationId).toBe("string"); });
+  it("writes JSON log on res.end()", () => { const res = makeRes(200); requestLoggerMiddleware(makeReq(), res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).httpRequest.status).toBe(200); });
+  it("sets WARNING for 4xx", () => { const res = makeRes(404); requestLoggerMiddleware(makeReq(), res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).severity).toBe("WARNING"); });
+  it("sets ERROR for 5xx", () => { const res = makeRes(500); requestLoggerMiddleware(makeReq(), res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).severity).toBe("ERROR"); });
+  it("redacts Authorization header", () => { const req = makeReq({ headers: { authorization: "Bearer secret-token", "user-agent": "v", "x-forwarded-for": "1.1.1.1" } }); const res = makeRes(); requestLoggerMiddleware(req, res, vi.fn()); res.end(); const parsed = JSON.parse(lines[0]); expect(parsed.requestHeaders.authorization).toBe("[REDACTED]"); expect(JSON.stringify(parsed)).not.toContain("secret-token"); });
+  it("redacts Cookie header", () => { const req = makeReq({ headers: { cookie: "session=abc123", "user-agent": "v", "x-forwarded-for": "1.1.1.1" } }); const res = makeRes(); requestLoggerMiddleware(req, res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).requestHeaders.cookie).toBe("[REDACTED]"); });
+  it("redacts Set-Cookie response header", () => { const res = makeRes(200); res.setHeader("set-cookie", "session=secret; HttpOnly"); requestLoggerMiddleware(makeReq(), res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).responseHeaders["set-cookie"]).toBe("[REDACTED]"); });
+  it("includes correlationId in log", () => { const req = makeReq(); const res = makeRes(); requestLoggerMiddleware(req, res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).correlationId).toBe(req.correlationId); });
+  it("uses X-Forwarded-For as remoteIp", () => { const req = makeReq({ headers: { "x-forwarded-for": "203.0.113.5, 10.0.0.1" } }); const res = makeRes(); requestLoggerMiddleware(req, res, vi.fn()); res.end(); expect(JSON.parse(lines[0]).httpRequest.remoteIp).toBe("203.0.113.5"); });
+});
+
+describe("logEvent", () => {
+  let spy, lines;
+  beforeEach(() => { lines = []; spy = vi.spyOn(process.stdout, "write").mockImplementation(l => { lines.push(l); return true; }); });
+  afterEach(() => spy.mockRestore());
+
+  it("writes valid JSON", () => { logEvent("INFO", "started", { port: 8080 }); const p = JSON.parse(lines[0]); expect(p.severity).toBe("INFO"); expect(p.port).toBe(8080); });
+  it("includes timestamp", () => { logEvent("WARNING", "high mem"); expect(new Date(JSON.parse(lines[0]).timestamp).getTime()).not.toBeNaN(); });
+});


### PR DESCRIPTION
## Summary

- what changed: Added `api/shared/requestLogger.js` with a `requestLoggerMiddleware` Express middleware and a `logEvent` helper. Wired the middleware into `server.js` after body parsing. Replaced the `console.log` startup message with a structured `logEvent` call. Every request now emits a JSON log line with `httpRequest` fields that Google Cloud Logging parses natively (method, path, status, latency, remoteIp, userAgent). Sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`) are redacted before logging.
- why it changed: The Cloud Run server had no per-request logging. Debugging production issues required guessing from application-level logs. Cloud Logging can parse structured `httpRequest` JSON fields into a dedicated request log view with latency histograms and status-code filtering — but only if the server emits the correct format. The `console.log` startup message was also unstructured and would not be indexed correctly.
- linked issue: none — observability improvement for Cloud Run production environment, no open issue exists for this
- acceptance criteria covered: Every request produces a JSON log line. `Authorization` and `Cookie` headers are replaced with `[REDACTED]`. `Set-Cookie` response headers are replaced with `[REDACTED]`. Severity maps correctly (INFO/WARNING/ERROR) to HTTP status ranges. `correlationId` is attached to `req` for downstream handlers. 12 tests verify all of the above.
- risk area touched: infra, api
- reviewer focus: Verify that `sanitiseHeaders` in `requestLogger.js` covers all sensitive header names. Confirm that response bodies are never logged (only headers and status). Check that the middleware is registered before route handlers in `server.js`.
- Sensitive headers are redacted using a `Set` lookup before the log line is written — the raw values never appear in stdout.

## Validation

- [x] `npm test` — 12 new tests in `tests/requestLogger.test.js` all pass
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run lint:ci` — no lint violations
- [x] `npm run security:gitleaks` — no secrets detected
- [x] `npm run security:audit` — no new vulnerabilities above baseline
- [x] `npm run env:check` — no new environment variables required
- [ ] `npm run build:web` — not run (no frontend changes)
- [ ] `npm run smoke:ci` — not run locally
- ran: `npm test`, `npx tsc --noEmit`, `npm run lint:ci`, `npm run security:gitleaks`, `npm run security:audit`, `npm run env:check`
- did not run: `npm run build:web` (no frontend changes), `npm run smoke:ci` (requires deploy)
- reviewer should verify: Confirm `REDACTED_REQUEST_HEADERS` set in `requestLogger.js` includes `authorization` and `cookie`. Confirm response bodies are not referenced anywhere in the logger. Verify middleware order in `server.js` (logger must come before route handlers).

## Notes

- deployment impact: Adds structured JSON lines to Cloud Run stdout. Cloud Logging will automatically parse `httpRequest` fields. No breaking changes to existing log consumers.
- migration or env requirements: None — no new environment variables.
- rollback or release notes: Revert by removing the `requestLoggerMiddleware` import and `app.use(requestLoggerMiddleware)` line from `server.js`. No data migration needed.
- follow-up work if any: Add `correlationId` propagation to Supabase client calls so a single request's full trace can be reconstructed across log lines.
- reviewer callouts or codeowners you expect to review this: `@ankitkumarsingh1702` — please confirm the `httpRequest` JSON structure matches what your Cloud Logging dashboard expects for the request log view.
