### PR TITLE
fix(a11y): improve escape-key handling for dropdown menus

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -63,6 +63,7 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant = 'light' }
 
     const handleDocumentKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape') return;
+      if (!dropdownRef.current?.contains(document.activeElement)) return;
 
       event.preventDefault();
       closeDropdown(true);

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -58,6 +58,22 @@ const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ variant = 'light' }
     optionRefs.current[activeIndex]?.focus();
   }, [activeIndex, isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+
+      event.preventDefault();
+      closeDropdown(true);
+    };
+
+    document.addEventListener('keydown', handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleDocumentKeyDown);
+    };
+  }, [closeDropdown, isOpen]);
+
   const changeLanguage = React.useCallback((langCode: string) => {
     i18n.changeLanguage(langCode);
     

--- a/tests/languageSwitcherKeyboard.test.ts
+++ b/tests/languageSwitcherKeyboard.test.ts
@@ -131,4 +131,24 @@ describe("LanguageSwitcher keyboard accessibility", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
     expect(document.activeElement).toBe(trigger);
   });
+
+  it("closes with document-level Escape when the menu is open", async () => {
+    const trigger = await renderSwitcher();
+
+    trigger.focus();
+    await keyDown(trigger, "ArrowDown");
+
+    expect(container.querySelector("[role='menu']")).not.toBeNull();
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(i18nMock.changeLanguage).not.toHaveBeenCalled();
+    expect(container.querySelector("[role='menu']")).toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(trigger);
+  });
 });

--- a/tests/languageSwitcherKeyboard.test.ts
+++ b/tests/languageSwitcherKeyboard.test.ts
@@ -151,4 +151,26 @@ describe("LanguageSwitcher keyboard accessibility", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
     expect(document.activeElement).toBe(trigger);
   });
+
+  it("keeps the menu open when Escape belongs to another focused component", async () => {
+    const trigger = await renderSwitcher();
+    const modalButton = document.createElement("button");
+    document.body.appendChild(modalButton);
+
+    trigger.focus();
+    await keyDown(trigger, "ArrowDown");
+    modalButton.focus();
+
+    await act(async () => {
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(container.querySelector("[role='menu']")).not.toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(document.activeElement).toBe(modalButton);
+
+    modalButton.remove();
+  });
 });


### PR DESCRIPTION
## Summary

- what changed: Improved escape-key handling behavior for targeted dropdown menu interactions by ensuring dropdowns close predictably and restore focus appropriately during keyboard navigation
- why it changed: Enhances accessibility and keyboard usability by providing more consistent and expected escape-key interaction behavior for dropdown-based UI controls
- linked issue: none - standalone accessibility enhancement focused on improving keyboard interaction semantics and dropdown usability
- acceptance criteria covered: Dropdown menus close correctly on escape focus returns predictably to triggering controls keyboard navigation behavior remains consistent existing UI interactions remain visually unchanged
- risk area touched: ui
- reviewer focus: Confirm dropdowns close correctly when pressing escape verify focus restoration behaves consistently ensure no interaction or keyboard navigation regressions were introduced

## Validation

- [x] Verified dropdown menus close correctly on escape-key interaction
- [x] Verified focus restoration returns users to the triggering control
- [x] Verified keyboard navigation remains functional and predictable
- [x] Verified existing dropdown interactions continue functioning normally
- [x] No runtime rendering or interaction errors introduced

- ran: Manual keyboard navigation testing focus traversal verification local rendering validation code review for dropdown interaction and focus restoration behavior
- did not run: Automated accessibility integration testing and assistive technology validation can be added in a follow-up PR if maintainers request expanded accessibility coverage
- reviewer should verify: Open dropdown menus using keyboard only press escape to close verify focus restoration behaves correctly and confirm existing dropdown interactions remain visually unchanged

## Notes

- deployment impact: Low risk frontend accessibility enhancement no backend or API changes purely keyboard interaction and dropdown usability improvements
- migration or env requirements: None required no environment variables or infrastructure changes
- rollback or release notes: Safe to rollback if needed restores previous dropdown escape-key behavior without affecting application functionality
- follow-up work if any: Consider introducing shared keyboard interaction utilities and automated accessibility regression testing for dropdown and overlay interactions in future improvements
- reviewer callouts or codeowners you expect to review this: This is a frontend accessibility enhancement focused on improving keyboard usability focus predictability and assistive technology interaction quality for dropdown menus