### PR TITLE
a11y(navbar): improve logo alt text description

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -219,7 +219,7 @@ export default function Navbar() {
             <div className="flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-br from-gray-100 to-gray-200 border border-gray-200/50 shadow-sm shrink-0 overflow-hidden">
               <Image 
                 src={hushhLogo} 
-                alt="Hushh Logo" 
+                alt="Hushh Technologies - AI-Powered Investment Platform" 
                 className="w-7 h-7 object-contain"
               />
             </div>


### PR DESCRIPTION
## Summary

- what changed: Updated Navbar logo alt text from 'Hushh Logo' to 'Hushh Technologies - AI-Powered Investment Platform'
- why it changed: To improve accessibility for screen reader users by providing more descriptive context
- linked issue: none - standalone accessibility improvement for WCAG compliance
- acceptance criteria covered: WCAG 2.1 Level A Success Criterion 1.1.1 (Non-text Content)
- risk area touched: ui
- reviewer focus: Verify alt text is descriptive and appropriate for screen readers

## Validation

[x] commits are signed off with DCO ( git commit -s )
[x] npm run test
[x] npx tsc --noEmit
[x] npm run build:web
[x] npm run env:check
[x] npm run lint:ci
[x] relevant route or smoke checks
[ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: npm run test, npx tsc --noEmit, npm run build:web, npm run lint:ci, verified alt text in browser inspector
- did not run: none
- reviewer should verify: Alt text provides meaningful context for assistive technology users

## Notes

- deployment impact: None - frontend-only alt text change
- migration or env requirements: None
- rollback or release notes: None required
- follow-up work if any: Consider auditing other images for descriptive alt text
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/accessibility reviewers
