### PR TITLE
a11y(error-boundary): add aria-label to refresh button

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -65,6 +65,7 @@ class ErrorBoundary extends Component<Props, State> {
             <button
               onClick={() => window.location.reload()}
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              aria-label="Refresh page to recover from error"
             >
               Refresh Page
             </button>


### PR DESCRIPTION
## Summary

- what changed:
- why it changed:
- linked issue: `#123` | `none - reason`
- acceptance criteria covered:
- risk area touched: `ui` | `api` | `auth` | `deploy` | `security` | `docs` | `data` | `infra` | `ci`
- reviewer focus:

## Validation

- [ ] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [ ] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran:
- did not run:
- reviewer should verify:

## Notes

- deployment impact:
- migration or env requirements:
- rollback or release notes:
- follow-up work if any:
- reviewer callouts or CODEOWNERS you expect to review this:
