### PR TITLE
fix: harden send-email-notification with type validation, HTML escapi…

### DIFF
--- a/api/send-email-notification.js
+++ b/api/send-email-notification.js
@@ -1,24 +1,68 @@
-// Vercel Serverless Function for Email Notifications
-// Works with Gmail SMTP (Node.js compatible)
-
+ 
 import nodemailer from 'nodemailer';
 import { createClient } from '@supabase/supabase-js';
-
-// CORS headers
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type',
-};
-
+ 
+const ALLOWED_EMAIL_TYPES = new Set(['profile_view', 'payment_received']);
+ 
+const rateLimitStore = new Map();
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour per slug
+ 
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+ 
+function isValidEmail(value) {
+  return typeof value === 'string' && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+}
+ 
+function isRateLimited(slug) {
+  const now = Date.now();
+  const entry = rateLimitStore.get(slug);
+ 
+  if (!entry || now - entry.windowStart > RATE_LIMIT_WINDOW_MS) {
+    rateLimitStore.set(slug, { count: 1, windowStart: now });
+    return false;
+  }
+ 
+  if (entry.count >= RATE_LIMIT_MAX) {
+    return true;
+  }
+ 
+  entry.count += 1;
+  return false;
+}
+ 
+function isAuthorizedTestRequest(req) {
+  const configuredSecret = typeof process.env.EMAIL_TEST_SECRET === 'string'
+    ? process.env.EMAIL_TEST_SECRET.trim()
+    : '';
+ 
+  if (!configuredSecret) {
+    return process.env.NODE_ENV !== 'production';
+  }
+ 
+  const providedSecret =
+    typeof req.headers['x-email-test-secret'] === 'string'
+      ? req.headers['x-email-test-secret'].trim()
+      : '';
+ 
+  return providedSecret === configuredSecret;
+}
+ 
 function createSupabaseAdminClient() {
   const supabaseUrl = process.env.SUPABASE_URL?.trim();
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
-
+ 
   if (!supabaseUrl || !serviceRoleKey) {
     throw new Error('Supabase server environment variables are missing');
   }
-
+ 
   return createClient(supabaseUrl, serviceRoleKey, {
     auth: {
       autoRefreshToken: false,
@@ -26,7 +70,7 @@ function createSupabaseAdminClient() {
     },
   });
 }
-
+ 
 async function resolvePublicProfileOwner(slug) {
   const supabase = createSupabaseAdminClient();
   const { data, error } = await supabase
@@ -36,45 +80,145 @@ async function resolvePublicProfileOwner(slug) {
     .eq('is_public', true)
     .eq('user_confirmed', true)
     .maybeSingle();
-
+ 
   if (error) {
     throw new Error(`Failed to resolve profile owner: ${error.message}`);
   }
-
+ 
   if (!data?.email) {
     throw new Error('Public profile owner email not found');
   }
-
+ 
+  if (!isValidEmail(data.email)) {
+    throw new Error('Resolved profile owner email is not a valid email address');
+  }
+ 
   return {
     email: data.email,
     name: data.name || 'Your Profile',
   };
 }
-
+ 
+function createTransporter() {
+  const user = process.env.GMAIL_USER?.trim();
+  const pass = process.env.GMAIL_APP_PASSWORD?.trim();
+ 
+  if (!user || !pass) {
+    throw new Error('GMAIL_USER and GMAIL_APP_PASSWORD are required');
+  }
+ 
+  return nodemailer.createTransport({
+    service: 'gmail',
+    auth: { user, pass },
+    connectionTimeout: 5000,
+    greetingTimeout: 5000,
+    socketTimeout: 10000,
+  });
+}
+ 
+function buildProfileViewEmail(slug, resolvedProfileName) {
+  const viewTime = new Date().toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+ 
+  const safeName = escapeHtml(resolvedProfileName);
+  const safeSlug = escapeHtml(slug);
+  const safeTime = escapeHtml(viewTime);
+ 
+  return {
+    subject: `👀 New Profile View - ${safeName}`,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #0A84FF;">👀 Someone is viewing your profile!</h2>
+ 
+        <div style="background: #F8FAFC; border-radius: 8px; padding: 20px; margin: 20px 0;">
+          <p style="margin: 8px 0;"><strong>Profile:</strong> ${safeName}</p>
+          <p style="margin: 8px 0;"><strong>Time:</strong> ${safeTime}</p>
+          <p style="margin: 8px 0;"><strong>Visitor:</strong> Anonymous</p>
+        </div>
+ 
+        <a href="https://hushhtech.com/investor/${safeSlug}"
+           style="display: inline-block; background: #0A84FF; color: white; padding: 12px 24px;
+                  text-decoration: none; border-radius: 8px; margin-top: 16px;">
+          View Your Profile →
+        </a>
+ 
+        <p style="color: #6B7280; font-size: 14px; margin-top: 32px;">
+          Instant notification - someone is browsing your profile now.
+        </p>
+      </div>
+    `,
+  };
+}
+ 
+function buildPaymentReceivedEmail(slug, resolvedProfileName) {
+  const paymentTime = new Date().toLocaleString('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+ 
+  const safeName = escapeHtml(resolvedProfileName);
+  const safeSlug = escapeHtml(slug);
+  const safeTime = escapeHtml(paymentTime);
+ 
+  return {
+    subject: `💰 Payment Received - $1.00`,
+    html: `
+      <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #34C759;">💰 Payment Received!</h2>
+ 
+        <p style="font-size: 16px; color: #0B1120;">
+          Great news! Someone just paid to unlock chat access.
+        </p>
+ 
+        <div style="background: #F0F9FF; border-left: 4px solid #0A84FF; padding: 20px; margin: 20px 0;">
+          <p style="margin: 8px 0;"><strong>Amount:</strong> $1.00</p>
+          <p style="margin: 8px 0;"><strong>Access:</strong> 30 minutes</p>
+          <p style="margin: 8px 0;"><strong>Profile:</strong> ${safeName}</p>
+          <p style="margin: 8px 0;"><strong>Time:</strong> ${safeTime}</p>
+        </div>
+ 
+        <a href="https://hushhtech.com/investor/${safeSlug}"
+           style="display: inline-block; background: #34C759; color: white; padding: 12px 24px;
+                  text-decoration: none; border-radius: 8px; margin-top: 16px;">
+          View Your Profile →
+        </a>
+ 
+        <p style="color: #6B7280; font-size: 14px; margin-top: 32px;">
+          Check your Stripe dashboard for payout details.
+        </p>
+      </div>
+    `,
+  };
+}
+ 
 export default async function handler(req, res) {
-  // Handle CORS preflight
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-email-test-secret');
+ 
   if (req.method === 'OPTIONS') {
     return res.status(200).json({ ok: true });
   }
-
+ 
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
-
+ 
   try {
-    const { type, slug, profileOwnerEmail, profileName, testEmail } = req.body;
-
-    // Configure Gmail transporter
-    const transporter = nodemailer.createTransport({
-      service: 'gmail',
-      auth: {
-        user: process.env.GMAIL_USER,
-        pass: process.env.GMAIL_APP_PASSWORD,
-      },
-    });
-
-    // Test mode: Send test email
+    const { type, slug, profileOwnerEmail, profileName, testEmail } = req.body || {};
+ 
     if (testEmail) {
+      if (!isAuthorizedTestRequest(req)) {
+        return res.status(401).json({ error: 'Unauthorized: test emails require x-email-test-secret header' });
+      }
+ 
+      if (!isValidEmail(testEmail)) {
+        return res.status(400).json({ error: 'Invalid testEmail address' });
+      }
+ 
+      const transporter = createTransporter();
       await transporter.sendMail({
         from: `"Hushh Notifications" <${process.env.GMAIL_USER}>`,
         to: testEmail,
@@ -83,113 +227,56 @@ export default async function handler(req, res) {
           <div style="font-family: -apple-system, sans-serif; max-width: 600px;">
             <h2>✅ Email System Working!</h2>
             <p>This is a test email from your Hushh notification system.</p>
-            <p><strong>Gmail:</strong> ${process.env.GMAIL_USER}</p>
-            <p><strong>Time:</strong> ${new Date().toLocaleString()}</p>
+            <p><strong>Gmail:</strong> ${escapeHtml(process.env.GMAIL_USER)}</p>
+            <p><strong>Time:</strong> ${escapeHtml(new Date().toLocaleString())}</p>
             <p>If you receive this, email notifications are working! 🎉</p>
           </div>
         `,
       });
-
+ 
       return res.status(200).json({ success: true, message: 'Test email sent!' });
     }
-
-    // Validate required fields
+ 
     if (!type || !slug) {
-      return res.status(400).json({ error: 'Missing required fields' });
+      return res.status(400).json({ error: 'Missing required fields: type and slug' });
     }
-
-    let resolvedOwnerEmail = profileOwnerEmail || '';
-    let resolvedProfileName = profileName || 'Your Profile';
-
-    if (!resolvedOwnerEmail) {
-      const owner = await resolvePublicProfileOwner(slug);
-      resolvedOwnerEmail = owner.email;
-      if (!profileName) {
-        resolvedProfileName = owner.name;
-      }
+ 
+    if (typeof slug !== 'string' || slug.trim().length === 0 || slug.length > 128) {
+      return res.status(400).json({ error: 'Invalid slug' });
     }
-
-    let subject = '';
-    let html = '';
-
-    // Build email based on type
+ 
+    if (!ALLOWED_EMAIL_TYPES.has(type)) {
+      return res.status(400).json({ error: `Unsupported email type: ${type}. Allowed: ${[...ALLOWED_EMAIL_TYPES].join(', ')}` });
+    }
+ 
+    if (isRateLimited(slug.trim())) {
+      return res.status(429).json({ error: 'Too many notifications for this profile. Try again later.' });
+    }
+ 
+    const owner = await resolvePublicProfileOwner(slug.trim());
+    const resolvedProfileName = profileName?.trim() || owner.name;
+ 
+    let emailContent;
     if (type === 'profile_view') {
-      const viewTime = new Date().toLocaleString('en-US', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      });
-
-      subject = `👀 New Profile View - ${resolvedProfileName}`;
-      html = `
-        <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2 style="color: #0A84FF;">👀 Someone is viewing your profile!</h2>
-          
-          <div style="background: #F8FAFC; border-radius: 8px; padding: 20px; margin: 20px 0;">
-            <p style="margin: 8px 0;"><strong>Profile:</strong> ${resolvedProfileName}</p>
-            <p style="margin: 8px 0;"><strong>Time:</strong> ${viewTime}</p>
-            <p style="margin: 8px 0;"><strong>Visitor:</strong> Anonymous</p>
-          </div>
-
-          <a href="https://hushhtech.com/investor/${slug}" 
-             style="display: inline-block; background: #0A84FF; color: white; padding: 12px 24px; 
-                    text-decoration: none; border-radius: 8px; margin-top: 16px;">
-            View Your Profile →
-          </a>
-
-          <p style="color: #6B7280; font-size: 14px; margin-top: 32px;">
-            Instant notification - someone is browsing your profile now.
-          </p>
-        </div>
-      `;
+      emailContent = buildProfileViewEmail(slug.trim(), resolvedProfileName);
     } else if (type === 'payment_received') {
-      const paymentTime = new Date().toLocaleString('en-US', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-      });
-
-      subject = `💰 Payment Received - $1.00`;
-      html = `
-        <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto;">
-          <h2 style="color: #34C759;">💰 Payment Received!</h2>
-          
-          <p style="font-size: 16px; color: #0B1120;">
-            Great news! Someone just paid to unlock chat access.
-          </p>
-
-          <div style="background: #F0F9FF; border-left: 4px solid #0A84FF; padding: 20px; margin: 20px 0;">
-            <p style="margin: 8px 0;"><strong>Amount:</strong> $1.00</p>
-            <p style="margin: 8px 0;"><strong>Access:</strong> 30 minutes</p>
-            <p style="margin: 8px 0;"><strong>Profile:</strong> ${resolvedProfileName}</p>
-            <p style="margin: 8px 0;"><strong>Time:</strong> ${paymentTime}</p>
-          </div>
-
-          <a href="https://hushhtech.com/investor/${slug}" 
-             style="display: inline-block; background: #34C759; color: white; padding: 12px 24px; 
-                    text-decoration: none; border-radius: 8px; margin-top: 16px;">
-            View Your Profile →
-          </a>
-
-          <p style="color: #6B7280; font-size: 14px; margin-top: 32px;">
-            Check your Stripe dashboard for payout details.
-          </p>
-        </div>
-      `;
+      emailContent = buildPaymentReceivedEmail(slug.trim(), resolvedProfileName);
     }
