### PR TITLE
chore(footer): use standard Tailwind sizing for social icons

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -183,19 +183,19 @@ export default function Footer() {
             rel="noopener noreferrer" 
             className="w-10 h-10 rounded-full bg-[#1F2937] flex items-center justify-center hover:bg-[#135bec] transition-colors group"
           >
-            <FaGlobe className="text-gray-400 group-hover:text-white text-[16px]" />
+            <FaGlobe className="text-gray-400 group-hover:text-white text-base" />
           </a>
           <a 
             href="mailto:support@hushh.ai" 
             className="w-10 h-10 rounded-full bg-[#1F2937] flex items-center justify-center hover:bg-[#135bec] transition-colors group"
           >
-            <FaAt className="text-gray-400 group-hover:text-white text-[16px]" />
+            <FaAt className="text-gray-400 group-hover:text-white text-base" />
           </a>
           <a 
             href="/community" 
             className="w-10 h-10 rounded-full bg-[#1F2937] flex items-center justify-center hover:bg-[#135bec] transition-colors group"
           >
-            <FaRss className="text-gray-400 group-hover:text-white text-[16px]" />
+            <FaRss className="text-gray-400 group-hover:text-white text-base" />
           </a>
         </div>
 


### PR DESCRIPTION
## Summary

- what changed: Replaced arbitrary text-[16px] with standard text-base class for social media icons
- why it changed: To improve code consistency by using Tailwind's standard sizing scale instead of arbitrary pixel values
- linked issue: none - standalone code quality improvement for Tailwind best practices
- acceptance criteria covered: Social icons use standard Tailwind sizing classes while maintaining identical visual output
- risk area touched: ui
- reviewer focus: Verify social icons render identically (both text-[16px] and text-base are 16px)

## Validation

- [x] commits are signed off with DCO ( git commit -s )
- [x] npm run test
- [x] npx tsc --noEmit
- [x] npm run build:web
- [x] npm run env:check
- [x] npm run lint:ci
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: npm run test, npx tsc --noEmit, npm run build:web, npm run lint:ci, verified icons render identically in browser
- did not run: none
- reviewer should verify: Social media icons in footer render with same size and appearance

## Notes

- deployment impact: None - pure CSS class swap with identical visual output
- migration or env requirements: None
- rollback or release notes: None required
- follow-up work if any: Consider auditing other components for arbitrary Tailwind values
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI reviewers
