### PR TITLE
feat(security): add CSP and secure browser headers

### DIFF
--- a/api/shared/securityHeaders.js
+++ b/api/shared/securityHeaders.js
@@ -1,0 +1,47 @@
+const ENFORCED_CSP_DIRECTIVES = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'self'",
+  "form-action 'self'",
+  "manifest-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.plaid.com",
+  "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:",
+  "img-src 'self' data: blob: https: http:",
+  // Wallet upstream traffic must stay behind same-origin /api proxies to avoid CSP regressions.
+  "connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co https://www.google.com https://www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com https://api.emailjs.com https://generativelanguage.googleapis.com https://*.googleapis.com https://www.walletlink.org wss://www.walletlink.org wss://mainnet.infura.io wss://*.infura.io https://*.seondnsresolve.com https://www.recaptcha.net https://hushhtech-nda-generation-53407187172.us-central1.run.app",
+  "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
+  "media-src 'self' blob: data:",
+  "worker-src 'self' blob:",
+  "child-src 'self' blob: https://cdn.plaid.com https://*.plaid.com",
+];
+
+const REPORT_ONLY_CSP_DIRECTIVES = ENFORCED_CSP_DIRECTIVES.map((directive) =>
+  directive
+    .replace(/ 'unsafe-inline'/g, "")
+    .replace(/ 'unsafe-eval'/g, "")
+);
+
+export const SECURITY_HEADERS = {
+  'Content-Security-Policy': ENFORCED_CSP_DIRECTIVES.join('; '),
+  'Content-Security-Policy-Report-Only': REPORT_ONLY_CSP_DIRECTIVES.join('; '),
+  'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+  'Cross-Origin-Resource-Policy': 'same-site',
+  'Origin-Agent-Cluster': '?1',
+  'Permissions-Policy': 'camera=(self), microphone=(), geolocation=(self), encrypted-media=(self), accelerometer=(self)',
+  'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+  'X-Content-Type-Options': 'nosniff',
+  'X-DNS-Prefetch-Control': 'on',
+  'X-Download-Options': 'noopen',
+  'X-Frame-Options': 'SAMEORIGIN',
+  'X-Permitted-Cross-Domain-Policies': 'none',
+  'X-XSS-Protection': '1; mode=block',
+};
+
+export function applySecurityHeaders(res) {
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+    res.setHeader(name, value);
+  }
+}

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@
 import express from 'express';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { applySecurityHeaders } from './api/shared/securityHeaders.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -30,32 +31,7 @@ app.use(express.urlencoded({ extended: true }));
 
 // Global security headers for Cloud Run. This file is the authoritative runtime config.
 app.use((_req, res, next) => {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader('X-XSS-Protection', '1; mode=block');
-  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
-  res.setHeader(
-    'Content-Security-Policy',
-    [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.plaid.com",
-      "font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com data:",
-      "img-src 'self' data: blob: https: http:",
-      // Wallet upstream traffic must stay behind same-origin /api proxies to avoid CSP regressions.
-      "connect-src 'self' https://*.plaid.com https://*.supabase.co wss://*.supabase.co https://www.google.com https://www.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com https://api.emailjs.com https://generativelanguage.googleapis.com https://*.googleapis.com https://www.walletlink.org wss://www.walletlink.org wss://mainnet.infura.io wss://*.infura.io https://*.seondnsresolve.com https://www.recaptcha.net https://hushhtech-nda-generation-53407187172.us-central1.run.app",
-      "frame-src 'self' https://cdn.plaid.com https://*.plaid.com https://www.google.com https://www.gstatic.com https://calendly.com https://www.recaptcha.net https://lookerstudio.google.com https://datastudio.google.com",
-      "media-src 'self' blob: data:",
-      "worker-src 'self' blob:",
-      "child-src 'self' blob: https://cdn.plaid.com https://*.plaid.com",
-    ].join('; ')
-  );
-  res.setHeader(
-    'Permissions-Policy',
-    'camera=*, microphone=(), geolocation=(self), encrypted-media=*, accelerometer=*'
-  );
-  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
-  res.setHeader('X-DNS-Prefetch-Control', 'on');
+  applySecurityHeaders(res);
   next();
 });
 

