### PR TITLE
feat: add back to top scroll button component (#1071)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,8 +77,8 @@ import DocumentViewerPage from './pages/document-viewer';
 import NDAAdminPage from './pages/nda-admin';
 import { AuthSessionProvider, useAuthSession } from './auth/AuthSessionProvider';
 import AuthRequiredRoute from './components/AuthRequiredRoute';
-import HushhHackathonPage from './pages/hushh-hackathon/ui';
 import MetricsPage from './pages/metrics';
+import BackToTop from './components/BackToTop'
 import NotFound from './pages/NotFound';
 
 const KaiIndiaApp = React.lazy(() => import('./kai-india/pages'));
@@ -402,6 +402,7 @@ function App() {
         <Router>
           <GoogleAnalyticsRouteTracker />
           <ScrollToTop />
+          <BackToTop />
           <OnboardingShellAutoPadding />
           <GlobalNDAGate>
             <AppLayout />

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react'
+
+const BackToTop: React.FC = () => {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300)
+    }
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  if (!visible) return null
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      className="fixed bottom-8 right-8 z-50 bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg transition-all duration-300"
+    >
+      ↑
+    </button>
+  )
+}
+
+export default BackToTop


### PR DESCRIPTION
Closes #1070

## Summary
- what changed: Added a reusable BackToTop component at src/components/BackToTop.tsx
- why it changed: Users on long pages had no way to scroll back to top
- risk area touched: `ui`

## Validation
- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [x] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed

## Notes
- deployment impact: none
- migration or env requirements: none
- follow-up work if any: can be used across all long pages
- reviewer callouts or CODEOWNERS you expect to review this: ankitkumarsingh1702