### PR TITLE
fix(onboarding): harden GPS address normalization

### DIFF
--- a/src/services/location/addressNormalization.js
+++ b/src/services/location/addressNormalization.js
@@ -57,6 +57,17 @@ const isStatePostalSegment = (segment, { state, stateCode, zipCode }) => {
 const buildCityStateLine2 = (city, state) =>
   [cleanString(city), cleanString(state)].filter(Boolean).join(', ');
 
+const looksLikeStateCode = (value) => /^[A-Z]{2,3}$/.test(cleanString(value));
+
+const removeKnownLocationTokens = (segment, { city, state, stateCode, zipCode }) => {
+  let working = cleanString(segment);
+  [zipCode, state, stateCode, city].forEach((candidate) => {
+    working = stripCandidate(working, candidate);
+  });
+
+  return normalizeSpacing(working.replace(/-/g, ' '));
+};
+
 const inferPostalCodeFromSegment = (segment, { state, stateCode }) => {
   const normalized = normalizeSpacing(
     stripCandidate(stripCandidate(segment, state), stateCode)
@@ -75,6 +86,20 @@ const inferPostalCodeFromSegment = (segment, { state, stateCode }) => {
   return POSTAL_CODE_PATTERN.test(last) ? last : '';
 };
 
+const inferCityFromTerminalSegment = (segment, { state, stateCode, zipCode }) => {
+  let working = cleanString(segment);
+  if (!working) return '';
+
+  if (zipCode) {
+    working = working.replace(new RegExp(`\\b${escapeRegExp(zipCode)}\\b`, 'gi'), ' ');
+  }
+
+  working = normalizeSpacing(stripCandidate(stripCandidate(working, state), stateCode));
+  if (looksLikeStateCode(working)) return '';
+
+  return POSTAL_CODE_PATTERN.test(working) ? '' : working;
+};
+
 const inferStateFromSegment = (segment, { zipCode, stateCode }) => {
   let working = cleanString(segment);
   if (!working) return cleanString(stateCode);
@@ -86,6 +111,11 @@ const inferStateFromSegment = (segment, { zipCode, stateCode }) => {
 
   working = normalizeSpacing(stripCandidate(working, stateCode));
   return working || cleanString(stateCode);
+};
+
+const isCityStatePostalSegment = (segment, { city, state, stateCode, zipCode }) => {
+  const working = removeKnownLocationTokens(segment, { city, state, stateCode, zipCode });
+  return working.length === 0 || POSTAL_CODE_PATTERN.test(working);
 };
 
 export function normalizeDetectedAddress(locationData, countryNameOverride = '') {
@@ -104,14 +134,29 @@ export function normalizeDetectedAddress(locationData, countryNameOverride = '')
 
   const statePostalSegment = segments[segments.length - 1] || '';
   const zipCode = gpsZipCode || inferPostalCodeFromSegment(statePostalSegment, { state: gpsState, stateCode });
-  const state = gpsState || inferStateFromSegment(statePostalSegment, { zipCode, stateCode });
-  const city = gpsCity || (segments.length > 1 ? segments[segments.length - 2] : '');
+  const inferredTerminalCity = inferCityFromTerminalSegment(statePostalSegment, {
+    state: gpsState,
+    stateCode,
+    zipCode,
+  });
+  const city = gpsCity || inferredTerminalCity || (segments.length > 1 ? segments[segments.length - 2] : '');
+  const state = gpsState || (
+    inferredTerminalCity && normalizeComparable(inferredTerminalCity) === normalizeComparable(city)
+      ? cleanString(stateCode)
+      : inferStateFromSegment(statePostalSegment, { zipCode, stateCode })
+  );
 
-  if (segments.length && isStatePostalSegment(segments[segments.length - 1], { state, stateCode, zipCode })) {
+  if (
+    segments.length &&
+    (
+      isStatePostalSegment(segments[segments.length - 1], { state, stateCode, zipCode }) ||
+      isCityStatePostalSegment(segments[segments.length - 1], { city, state, stateCode, zipCode })
+    )
+  ) {
     segments.pop();
   }
 
-  if (segments.length && matchesSegment(segments[segments.length - 1], [city])) {
+  while (segments.length && matchesSegment(segments[segments.length - 1], [city])) {
     segments.pop();
   }
 

--- a/tests/addressNormalization.test.ts
+++ b/tests/addressNormalization.test.ts
@@ -34,6 +34,20 @@ const seattleAddress = {
   longitude: -122.3378,
 } satisfies LocationData;
 
+const londonAddress = {
+  country: 'United Kingdom',
+  countryCode: 'GB',
+  state: 'Greater London',
+  stateCode: '',
+  city: 'London',
+  postalCode: 'SW1A 2AA',
+  phoneDialCode: '+44',
+  timezone: 'Europe/London',
+  formattedAddress: '10 Downing Street, Westminster, London SW1A 2AA, United Kingdom',
+  latitude: 51.5034,
+  longitude: -0.1276,
+} satisfies LocationData;
+
 describe('address normalization', () => {
   it('keeps the full street/building/locality prefix in address line 1', () => {
     const normalized = normalizeDetectedAddress(mahalungeAddress, 'India');
@@ -54,6 +68,70 @@ describe('address normalization', () => {
     expect(normalized.city).toBe('Seattle');
     expect(normalized.state).toBe('Washington');
     expect(normalized.zipCode).toBe('98109');
+  });
+
+  it('keeps UK city and postcode segments out of address line 1', () => {
+    const normalized = normalizeDetectedAddress(londonAddress, 'United Kingdom');
+
+    expect(normalized.addressLine1).toBe('10 Downing Street, Westminster');
+    expect(normalized.addressLine2).toBe('London, Greater London');
+    expect(normalized.city).toBe('London');
+    expect(normalized.state).toBe('Greater London');
+    expect(normalized.zipCode).toBe('SW1A 2AA');
+  });
+
+  it('accepts US state abbreviations while returning the full GPS state name', () => {
+    const normalized = normalizeDetectedAddress({
+      country: 'United States',
+      countryCode: 'US',
+      state: 'California',
+      stateCode: 'CA',
+      city: 'San Francisco',
+      postalCode: '94105',
+      phoneDialCode: '+1',
+      timezone: 'America/Los_Angeles',
+      formattedAddress: '1 Market St, San Francisco, CA 94105, United States',
+      latitude: 37.7936,
+      longitude: -122.3958,
+    }, 'United States');
+
+    expect(normalized.addressLine1).toBe('1 Market St');
+    expect(normalized.addressLine2).toBe('San Francisco, California');
+    expect(normalized.city).toBe('San Francisco');
+    expect(normalized.state).toBe('California');
+    expect(normalized.zipCode).toBe('94105');
+  });
+
+  it('does not infer a state abbreviation as the city when GPS locality data is incomplete', () => {
+    const normalized = normalizeDetectedAddress({
+      country: 'United States',
+      countryCode: 'US',
+      state: '',
+      stateCode: '',
+      city: '',
+      postalCode: '12345',
+      phoneDialCode: '+1',
+      timezone: 'America/New_York',
+      formattedAddress: '123 Main St, Anytown, ST 12345, United States',
+      latitude: 40.7128,
+      longitude: -74.006,
+    }, 'United States');
+
+    expect(normalized.addressLine1).toBe('123 Main St');
+    expect(normalized.addressLine2).toBe('Anytown, ST');
+    expect(normalized.city).toBe('Anytown');
+    expect(normalized.state).toBe('ST');
+    expect(normalized.zipCode).toBe('12345');
+  });
+
+  it('removes repeated trailing city segments without dropping street locality', () => {
+    const normalized = normalizeDetectedAddress({
+      ...seattleAddress,
+      formattedAddress: '500 Terry Ave N, Seattle, Seattle, Washington 98109, United States',
+    }, 'United States');
+
+    expect(normalized.addressLine1).toBe('500 Terry Ave N');
+    expect(normalized.addressLine2).toBe('Seattle, Washington');
   });
 
   it('falls back to the formatted GPS address when the structured city is missing', () => {
@@ -104,5 +182,21 @@ describe('address normalization', () => {
       zip_code: '411045',
       address_country: 'India',
     });
+  });
+
+  it('does not build a repair patch when GPS columns have no usable address evidence', () => {
+    expect(buildOnboardingAddressRepairPatch({
+      address_line_1: 'Saved manual address',
+      address_line_2: 'Suite 2',
+      city: 'Seattle',
+      state: 'Washington',
+      zip_code: '98109',
+      address_country: 'United States',
+      gps_full_address: '',
+      gps_city: '',
+      gps_state: '',
+      gps_country: '',
+      gps_zip_code: '',
+    })).toBeNull();
   });
 });

--- a/tests/step3AddressLogic.test.ts
+++ b/tests/step3AddressLogic.test.ts
@@ -56,6 +56,20 @@ const seattleGpsAddress = {
   longitude: -122.3378,
 } satisfies LocationData;
 
+const londonGpsAddress = {
+  country: 'United Kingdom',
+  countryCode: 'GB',
+  state: 'Greater London',
+  stateCode: '',
+  city: 'London',
+  postalCode: 'SW1A 2AA',
+  phoneDialCode: '+44',
+  timezone: 'Europe/London',
+  formattedAddress: '10 Downing Street, Westminster, London SW1A 2AA, United Kingdom',
+  latitude: 51.5034,
+  longitude: -0.1276,
+} satisfies LocationData;
+
 describe('step 3 address logic', () => {
   it('auto-fills the full normalized address instead of collapsing line 1 to the first token', () => {
     const patch = buildStep3AutofillPatch({
@@ -92,6 +106,25 @@ describe('step 3 address logic', () => {
       city: 'Seattle',
       state: 'Washington',
       addressCountry: 'United States',
+    });
+  });
+
+  it('auto-fills UK city and postcode formats without polluting address line 1', () => {
+    const patch = buildStep3AutofillPatch({
+      current: emptyFormState,
+      manual: noManualOverrides,
+      locationData: londonGpsAddress,
+    });
+
+    expect(patch).toMatchObject({
+      citizenshipCountry: 'United Kingdom',
+      residenceCountry: 'United Kingdom',
+      addressLine1: '10 Downing Street, Westminster',
+      addressLine2: 'London, Greater London',
+      zipCode: 'SW1A 2AA',
+      city: 'London',
+      state: 'Greater London',
+      addressCountry: 'United Kingdom',
     });
   });
 


### PR DESCRIPTION
## Summary
- What changed: Hardened onboarding GPS address normalization for UK city/postcode segments, US state abbreviations, and repeated trailing city segments.
- Why it changed: Some international formatted addresses could leave city/postcode text in address line 1, which pollutes saved onboarding address fields.
- Linked issue: none - proactive regression hardening for onboarding address autofill.
- Acceptance criteria covered: Address line 1 keeps street/locality prefixes while city, state, and postcode resolve into structured onboarding fields.
- Risk area touched: ui, data
- Reviewer focus: Verify the new parser cases still preserve manual onboarding address edits and existing India/US behavior.

## Validation
- [x] npm.cmd test -- addressNormalization step3AddressLogic
- [x] npx.cmd tsc --noEmit
- [x] npm.cmd test
- [x] npm.cmd run build:web
- Ran: Targeted Vitest regressions, TypeScript typecheck, full Vitest suite, and Vite production build.
- Did not run: none - all relevant local checks for this frontend parsing change were covered.
- Reviewer should verify: Confirm PR Validation reports DCO and PR Hygiene green on the fork pull request.

## Notes
- Deployment impact: No migration, env, route registration, or deploy workflow changes; this is a frontend service parsing change with test coverage.