### PR TITLE
fix(navbar): improve ticker timestamp visibility

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -326,7 +326,7 @@ export default function Navbar() {
           {lastUpdated && (
             <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-1.5">
               <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse"></span>
-              <span className="text-[9px] font-medium text-gray-500">
+              <span className="text-[9px] font-medium text-gray-700">
                 {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
               </span>
             </div>


### PR DESCRIPTION
## Summary

- what changed: Changed ticker timestamp color from text-gray-500 to text-gray-700
- why it changed: To improve readability and contrast on the light background - the timestamp was too faint to read comfortably
- linked issue: none - standalone UI visibility improvement
- acceptance criteria covered: Ticker timestamp is now clearly visible with better contrast
- risk area touched: ui
- reviewer focus: Verify timestamp is more visible in the navbar ticker section

## Validation

- [x] commits are signed off with DCO ( git commit -s )
- [x] npm run test
- [x] npx tsc --noEmit
- [x] npm run build:web
- [x] npm run env:check
- [x] npm run lint:ci
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: npm run test, npx tsc --noEmit, npm run build:web, npm run lint:ci, verified timestamp visibility in browser
- did not run: Security checks not applicable for CSS-only color change
- reviewer should verify: Ticker timestamp in navbar is more readable with darker text color

## Notes

- deployment impact: None - CSS color change only
- migration or env requirements: None
- rollback or release notes: None required
- follow-up work if any: None
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI reviewers
