### PR TITLE
feat(consent): add granular consent preference center

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,6 +80,8 @@ import AuthRequiredRoute from './components/AuthRequiredRoute';
 import HushhHackathonPage from './pages/hushh-hackathon/ui';
 import MetricsPage from './pages/metrics';
 import NotFound from './pages/NotFound';
+import ConsentPreferenceCenter from './components/consent/ConsentPreferenceCenter';
+import ConsentPreferencesPage from './pages/consent-preferences';
 
 const KaiIndiaApp = React.lazy(() => import('./kai-india/pages'));
 
@@ -180,6 +182,7 @@ function App() {
             <Route path="/career" element={<Career />} />
             <Route path="/career/*" element={<Career />} />
             <Route path='/privacy-policy' element={<PrivacyPolicy />} />
+            <Route path='/consent-preferences' element={<ConsentPreferencesPage />} />
             <Route path='/carrer-privacy-policy' element={<CareersPrivacyPolicy />} />
             <Route path="/community" element={
               <CommunityPage />
@@ -406,6 +409,7 @@ function App() {
           <GlobalNDAGate>
             <AppLayout />
           </GlobalNDAGate>
+          <ConsentPreferenceCenter />
         </Router>
       </AuthSessionProvider>
     </ChakraProvider>

--- a/src/auth/routePolicy.ts
+++ b/src/auth/routePolicy.ts
@@ -14,6 +14,7 @@ export const PUBLIC_MARKETING_ROUTE_PREFIXES = [
   "/metric",
   "/metrics",
   "/privacy-policy",
+  "/consent-preferences",
   "/faq",
   "/carrer-privacy-policy",
   "/california-privacy-policy",

--- a/src/components/consent/ConsentPreferenceCenter.tsx
+++ b/src/components/consent/ConsentPreferenceCenter.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useMemo, useState } from "react";
+import { Check, Cookie, ShieldCheck, SlidersHorizontal, X } from "lucide-react";
+import {
+  acceptAllConsentPreferences,
+  ConsentCategory,
+  ConsentPreferences,
+  declineOptionalConsentPreferences,
+  getConsentPreferences,
+  hasStoredConsentPreferences,
+  saveConsentPreferences,
+} from "../../services/consent/preferences";
+
+type ConsentPreferenceCenterProps = {
+  mode?: "global" | "page";
+};
+
+type ConsentItem = {
+  id: ConsentCategory;
+  title: string;
+  description: string;
+  required?: boolean;
+};
+
+const CONSENT_ITEMS: ConsentItem[] = [
+  {
+    id: "necessary",
+    title: "Necessary",
+    description:
+      "Required for security, authentication, saved choices, and core site features.",
+    required: true,
+  },
+  {
+    id: "analytics",
+    title: "Analytics",
+    description:
+      "Helps us measure page views, feature usage, and site reliability without sending raw query values.",
+  },
+  {
+    id: "personalization",
+    title: "Personalization",
+    description:
+      "Allows remembered product preferences and a more tailored Hushh experience.",
+  },
+  {
+    id: "marketing",
+    title: "Marketing",
+    description:
+      "Allows campaign measurement and marketing improvements across Hushh surfaces.",
+  },
+];
+
+function PreferenceToggle({
+  item,
+  checked,
+  onChange,
+}: {
+  item: ConsentItem;
+  checked: boolean;
+  onChange: (category: ConsentCategory, value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 border-b border-gray-100 px-4 py-4 last:border-b-0">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-sm font-semibold text-gray-950">{item.title}</h3>
+          {item.required && (
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-normal text-gray-600">
+              Always on
+            </span>
+          )}
+        </div>
+        <p className="mt-1 text-sm leading-6 text-gray-600">{item.description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={`${item.title} consent`}
+        disabled={item.required}
+        onClick={() => onChange(item.id, !checked)}
+        className={`relative h-8 w-14 shrink-0 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-[#2B8CEE] focus:ring-offset-2 disabled:cursor-not-allowed ${
+          checked ? "bg-[#2B8CEE]" : "bg-gray-300"
+        }`}
+      >
+        <span
+          className={`absolute left-0 top-1 h-6 w-6 rounded-full bg-white shadow-sm transition-transform ${
+            checked ? "translate-x-7" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export default function ConsentPreferenceCenter({
+  mode = "global",
+}: ConsentPreferenceCenterProps) {
+  const [preferences, setPreferences] = useState<ConsentPreferences>(() =>
+    getConsentPreferences()
+  );
+  const [isBannerVisible, setIsBannerVisible] = useState(false);
+  const [isPanelOpen, setIsPanelOpen] = useState(mode === "page");
+
+  useEffect(() => {
+    if (mode === "global") {
+      setIsBannerVisible(!hasStoredConsentPreferences());
+    }
+  }, [mode]);
+
+  const enabledOptionalCount = useMemo(
+    () =>
+      CONSENT_ITEMS.filter((item) => !item.required && preferences[item.id])
+        .length,
+    [preferences]
+  );
+
+  const handleToggle = (category: ConsentCategory, value: boolean) => {
+    if (category === "necessary") {
+      return;
+    }
+
+    setPreferences((current) => ({
+      ...current,
+      [category]: value,
+      necessary: true,
+    }));
+  };
+
+  const handleSave = () => {
+    const saved = saveConsentPreferences(preferences);
+    setPreferences(saved);
+    setIsPanelOpen(false);
+    setIsBannerVisible(false);
+  };
+
+  const handleAcceptAll = () => {
+    const saved = acceptAllConsentPreferences();
+    setPreferences(saved);
+    setIsPanelOpen(false);
+    setIsBannerVisible(false);
+  };
+
+  const handleDeclineOptional = () => {
+    const saved = declineOptionalConsentPreferences();
+    setPreferences(saved);
+    setIsPanelOpen(false);
+    setIsBannerVisible(false);
+  };
+
+  const panel = (
+    <div
+      className={
+        mode === "page"
+          ? "mx-auto w-full max-w-3xl"
+          : "fixed inset-x-4 bottom-4 z-[120] mx-auto w-auto max-w-2xl"
+      }
+    >
+      <section
+        className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-2xl"
+        aria-label="Consent preference center"
+      >
+        <div className="flex items-start justify-between gap-4 border-b border-gray-100 px-5 py-5">
+          <div>
+            <div className="mb-3 inline-flex h-10 w-10 items-center justify-center rounded-full bg-[#2B8CEE]/10 text-[#2B8CEE]">
+              <SlidersHorizontal size={20} />
+            </div>
+            <h2 className="text-xl font-semibold text-gray-950">
+              Consent preference center
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-gray-600">
+              Choose how Hushh may use optional data on this device. Necessary
+              settings stay on so the site can work.
+            </p>
+          </div>
+          {mode === "global" && (
+            <button
+              type="button"
+              onClick={() => setIsPanelOpen(false)}
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-gray-500 hover:bg-gray-100"
+              aria-label="Close consent preferences"
+            >
+              <X size={18} />
+            </button>
+          )}
+        </div>
+
+        <div>
+          {CONSENT_ITEMS.map((item) => (
+            <PreferenceToggle
+              key={item.id}
+              item={item}
+              checked={preferences[item.id]}
+              onChange={handleToggle}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-gray-100 bg-gray-50 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-gray-600">
+            {enabledOptionalCount} of 3 optional categories enabled.
+          </p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <button
+              type="button"
+              onClick={handleDeclineOptional}
+              className="inline-flex min-h-11 items-center justify-center rounded-md border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-800 hover:bg-gray-100"
+            >
+              Decline optional
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-gray-950 px-4 text-sm font-semibold text-white hover:bg-gray-800"
+            >
+              <Check size={16} />
+              Save choices
+            </button>
+            <button
+              type="button"
+              onClick={handleAcceptAll}
+              className="inline-flex min-h-11 items-center justify-center rounded-md bg-[#2B8CEE] px-4 text-sm font-semibold text-white hover:bg-[#176fc5]"
+            >
+              Accept all
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+
+  if (mode === "page") {
+    return (
+      <main className="min-h-screen bg-white px-4 py-16 sm:px-6">
+        {panel}
+      </main>
+    );
+  }
+
+  return (
+    <>
+      {isBannerVisible && !isPanelOpen && (
+        <div className="fixed inset-x-4 bottom-4 z-[110] mx-auto max-w-4xl rounded-lg border border-gray-200 bg-white p-4 shadow-2xl">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="flex gap-3">
+              <div className="mt-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#2B8CEE]/10 text-[#2B8CEE]">
+                <Cookie size={20} />
+              </div>
+              <div>
+                <h2 className="text-base font-semibold text-gray-950">
+                  Manage your data choices
+                </h2>
+                <p className="mt-1 text-sm leading-6 text-gray-600">
+                  Hushh uses necessary storage for the site to work. You can
+                  choose optional analytics, personalization, and marketing.
+                </p>
+              </div>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => setIsPanelOpen(true)}
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-md border border-gray-300 bg-white px-4 text-sm font-semibold text-gray-800 hover:bg-gray-50"
+              >
+                <ShieldCheck size={16} />
+                Customize
+              </button>
+              <button
+                type="button"
+                onClick={handleDeclineOptional}
+                className="inline-flex min-h-11 items-center justify-center rounded-md bg-gray-100 px-4 text-sm font-semibold text-gray-800 hover:bg-gray-200"
+              >
+                Decline optional
+              </button>
+              <button
+                type="button"
+                onClick={handleAcceptAll}
+                className="inline-flex min-h-11 items-center justify-center rounded-md bg-[#2B8CEE] px-4 text-sm font-semibold text-white hover:bg-[#176fc5]"
+              >
+                Accept all
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {isPanelOpen && panel}
+    </>
+  );
+}

--- a/src/pages/consent-preferences/index.tsx
+++ b/src/pages/consent-preferences/index.tsx
@@ -1,0 +1,5 @@
+import ConsentPreferenceCenter from "../../components/consent/ConsentPreferenceCenter";
+
+export default function ConsentPreferencesPage() {
+  return <ConsentPreferenceCenter mode="page" />;
+}

--- a/src/services/analytics/googleAnalytics.ts
+++ b/src/services/analytics/googleAnalytics.ts
@@ -2,6 +2,10 @@ import {
   sanitizeAnalyticsPath,
   trackPageViewEvent,
 } from "./siteAnalytics";
+import {
+  hasConsentFor,
+  onConsentPreferencesChange,
+} from "../consent/preferences";
 
 const GOOGLE_ANALYTICS_TRACKING_ID = "G-R58S9WWPM0";
 const GOOGLE_ANALYTICS_SCRIPT_SRC = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ANALYTICS_TRACKING_ID}`;
@@ -10,6 +14,7 @@ const DUPLICATE_PAGE_VIEW_WINDOW_MS = 1000;
 let isAnalyticsConfigured = false;
 let lastTrackedPageKey = "";
 let lastTrackedAt = 0;
+let hasRegisteredConsentListener = false;
 
 function ensureGtagQueue() {
   window.dataLayer = window.dataLayer || [];
@@ -37,12 +42,63 @@ function ensureAnalyticsScript() {
   document.head.appendChild(script);
 }
 
+function removeAnalyticsScript() {
+  const existingScript = document.querySelector<HTMLScriptElement>(
+    `script[src="${GOOGLE_ANALYTICS_SCRIPT_SRC}"]`
+  );
+
+  existingScript?.remove();
+}
+
+function applyGoogleConsentMode() {
+  ensureGtagQueue();
+
+  window.gtag("consent", "update", {
+    ad_storage: hasConsentFor("marketing") ? "granted" : "denied",
+    analytics_storage: hasConsentFor("analytics") ? "granted" : "denied",
+    ad_user_data: hasConsentFor("marketing") ? "granted" : "denied",
+    ad_personalization: hasConsentFor("marketing") ? "granted" : "denied",
+  });
+}
+
+function registerConsentListener() {
+  if (hasRegisteredConsentListener) {
+    return;
+  }
+
+  onConsentPreferencesChange(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") {
+      return;
+    }
+
+    applyGoogleConsentMode();
+
+    if (!hasConsentFor("analytics")) {
+      removeAnalyticsScript();
+      isAnalyticsConfigured = false;
+      return;
+    }
+
+    initializeGoogleAnalytics();
+  });
+
+  hasRegisteredConsentListener = true;
+}
+
 export function initializeGoogleAnalytics() {
   if (typeof window === "undefined" || typeof document === "undefined") {
     return;
   }
 
+  registerConsentListener();
   ensureGtagQueue();
+  applyGoogleConsentMode();
+
+  if (!hasConsentFor("analytics")) {
+    removeAnalyticsScript();
+    return;
+  }
+
   ensureAnalyticsScript();
 
   if (isAnalyticsConfigured) {
@@ -59,6 +115,10 @@ export function initializeGoogleAnalytics() {
 
 export function trackPageView(pathname: string, search = "", hash = "") {
   if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  if (!hasConsentFor("analytics")) {
     return;
   }
 

--- a/src/services/analytics/siteAnalytics.ts
+++ b/src/services/analytics/siteAnalytics.ts
@@ -1,4 +1,5 @@
 import config from "../../resources/config/config";
+import { hasConsentFor } from "../consent/preferences";
 
 const ANALYTICS_ID_KEY = "hushh_site_analytics_id";
 const ANALYTICS_SESSION_KEY = "hushh_site_analytics_session_id";
@@ -242,6 +243,10 @@ function getQueryLengthBucket(query: string) {
 
 export async function trackSiteEvent(eventName: string, options: TrackEventOptions = {}) {
   if (typeof window === "undefined" || typeof navigator === "undefined") {
+    return;
+  }
+
+  if (!hasConsentFor("analytics")) {
     return;
   }
 

--- a/src/services/consent/preferences.ts
+++ b/src/services/consent/preferences.ts
@@ -1,0 +1,135 @@
+export type ConsentCategory =
+  | "necessary"
+  | "analytics"
+  | "personalization"
+  | "marketing";
+
+export type ConsentPreferences = Record<ConsentCategory, boolean>;
+
+export const CONSENT_STORAGE_KEY = "hushh_consent_preferences";
+export const CONSENT_VERSION = 1;
+
+const DEFAULT_PREFERENCES: ConsentPreferences = {
+  necessary: true,
+  analytics: false,
+  personalization: false,
+  marketing: false,
+};
+
+type StoredConsentPreferences = {
+  version: number;
+  updatedAt: string;
+  preferences: ConsentPreferences;
+};
+
+function canUseStorage() {
+  return typeof window !== "undefined" && Boolean(window.localStorage);
+}
+
+function normalizePreferences(
+  preferences: Partial<ConsentPreferences> | undefined
+): ConsentPreferences {
+  return {
+    ...DEFAULT_PREFERENCES,
+    ...(preferences || {}),
+    necessary: true,
+  };
+}
+
+function readStoredConsent(): StoredConsentPreferences | null {
+  if (!canUseStorage()) {
+    return null;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (!rawValue) {
+      return null;
+    }
+
+    const parsed = JSON.parse(rawValue) as Partial<StoredConsentPreferences>;
+    return {
+      version: parsed.version || CONSENT_VERSION,
+      updatedAt: parsed.updatedAt || new Date(0).toISOString(),
+      preferences: normalizePreferences(parsed.preferences),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function emitConsentChange(preferences: ConsentPreferences) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent("hushh:consent-preferences-changed", {
+      detail: preferences,
+    })
+  );
+}
+
+export function hasStoredConsentPreferences() {
+  return readStoredConsent() !== null;
+}
+
+export function getConsentPreferences(): ConsentPreferences {
+  return readStoredConsent()?.preferences || DEFAULT_PREFERENCES;
+}
+
+export function hasConsentFor(category: ConsentCategory) {
+  return getConsentPreferences()[category];
+}
+
+export function saveConsentPreferences(
+  preferences: Partial<ConsentPreferences>
+): ConsentPreferences {
+  const nextPreferences = normalizePreferences(preferences);
+
+  if (canUseStorage()) {
+    const payload: StoredConsentPreferences = {
+      version: CONSENT_VERSION,
+      updatedAt: new Date().toISOString(),
+      preferences: nextPreferences,
+    };
+
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, JSON.stringify(payload));
+  }
+
+  emitConsentChange(nextPreferences);
+  return nextPreferences;
+}
+
+export function acceptAllConsentPreferences() {
+  return saveConsentPreferences({
+    necessary: true,
+    analytics: true,
+    personalization: true,
+    marketing: true,
+  });
+}
+
+export function declineOptionalConsentPreferences() {
+  return saveConsentPreferences(DEFAULT_PREFERENCES);
+}
+
+export function onConsentPreferencesChange(
+  callback: (preferences: ConsentPreferences) => void
+) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handler = (event: Event) => {
+    callback(
+      (event as CustomEvent<ConsentPreferences>).detail ||
+        getConsentPreferences()
+    );
+  };
+
+  window.addEventListener("hushh:consent-preferences-changed", handler);
+  return () => {
+    window.removeEventListener("hushh:consent-preferences-changed", handler);
+  };
+}

--- a/tests/consentPreferences.test.ts
+++ b/tests/consentPreferences.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("consent preferences", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    window.localStorage.clear();
+  });
+
+  it("defaults optional categories off and keeps necessary consent enabled", async () => {
+    const consent = await import("../src/services/consent/preferences");
+
+    expect(consent.hasStoredConsentPreferences()).toBe(false);
+    expect(consent.getConsentPreferences()).toEqual({
+      necessary: true,
+      analytics: false,
+      personalization: false,
+      marketing: false,
+    });
+  });
+
+  it("persists granular choices and forces necessary consent on", async () => {
+    const consent = await import("../src/services/consent/preferences");
+    const listener = vi.fn();
+
+    const unsubscribe = consent.onConsentPreferencesChange(listener);
+    const saved = consent.saveConsentPreferences({
+      necessary: false,
+      analytics: true,
+      personalization: false,
+      marketing: true,
+    });
+
+    expect(saved).toMatchObject({
+      necessary: true,
+      analytics: true,
+      personalization: false,
+      marketing: true,
+    });
+    expect(consent.hasConsentFor("analytics")).toBe(true);
+    expect(consent.hasStoredConsentPreferences()).toBe(true);
+    expect(listener).toHaveBeenCalledWith(saved);
+
+    unsubscribe();
+  });
+});

--- a/tests/googleAnalytics.test.ts
+++ b/tests/googleAnalytics.test.ts
@@ -13,6 +13,7 @@ describe("google analytics client tracking", () => {
   beforeEach(() => {
     vi.resetModules();
     document.head.innerHTML = "";
+    window.localStorage.clear();
     window.dataLayer = [];
     window.gtag = undefined as unknown as Window["gtag"];
     document.title = "Metrics";
@@ -25,6 +26,8 @@ describe("google analytics client tracking", () => {
   });
 
   it("initializes GA only once and disables automatic page views", async () => {
+    const consent = await import("../src/services/consent/preferences");
+    consent.acceptAllConsentPreferences();
     const analytics = await import("../src/services/analytics/googleAnalytics");
 
     analytics.initializeGoogleAnalytics();
@@ -35,13 +38,27 @@ describe("google analytics client tracking", () => {
     );
 
     expect(scripts).toHaveLength(1);
-    expect(window.dataLayer).toEqual([
-      ["js", expect.any(Date)],
-      ["config", "G-R58S9WWPM0", { send_page_view: false }],
+    expect(window.dataLayer).toContainEqual([
+      "consent",
+      "update",
+      {
+        ad_storage: "granted",
+        analytics_storage: "granted",
+        ad_user_data: "granted",
+        ad_personalization: "granted",
+      },
+    ]);
+    expect(window.dataLayer).toContainEqual(["js", expect.any(Date)]);
+    expect(window.dataLayer).toContainEqual([
+      "config",
+      "G-R58S9WWPM0",
+      { send_page_view: false },
     ]);
   });
 
   it("tracks page views without duplicating the same route immediately", async () => {
+    const consent = await import("../src/services/consent/preferences");
+    consent.acceptAllConsentPreferences();
     const analytics = await import("../src/services/analytics/googleAnalytics");
 
     analytics.trackPageView("/metrics", "?view=public");
@@ -62,5 +79,24 @@ describe("google analytics client tracking", () => {
       "?view=public",
       ""
     );
+  });
+
+  it("does not load GA or track page views before analytics consent", async () => {
+    const analytics = await import("../src/services/analytics/googleAnalytics");
+
+    analytics.initializeGoogleAnalytics();
+    analytics.trackPageView("/metrics");
+
+    expect(
+      document.head.querySelectorAll(
+        'script[src="https://www.googletagmanager.com/gtag/js?id=G-R58S9WWPM0"]'
+      )
+    ).toHaveLength(0);
+    expect(
+      window.dataLayer.filter(
+        (entry) => entry[0] === "event" && entry[1] === "page_view"
+      )
+    ).toHaveLength(0);
+    expect(trackPageViewEvent).not.toHaveBeenCalled();
   });
 });

--- a/tests/siteAnalytics.test.ts
+++ b/tests/siteAnalytics.test.ts
@@ -45,6 +45,8 @@ describe("site analytics client", () => {
   });
 
   it("does not forward raw UTM query values", async () => {
+    const consent = await import("../src/services/consent/preferences");
+    consent.acceptAllConsentPreferences();
     const { trackSiteEvent } = await import("../src/services/analytics/siteAnalytics");
 
     await trackSiteEvent("page_view");
@@ -56,5 +58,13 @@ describe("site analytics client", () => {
     expect(body.events[0].routePath).toBe("/profile/:id");
     expect(serialized).not.toContain("person@example.com");
     expect(serialized).not.toContain("token-secret");
+  });
+
+  it("does not collect first-party analytics before analytics consent", async () => {
+    const { trackSiteEvent } = await import("../src/services/analytics/siteAnalytics");
+
+    await trackSiteEvent("page_view");
+
+    expect(fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

## Summary

- what changed: Added a granular consent preference center allowing users to manage individual consent categories for analytics marketing and functional integrations
- why it changed: Improves privacy transparency and user control by enabling selective consent management instead of relying on a single global consent action
- linked issue: none - standalone privacy and consent management enhancement focused on improving user-controlled preference handling
- acceptance criteria covered: Users can manage consent categories independently consent preferences persist correctly existing application rendering and consent flows remain stable
- risk area touched: security | ui
- reviewer focus: Confirm consent categories can be toggled independently verify consent persistence behaves correctly ensure analytics and third-party integrations respect updated preferences

## Validation

- [x] Verified consent preference center renders correctly
- [x] Verified individual consent categories update independently
- [x] Verified consent preferences persist across refreshes
- [x] Verified blocked integrations remain disabled without consent
- [x] No runtime rendering or interaction errors introduced

- ran: Manual consent flow testing preference persistence verification local rendering validation code review for conditional integration handling and consent state management
- did not run: Automated privacy compliance testing and third-party integration validation can be added in a follow-up PR if maintainers request expanded coverage
- reviewer should verify: Toggle consent categories individually confirm integrations respond correctly to preference changes verify consent persistence and UI behavior remain consistent after refreshes and navigation

## Notes

- deployment impact: Low risk frontend privacy enhancement no backend or API changes purely client-side consent preference management improvements
- migration or env requirements: None required no environment variables or infrastructure changes
- rollback or release notes: Safe to rollback if needed restores previous consent handling behavior without affecting application state
- follow-up work if any: Consider adding consent audit history preference export functionality and category-level analytics reporting in future improvements
- reviewer callouts or codeowners you expect to review this: This is a frontend privacy enhancement focused on improving granular consent management transparency and user-controlled integration behavior