-
-    // Send email
+ 
+    const transporter = createTransporter();
     await transporter.sendMail({
       from: `"Hushh Notifications" <${process.env.GMAIL_USER}>`,
-      to: resolvedOwnerEmail,
-      subject,
-      html,
+      to: owner.email,
+      subject: emailContent.subject,
+      html: emailContent.html,
     });
-
+ 
     return res.status(200).json({ success: true, emailSent: true });
   } catch (error) {
     console.error('Email error:', error);
-    return res.status(500).json({ 
+    return res.status(500).json({
       error: error.message || 'Failed to send email',
-      details: error.toString()
     });
   }
 }
+ 


### PR DESCRIPTION
## Summary
- what changed: Hardened `api/send-email-notification.js` with email type allowlist validation, HTML escaping on all interpolated values, in-memory rate limiting per slug, secret-gated test email authorization, CORS headers applied on every response, nodemailer connection timeouts, server-side-only email resolution ignoring caller-supplied recipient, and removal of the unused `corsHeaders` object.
- why it changed: The previous implementation had multiple security and reliability gaps — unknown email types silently sent empty emails, profile name and slug values were interpolated into HTML without escaping creating XSS risk, the test email endpoint had no authentication allowing anyone to send emails to arbitrary addresses, and the caller could supply any recipient email bypassing the database-verified owner lookup.
- linked issue: none - no linked issue exists, this is a standalone backend security and reliability hardening change
- acceptance criteria covered: Unknown types return 400, HTML values are escaped before interpolation, rate limit returns 429 after 5 requests per slug per hour, test emails require x-email-test-secret header, recipient is always resolved from database regardless of caller input, CORS headers present on all responses, nodemailer has connection and socket timeouts configured.
- risk area touched: api, security
- reviewer focus: Verify that caller-supplied profileOwnerEmail is fully ignored in favor of server-side resolution, that HTML interpolation uses escapeHtml on all dynamic values, and that the rate limit resets correctly after the 1-hour window.

## Validation
- [x] Commits are signed off with DCO (`git commit -s`)
- [x] `npm run lint:ci` passes with zero violations
- [x] Manual smoke tests performed against all email type paths and edge cases
- ran: `npm run lint:ci` and manual verification of type validation, rate limiting, and HTML escaping paths
- reviewer should verify: That `type: "unknown"` returns 400, that `testEmail` without the secret header returns 401, that a slug receiving more than 5 requests in an hour returns 429, and that a profile name containing `<script>` tags is escaped in the email HTML output
- did not run: none

## Notes
- Rate limit store is in-memory and resets on server restart — acceptable for Cloud Run given the per-instance scope and the low notification volume expected.
- `profileOwnerEmail` from the request body is now fully ignored to prevent caller-controlled recipient spoofing.
- `EMAIL_TEST_SECRET` env var must be set in production to gate test email usage — falls back to allowing only in non-production environments if unset.
- No changes outside `api/send-email-notification.js`.
- Removed unused `corsHeaders` constant that was defined but never applied to any response.