--- a/tests/securityHeaders.test.ts
+++ b/tests/securityHeaders.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { SECURITY_HEADERS, applySecurityHeaders } from "../api/shared/securityHeaders.js";
+
+describe("security headers", () => {
+  it("defines an enforced CSP with browser hardening directives", () => {
+    const csp = SECURITY_HEADERS["Content-Security-Policy"];
+
+    expect(csp).toContain("default-src 'self'");
+    expect(csp).toContain("base-uri 'self'");
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("frame-ancestors 'self'");
+    expect(csp).toContain("form-action 'self'");
+    expect(csp).toContain("connect-src 'self'");
+    expect(csp).toContain("https://*.supabase.co");
+    expect(csp).toContain("https://cdn.plaid.com");
+  });
+
+  it("ships a stricter report-only CSP before removing inline and eval allowances", () => {
+    const enforced = SECURITY_HEADERS["Content-Security-Policy"];
+    const reportOnly = SECURITY_HEADERS["Content-Security-Policy-Report-Only"];
+
+    expect(enforced).toContain("'unsafe-inline'");
+    expect(enforced).toContain("'unsafe-eval'");
+    expect(reportOnly).not.toContain("'unsafe-inline'");
+    expect(reportOnly).not.toContain("'unsafe-eval'");
+  });
+
+  it("applies secure browser headers to runtime responses", () => {
+    const headers = new Map<string, string>();
+    const res = {
+      setHeader(name: string, value: string) {
+        headers.set(name, value);
+      },
+    };
+
+    applySecurityHeaders(res);
+
+    expect(headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains; preload"
+    );
+    expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+    expect(headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    expect(headers.get("Permissions-Policy")).toContain("microphone=()");
+    expect(headers.get("Cross-Origin-Opener-Policy")).toBe("same-origin-allow-popups");
+    expect(headers.get("Cross-Origin-Resource-Policy")).toBe("same-site");
+    expect(headers.get("Origin-Agent-Cluster")).toBe("?1");
+    expect(headers.get("X-Permitted-Cross-Domain-Policies")).toBe("none");
+    expect(headers.get("X-Download-Options")).toBe("noopen");
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: Added Content Security Policy (CSP) configuration and secure browser response headers to strengthen frontend security protections across the Hushh platform
- why it changed: Improves browser-level security by reducing exposure to script injection attacks clickjacking MIME-type sniffing and insecure resource execution
- linked issue: none - standalone security hardening enhancement focused on improving frontend browser protection and secure response handling
- acceptance criteria covered: Secure browser headers are applied CSP configuration is enforced existing application rendering and asset loading continue functioning normally
- risk area touched: security
- reviewer focus: Confirm CSP rules do not block legitimate assets verify browser security headers are applied correctly ensure existing scripts styles and application flows remain unaffected

## Validation

- [x] Verified secure browser headers are applied correctly
- [x] Verified CSP configuration allows expected application resources
- [x] Verified no frontend rendering regressions introduced
- [x] Verified application assets continue loading successfully
- [x] No runtime browser security errors introduced

- ran: Local browser verification manual CSP inspection developer tools security header validation code review for secure header configuration and resource loading behavior
- did not run: Automated penetration testing and CSP violation monitoring integration can be added in a follow-up PR if maintainers request expanded security validation
- reviewer should verify: Inspect browser response headers confirm CSP rules do not block expected resources verify application scripts styles and external integrations continue functioning normally

## Notes

- deployment impact: Low risk frontend security enhancement no backend business logic changes purely browser-level security hardening
- migration or env requirements: None required unless future CSP policies introduce stricter external asset restrictions
- rollback or release notes: Safe to rollback if needed restores previous browser security header behavior without affecting application state
- follow-up work if any: Consider introducing CSP violation reporting endpoints stricter CSP directives and automated browser security audits in future improvements
- reviewer callouts or codeowners you expect to review this: This is a defensive frontend security enhancement focused on improving browser-level protection and reducing exposure to common client-side attack vectors