### PR TITLE
fix(hero): make max-width responsive for larger screens

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -259,7 +259,7 @@ export default function Hero() {
       {/* Scrollable content */}
       <Box
         as="main"
-        maxW="393px"
+        maxW={{ base: "393px", md: "768px", lg: "1024px" }}
         mx="auto"
         pb="120px"
         pt="50px"
@@ -527,7 +527,7 @@ export default function Hero() {
         borderTop="0.5px solid rgba(0,0,0,0.1)"
         pb="28px" pt={2} px={6} zIndex={40}
       >
-        <Flex justify="space-between" align="center" maxW="393px" mx="auto">
+        <Flex justify="space-between" align="center" maxW={{ base: "393px", md: "768px", lg: "1024px" }} mx="auto">
           <TabItem icon="home" label="Home" active />
           <Box onClick={() => navigate("/hushh-user-profile")} cursor="pointer">
             <TabItem icon="pie_chart" label="Portfolio" />


### PR DESCRIPTION
## Summary

- what changed: Replaced fixed 393px max-width with responsive breakpoints in Hero component
- why it changed: To properly utilize screen space on tablet and desktop devices instead of staying narrow
- linked issue: none - standalone responsive improvement
- acceptance criteria covered: Hero component now uses 393px (mobile), 768px (tablet), 1024px (desktop) max-widths
- risk area touched: ui
- reviewer focus: Verify Hero component expands properly on larger screens while maintaining mobile layout

## Validation

- [x] commits are signed off with DCO ( git commit -s )
- [x] npm run test
- [x] npx tsc --noEmit
- [x] npm run build:web
- [x] npm run env:check
- [x] npm run lint:ci
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: npm run test, npx tsc --noEmit, npm run build:web, npm run lint:ci, verified responsive behavior in browser
- did not run: Security checks not applicable for CSS-only responsive change
- reviewer should verify: Hero component properly expands on tablet and desktop screens

## Notes

- deployment impact: None - CSS responsive breakpoints only
- migration or env requirements: None
- rollback or release notes: None required
- follow-up work if any: None
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI reviewers
