### PR TITLE
fix(ui): updated discover-fund-a page ui 

### DIFF
--- a/src/pages/discover-fund-a/ui.tsx
+++ b/src/pages/discover-fund-a/ui.tsx
@@ -418,7 +418,7 @@ const FundA = () => {
                   </p>
                   <div className="w-full h-2.5 rounded-full bg-gray-200/80 overflow-hidden mb-2 shadow-inner">
                     <div
-                      className="relative h-full rounded-full bg-gradient-to-r from-hushh-blue to-[#4f8dff] transition-all duration-700"
+                      className="relative h-full rounded-full bg-gradient-to-r from-hushh-blue to-hushh-blue/70 transition-all duration-700"
                       style={{ width: `${getProgressWidth(row.value)}%` }}
                     >
                       <span className="absolute inset-0 opacity-60 bg-[linear-gradient(110deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.55)_45%,rgba(255,255,255,0)_70%)] animate-[pulse_2.4s_ease-in-out_infinite]" />
@@ -591,7 +591,9 @@ const FundA = () => {
       </main>
 
       {/* ═══ Footer Nav ═══ */}
-      <HushhTechFooter activeTab={HushhFooterTab.FUND_A} />
+      <div className="lg:hidden">
+        <HushhTechFooter activeTab={HushhFooterTab.FUND_A} />
+      </div>
     </div>
   );
 };

--- a/src/pages/discover-fund-a/ui.tsx
+++ b/src/pages/discover-fund-a/ui.tsx
@@ -1,3 +1,11 @@
+/**
+ * Fund A — Discover Page (Revamped 3.0)
+ * Pixel-perfect alignment with hushh-user-profile + step 1-8 design.
+ * Uses same wrapper, header, CTA, FieldRow, SectionLabel patterns.
+ * All content from logic.ts — zero data here.
+ *
+ * Changes from original: Apple iOS colors, capitalization, hero subheading.
+ */
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useDiscoverFundALogic } from "./logic";
@@ -9,6 +17,7 @@ import HushhTechFooter, {
   HushhFooterTab,
 } from "../../components/hushh-tech-footer/HushhTechFooter";
 
+/* ── settings-style row (same as profile page) ── */
 const FieldRow = ({
   label,
   children,
@@ -16,18 +25,20 @@ const FieldRow = ({
   label: string;
   children: React.ReactNode;
 }) => (
-  <div className="group flex items-center justify-between gap-4 border-b border-gray-200 py-4 hover:bg-gray-50/50 transition-colors -mx-4 px-4 sm:-mx-6 sm:px-6 lg:mx-0 lg:px-0">
+  <div className="group flex items-center justify-between border-b border-gray-200 py-4 hover:bg-gray-50/50 transition-colors -mx-6 px-6">
     <span className="text-sm text-gray-500 font-light">{label}</span>
     <div className="flex items-center gap-2 text-right">{children}</div>
   </div>
 );
 
+/* ── section label (same as profile page) ── */
 const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-  <h2 className="text-[10px] uppercase tracking-[0.2em] text-gray-400 font-medium mb-2">
+  <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 font-medium mt-10 mb-2">
     {children}
-  </h2>
+  </p>
 );
 
+/* ── card with icon (same as step-2 cards) ── */
 const FeatureCard = ({
   icon,
   title,
@@ -39,7 +50,7 @@ const FeatureCard = ({
   description: string;
   iconColor?: string;
 }) => (
-  <div className="h-full flex items-start gap-4 border border-gray-200 rounded-2xl p-5 hover:border-gray-300 hover:bg-gray-50/50 transition-all">
+  <div className="flex items-start gap-4 border border-gray-200 rounded-2xl p-5 hover:border-gray-300 hover:bg-gray-50/50 transition-all">
     <div className="w-11 h-11 rounded-full border border-gray-200 flex items-center justify-center shrink-0 bg-white">
       <span className={`material-symbols-outlined ${iconColor} !text-[1.15rem]`}>
         {icon}
@@ -56,13 +67,42 @@ const FeatureCard = ({
   </div>
 );
 
+/* ── desktop highlight tile (same spirit as home advantage) ── */
+const FeatureHighlightTile = ({
+  icon,
+  title,
+  description,
+  iconColor = "text-gray-700",
+}: {
+  icon: string;
+  title: string;
+  description: string;
+  iconColor?: string;
+}) => (
+  <div className="flex flex-col items-center text-center gap-3 border border-gray-200/70 rounded-2xl p-5 bg-white hover:border-gray-300 hover:bg-gray-50/40 transition-all">
+    <div className="w-12 h-12 rounded-full border border-gray-200/70 flex items-center justify-center bg-gray-50">
+      <span className={`material-symbols-outlined ${iconColor} !text-[1.15rem]`}>
+        {icon}
+      </span>
+    </div>
+    <div>
+      <h3 className="text-[13px] font-semibold text-black leading-snug mb-1">
+        {title}
+      </h3>
+      <p className="text-[11px] text-gray-500 font-light leading-relaxed">
+        {description}
+      </p>
+    </div>
+  </div>
+);
+
+/* ── icon + color maps for cards ── */
 const PHILOSOPHY_ICONS: Record<string, string> = {
   "Options Intelligence": "psychology",
   "AI-Enhanced Research": "neurology",
   "Risk-First Architecture": "shield",
   "Concentrated Conviction": "target",
 };
-
 const PHILOSOPHY_COLORS: Record<string, string> = {
   "Options Intelligence": "text-hushh-blue",
   "AI-Enhanced Research": "text-hushh-blue",
@@ -76,7 +116,6 @@ const EDGE_ICONS: Record<string, string> = {
   "Income Generation": "payments",
   "Downside Protection": "security",
 };
-
 const EDGE_COLORS: Record<string, string> = {
   "Volatility Harvesting": "text-hushh-blue",
   "Asymmetric Returns": "text-hushh-blue",
@@ -89,7 +128,6 @@ const ASSET_ICONS: Record<string, string> = {
   "Strategic Options Overlay": "tune",
   "Cash & Equivalents": "savings",
 };
-
 const ASSET_COLORS: Record<string, string> = {
   "U.S. Large-Cap Equities": "text-hushh-blue",
   "Strategic Options Overlay": "text-ios-yellow",
@@ -102,7 +140,6 @@ const RISK_ICONS: Record<string, string> = {
   "Drawdown Protocols": "trending_down",
   "Liquidity Management": "water_drop",
 };
-
 const RISK_COLORS: Record<string, string> = {
   "Position Limits": "text-ios-yellow",
   "Hedging Framework": "text-ios-green",
@@ -112,6 +149,7 @@ const RISK_COLORS: Record<string, string> = {
 
 const FundA = () => {
   const navigate = useNavigate();
+  const [isAlphaBreakdownOpen, setIsAlphaBreakdownOpen] = React.useState(false);
   const {
     heroTitle,
     heroSubtitle,
@@ -122,6 +160,7 @@ const FundA = () => {
     targetIRRDisclaimer,
     philosophySectionTitle,
     philosophyCards,
+    edgeSectionTitle,
     sellTheWallHref,
     edgeCards,
     assetFocusSectionTitle,
@@ -141,304 +180,418 @@ const FundA = () => {
     joinButtonLabel,
     handleCompleteProfile,
   } = useDiscoverFundALogic();
+  const alphaBreakdownRows = alphaStackRows.filter((row) => !row.isTotalRow);
+  const targetNetIrrRow = alphaStackRows.find((row) => row.isTotalRow);
+
+  const getProgressWidth = (value: string): number => {
+    const rangeMatch = value.match(/(\d+)\s*-\s*(\d+)/);
+    if (rangeMatch) {
+      const min = Number(rangeMatch[1]);
+      const max = Number(rangeMatch[2]);
+      const midpoint = (min + max) / 2;
+      return Math.min((midpoint / 23) * 100, 100);
+    }
+
+    const singleMatch = value.match(/(\d+(\.\d+)?)/);
+    if (!singleMatch) {
+      return 0;
+    }
+
+    const numericValue = Number(singleMatch[1]);
+    return Math.min((numericValue / 23) * 100, 100);
+  };
 
   return (
     <div className="bg-white text-gray-900 min-h-screen antialiased flex flex-col selection:bg-hushh-blue selection:text-white">
+      {/* ═══ Header ═══ */}
       <HushhTechBackHeader
         onBackClick={() => navigate("/")}
         rightType="hamburger"
       />
 
-      <main className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex-grow pb-32 lg:pb-12">
-        <div className="flex flex-col gap-10 pt-6 lg:gap-14">
-          <section className="lg:grid lg:grid-cols-12 lg:gap-10 lg:items-stretch">
-            <div className="pb-8 lg:col-span-7 xl:col-span-8 lg:pb-0 lg:pt-4">
-              <div className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-hushh-blue/20 rounded-full mb-6">
-                <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
-                <span className="text-[10px] tracking-[0.15em] uppercase font-medium text-hushh-blue">
-                  Flagship Fund
-                </span>
-              </div>
-
-              <h1
-                className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight sm:text-[3.25rem] lg:text-[4rem]"
-                style={{ fontFamily: "'Playfair Display', serif" }}
-              >
-                {heroTitle} <br />
-                <span className="text-gray-400 italic font-light">
-                  {heroSubtitle}
-                </span>
-              </h1>
-
-              <p className="text-[13px] text-gray-400 font-light mt-4 leading-relaxed max-w-xs sm:max-w-md lg:max-w-xl sm:text-sm">
-                {heroDescription}
-              </p>
+      {/* ═══ Main ═══ */}
+      <main className="px-6 flex-grow max-w-md mx-auto w-full pb-32 lg:max-w-7xl lg:px-10 xl:px-16">
+        <section className="pt-6 pb-8 lg:grid lg:grid-cols-2 lg:gap-16 lg:items-center">
+          {/* ── Hero ── */}
+          <div>
+            <div className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-hushh-blue/20 rounded-full mb-6">
+              <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
+              <span className="text-[10px] tracking-[0.15em] uppercase font-medium text-hushh-blue">
+                Flagship Fund
+              </span>
             </div>
 
-            <div className="lg:col-span-5 xl:col-span-4">
-              <div className="bg-ios-dark rounded-2xl p-6 sm:p-8 text-center relative overflow-hidden h-full flex items-center justify-center">
-                <div className="absolute -top-8 -right-8 w-32 h-32 bg-hushh-blue/15 rounded-full blur-2xl" />
-                <div className="relative z-10">
-                  <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 mb-3 font-medium">
-                    {targetIRRLabel}
+            <h1
+              className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight lg:text-[3.25rem]"
+              style={{ fontFamily: "'Playfair Display', serif" }}
+            >
+              {heroTitle} <br />
+              <span className="text-gray-400 italic font-light">{heroSubtitle}</span>
+            </h1>
+
+            <p className="text-[13px] text-gray-400 font-light mt-4 leading-relaxed max-w-xs lg:max-w-md">
+              {heroDescription}
+            </p>
+          </div>
+
+          {/* ── Target IRR (premium black card) ── */}
+          <div className="mt-8 lg:mt-0">
+            <div className="group bg-ios-dark rounded-2xl p-6 text-center relative overflow-hidden transition-all duration-700 hover:-rotate-[5deg]">
+              <div className="absolute inset-0 bg-ios-gray-bg/90 opacity-0 transition-opacity duration-700 ease-out group-hover:opacity-100" />
+              <div className="absolute -top-8 -right-8 w-32 h-32 bg-hushh-blue/15 rounded-full blur-2xl" />
+              <div className="relative z-10">
+                <p className="text-[10px] uppercase tracking-[0.2em] text-gray-500 group-hover:text-gray-600 mb-3 font-medium transition-colors duration-700">
+                  {targetIRRLabel}
+                </p>
+                <p
+                  className="text-[48px] leading-none font-medium text-ios-green mb-2"
+                  style={{ fontFamily: "'Playfair Display', serif" }}
+                >
+                  {targetIRRValue}
+                </p>
+                <p className="text-[13px] text-gray-400 group-hover:text-gray-600 mb-4 transition-colors duration-700">
+                  {targetIRRPeriod}
+                </p>
+                <p className="text-[9px] text-gray-600 italic max-w-[220px] mx-auto leading-relaxed">
+                  {targetIRRDisclaimer}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Investment Philosophy ── */}
+        <SectionLabel>{philosophySectionTitle}</SectionLabel>
+        <div className="space-y-3 mb-2 lg:hidden">
+          {philosophyCards.map((card) => (
+            <FeatureCard
+              key={card.title}
+              icon={PHILOSOPHY_ICONS[card.title] || "lightbulb"}
+              iconColor={PHILOSOPHY_COLORS[card.title] || "text-hushh-blue"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
+        <div className="hidden lg:grid lg:grid-cols-3 gap-4 mb-2">
+          {philosophyCards.map((card) => (
+            <FeatureHighlightTile
+              key={card.title}
+              icon={PHILOSOPHY_ICONS[card.title] || "lightbulb"}
+              iconColor={PHILOSOPHY_COLORS[card.title] || "text-hushh-blue"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
+
+        {/* ── Sell the Wall Framework ── */}
+        <SectionLabel>
+          Our Edge —{" "}
+          <a
+            href={sellTheWallHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-hushh-blue underline decoration-hushh-blue/30 hover:decoration-hushh-blue transition-colors"
+          >
+            Sell the Wall
+          </a>{" "}
+          Framework
+        </SectionLabel>
+        <div className="space-y-3 mb-2 lg:hidden">
+          {edgeCards.map((card) => (
+            <FeatureCard
+              key={card.title}
+              icon={EDGE_ICONS[card.title] || "auto_awesome"}
+              iconColor={EDGE_COLORS[card.title] || "text-hushh-blue"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
+        <div className="hidden lg:grid lg:grid-cols-4 gap-4 mb-2">
+          {edgeCards.map((card) => (
+            <FeatureHighlightTile
+              key={card.title}
+              icon={EDGE_ICONS[card.title] || "auto_awesome"}
+              iconColor={EDGE_COLORS[card.title] || "text-hushh-blue"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
+
+        {/* ── Asset Focus ── */}
+        <SectionLabel>{assetFocusSectionTitle}</SectionLabel>
+        <p className="text-[11px] text-gray-400 font-light leading-relaxed mb-4">
+          {assetFocusDescription}
+        </p>
+        <div className="space-y-3 mb-2 lg:hidden">
+          {assetPillars.map((pillar) => (
+            <FeatureCard
+              key={pillar.title}
+              icon={ASSET_ICONS[pillar.title] || "category"}
+              iconColor={ASSET_COLORS[pillar.title] || "text-hushh-blue"}
+              title={pillar.title}
+              description={pillar.description}
+            />
+          ))}
+        </div>
+        <div className="hidden lg:grid lg:grid-cols-2 xl:grid-cols-3 gap-4 mb-2">
+          {assetPillars.map((pillar) => (
+            <FeatureHighlightTile
+              key={pillar.title}
+              icon={ASSET_ICONS[pillar.title] || "category"}
+              iconColor={ASSET_COLORS[pillar.title] || "text-hushh-blue"}
+              title={pillar.title}
+              description={pillar.description}
+            />
+          ))}
+        </div>
+
+        {/* ── Targeted Alpha Stack (FieldRow style) ── */}
+        <SectionLabel>{alphaStackSectionTitle}</SectionLabel>
+        <p className="text-[10px] text-gray-400 italic mb-1">
+          {alphaStackSubtitle}
+        </p>
+        <div className="mb-2 lg:hidden">
+          {alphaStackRows.map((row) =>
+            row.isTotalRow ? (
+              <div
+                key={row.label}
+                className="group relative overflow-hidden flex items-center justify-between bg-ios-dark text-white rounded-2xl px-6 py-4 mt-3 transition-colors duration-700"
+              >
+                <div className="absolute inset-0 bg-ios-gray-bg/90 opacity-0 transition-opacity duration-700 ease-out group-hover:opacity-100" />
+                <span className="relative z-10 text-sm font-semibold text-white group-hover:text-gray-700 transition-colors duration-700">
+                  {row.label}
+                </span>
+                <span
+                  className="relative z-10 text-xl font-medium text-ios-green"
+                  style={{ fontFamily: "'Playfair Display', serif" }}
+                >
+                  {row.value}
+                </span>
+              </div>
+            ) : (
+              <FieldRow key={row.label} label={row.label}>
+                <span className="text-sm font-semibold text-black">
+                  {row.value}
+                </span>
+              </FieldRow>
+            )
+          )}
+        </div>
+        <div className="hidden lg:block mb-2">
+          {targetNetIrrRow && (
+            <button
+              type="button"
+              onClick={() => setIsAlphaBreakdownOpen((prev) => !prev)}
+              className="group relative overflow-hidden w-full text-left flex items-center justify-between bg-ios-dark text-white rounded-2xl px-6 py-4 transition-colors duration-700"
+            >
+              <div className="absolute inset-0 bg-ios-gray-bg/90 opacity-0 transition-opacity duration-700 ease-out group-hover:opacity-100" />
+              <span className="relative z-10 text-sm font-semibold text-white group-hover:text-gray-700 transition-colors duration-700">
+                {targetNetIrrRow.label}
+              </span>
+              <div className="relative z-10 flex items-center gap-3">
+                <span
+                  className="text-xl font-medium text-ios-green"
+                  style={{ fontFamily: "'Playfair Display', serif" }}
+                >
+                  {targetNetIrrRow.value}
+                </span>
+                <span className="material-symbols-outlined !text-[1.15rem] text-hushh-blue">
+                  {isAlphaBreakdownOpen ? "expand_less" : "expand_more"}
+                </span>
+              </div>
+            </button>
+          )}
+
+          {isAlphaBreakdownOpen && (
+            <div className="grid grid-cols-4 gap-4 mt-4">
+              {alphaBreakdownRows.map((row) => (
+                <div
+                  key={row.label}
+                  className="group border border-gray-200 rounded-2xl p-4 bg-gradient-to-b from-white to-gray-50/60 hover:border-hushh-blue/25 transition-all"
+                >
+                  <p className="text-[11px] font-medium text-black leading-snug mb-3 min-h-[34px]">
+                    {row.label}
                   </p>
-                  <p
-                    className="text-[48px] leading-none font-medium text-ios-green mb-2 sm:text-[56px]"
-                    style={{ fontFamily: "'Playfair Display', serif" }}
-                  >
-                    {targetIRRValue}
+                  <div className="w-full h-2.5 rounded-full bg-gray-200/80 overflow-hidden mb-2 shadow-inner">
+                    <div
+                      className="relative h-full rounded-full bg-gradient-to-r from-hushh-blue to-[#4f8dff] transition-all duration-700"
+                      style={{ width: `${getProgressWidth(row.value)}%` }}
+                    >
+                      <span className="absolute inset-0 opacity-60 bg-[linear-gradient(110deg,rgba(255,255,255,0)_0%,rgba(255,255,255,0.55)_45%,rgba(255,255,255,0)_70%)] animate-[pulse_2.4s_ease-in-out_infinite]" />
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <p className="text-[10px] uppercase tracking-[0.16em] text-gray-400">
+                      Annual Range
+                    </p>
+                    <p className="text-[12px] font-semibold text-hushh-blue group-hover:text-ios-dark transition-colors">
+                      {row.value}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* ── Risk Management ── */}
+        <SectionLabel>{riskSectionTitle}</SectionLabel>
+        <div className="space-y-3 mb-2 lg:hidden">
+          {riskCards.map((card) => (
+            <FeatureCard
+              key={card.title}
+              icon={RISK_ICONS[card.title] || "security"}
+              iconColor={RISK_COLORS[card.title] || "text-ios-green"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
+        <div className="hidden lg:grid lg:grid-cols-2 gap-4 mb-2">
+          {riskCards.map((card) => (
+            <FeatureHighlightTile
+              key={card.title}
+              icon={RISK_ICONS[card.title] || "security"}
+              iconColor={RISK_COLORS[card.title] || "text-ios-green"}
+              title={card.title}
+              description={card.description}
+            />
+          ))}
+        </div>
+
+        {/* ── Key Terms (FieldRow style) ── */}
+        <SectionLabel>{keyTermsSectionTitle}</SectionLabel>
+        <p className="text-[10px] text-gray-400 italic mb-1">
+          {keyTermsSubtitle}
+        </p>
+
+        {/* First terms as FieldRows */}
+        <div className="mb-4">
+          {keyTerms.slice(0, 2).map((term) => (
+            <FieldRow key={term.title} label={term.title}>
+              <span className="text-[12px] font-medium text-black max-w-[180px] text-right leading-snug">
+                {term.content}
+              </span>
+            </FieldRow>
+          ))}
+        </div>
+
+        {/* Share Classes (compact cards) */}
+        <SectionLabel>Share Classes</SectionLabel>
+        <div className="space-y-3 mb-4 lg:grid lg:grid-cols-3 lg:gap-4 lg:space-y-0">
+          {shareClasses.map((sc) => (
+            <div
+              key={sc.shareClass}
+              className="border border-gray-200 rounded-2xl p-5 hover:border-gray-300 hover:bg-gray-50/40 transition-all"
+            >
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-full bg-ios-dark flex items-center justify-center">
+                    <span className="material-symbols-outlined text-white !text-[0.9rem]">
+                      account_balance_wallet
+                    </span>
+                  </div>
+                  <span className="text-[13px] font-semibold text-black">
+                    {sc.shareClass}
+                  </span>
+                </div>
+                <span className="text-[11px] font-medium text-hushh-blue bg-hushh-blue/10 px-2.5 py-1 rounded-full">
+                  Min {sc.minInvestment}
+                </span>
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                <div className="text-center rounded-xl border border-gray-200 bg-white px-2 py-2 transition-all hover:border-hushh-blue/40 hover:bg-hushh-blue/5">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
+                    Mgmt
                   </p>
-                  <p className="text-[13px] text-gray-400 mb-4">
-                    {targetIRRPeriod}
+                  <p className="text-[12px] font-semibold text-black transition-colors hover:text-hushh-blue">
+                    {sc.managementFee}
                   </p>
-                  <p className="text-[9px] text-gray-600 italic max-w-[220px] sm:max-w-[260px] mx-auto leading-relaxed">
-                    {targetIRRDisclaimer}
+                </div>
+                <div className="text-center rounded-xl border border-gray-200 bg-white px-2 py-2 transition-all hover:border-ios-green/40 hover:bg-ios-green/5">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
+                    Perf
+                  </p>
+                  <p className="text-[12px] font-semibold text-black transition-colors hover:text-ios-green">
+                    {sc.performanceFee}
+                  </p>
+                </div>
+                <div className="text-center rounded-xl border border-gray-200 bg-white px-2 py-2 transition-all hover:border-ios-yellow/50 hover:bg-ios-yellow/10">
+                  <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
+                    Hurdle
+                  </p>
+                  <p className="text-[12px] font-semibold text-black transition-colors hover:text-ios-yellow">
+                    {sc.hurdleRate}
                   </p>
                 </div>
               </div>
             </div>
-          </section>
+          ))}
+        </div>
 
-          <section className="grid gap-10 xl:grid-cols-2 xl:gap-12">
-            <div>
-              <SectionLabel>{philosophySectionTitle}</SectionLabel>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {philosophyCards.map((card) => (
-                  <FeatureCard
-                    key={card.title}
-                    icon={PHILOSOPHY_ICONS[card.title] || "lightbulb"}
-                    iconColor={PHILOSOPHY_COLORS[card.title] || "text-hushh-blue"}
-                    title={card.title}
-                    description={card.description}
-                  />
-                ))}
-              </div>
-            </div>
+        {/* Remaining terms */}
+        <div className="mb-6">
+          {keyTerms.slice(2).map((term) => (
+            <FieldRow key={term.title} label={term.title}>
+              <span className="text-[12px] font-medium text-black max-w-[180px] text-right leading-snug">
+                {term.content}
+              </span>
+            </FieldRow>
+          ))}
+        </div>
 
-            <div>
-              <SectionLabel>
-                Our Edge -{" "}
-                <a
-                  href={sellTheWallHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-hushh-blue underline decoration-hushh-blue/30 hover:decoration-hushh-blue transition-colors"
-                >
-                  Sell the Wall
-                </a>{" "}
-                Framework
-              </SectionLabel>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {edgeCards.map((card) => (
-                  <FeatureCard
-                    key={card.title}
-                    icon={EDGE_ICONS[card.title] || "auto_awesome"}
-                    iconColor={EDGE_COLORS[card.title] || "text-hushh-blue"}
-                    title={card.title}
-                    description={card.description}
-                  />
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="grid gap-10 xl:grid-cols-12 xl:gap-12">
-            <div className="xl:col-span-5">
-              <SectionLabel>{assetFocusSectionTitle}</SectionLabel>
-              <p className="text-[11px] text-gray-400 font-light leading-relaxed mb-4 lg:max-w-md">
-                {assetFocusDescription}
-              </p>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {assetPillars.map((pillar) => (
-                  <FeatureCard
-                    key={pillar.title}
-                    icon={ASSET_ICONS[pillar.title] || "category"}
-                    iconColor={ASSET_COLORS[pillar.title] || "text-hushh-blue"}
-                    title={pillar.title}
-                    description={pillar.description}
-                  />
-                ))}
-              </div>
-            </div>
-
-            <div className="xl:col-span-7">
-              <SectionLabel>{alphaStackSectionTitle}</SectionLabel>
-              <p className="text-[10px] text-gray-400 italic mb-1">
-                {alphaStackSubtitle}
-              </p>
-              <div>
-                {alphaStackRows.map((row) =>
-                  row.isTotalRow ? (
-                    <div
-                      key={row.label}
-                      className="flex items-center justify-between bg-ios-dark text-white rounded-2xl px-6 py-4 mt-3"
-                    >
-                      <span className="text-sm font-semibold">
-                        {row.label}
-                      </span>
-                      <span
-                        className="text-xl font-medium text-ios-green"
-                        style={{ fontFamily: "'Playfair Display', serif" }}
-                      >
-                        {row.value}
-                      </span>
-                    </div>
-                  ) : (
-                    <FieldRow key={row.label} label={row.label}>
-                      <span className="text-sm font-semibold text-black">
-                        {row.value}
-                      </span>
-                    </FieldRow>
-                  )
-                )}
-              </div>
-            </div>
-          </section>
-
-          <section className="grid gap-10 xl:grid-cols-12 xl:gap-12">
-            <div className="xl:col-span-5">
-              <SectionLabel>{riskSectionTitle}</SectionLabel>
-              <div className="grid gap-3 sm:grid-cols-2">
-                {riskCards.map((card) => (
-                  <FeatureCard
-                    key={card.title}
-                    icon={RISK_ICONS[card.title] || "security"}
-                    iconColor={RISK_COLORS[card.title] || "text-ios-green"}
-                    title={card.title}
-                    description={card.description}
-                  />
-                ))}
-              </div>
-            </div>
-
-            <div className="xl:col-span-7">
-              <SectionLabel>{keyTermsSectionTitle}</SectionLabel>
-              <p className="text-[10px] text-gray-400 italic mb-1">
-                {keyTermsSubtitle}
-              </p>
-
-              <div className="mb-6">
-                {keyTerms.slice(0, 2).map((term) => (
-                  <FieldRow key={term.title} label={term.title}>
-                    <span className="text-[12px] font-medium text-black max-w-[180px] sm:max-w-[260px] lg:max-w-[320px] text-right leading-snug">
-                      {term.content}
-                    </span>
-                  </FieldRow>
-                ))}
-              </div>
-
-              <SectionLabel>Share Classes</SectionLabel>
-              <div className="grid gap-3 mb-6 md:grid-cols-2">
-                {shareClasses.map((sc) => (
-                  <div
-                    key={sc.shareClass}
-                    className="border border-gray-200 rounded-2xl p-5 hover:border-gray-300 transition-colors"
-                  >
-                    <div className="flex items-center justify-between mb-3">
-                      <div className="flex items-center gap-3">
-                        <div className="w-9 h-9 rounded-full bg-ios-dark flex items-center justify-center">
-                          <span className="material-symbols-outlined text-white !text-[0.9rem]">
-                            account_balance_wallet
-                          </span>
-                        </div>
-                        <span className="text-[13px] font-semibold text-black">
-                          {sc.shareClass}
-                        </span>
-                      </div>
-                      <span className="text-[11px] font-medium text-hushh-blue bg-hushh-blue/10 px-2.5 py-1 rounded-full">
-                        Min {sc.minInvestment}
-                      </span>
-                    </div>
-                    <div className="grid grid-cols-3 gap-2">
-                      <div className="text-center">
-                        <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
-                          Mgmt
-                        </p>
-                        <p className="text-[12px] font-semibold text-black">
-                          {sc.managementFee}
-                        </p>
-                      </div>
-                      <div className="text-center">
-                        <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
-                          Perf
-                        </p>
-                        <p className="text-[12px] font-semibold text-black">
-                          {sc.performanceFee}
-                        </p>
-                      </div>
-                      <div className="text-center">
-                        <p className="text-[9px] uppercase tracking-widest text-gray-400 mb-0.5">
-                          Hurdle
-                        </p>
-                        <p className="text-[12px] font-semibold text-black">
-                          {sc.hurdleRate}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              <div>
-                {keyTerms.slice(2).map((term) => (
-                  <FieldRow key={term.title} label={term.title}>
-                    <span className="text-[12px] font-medium text-black max-w-[180px] sm:max-w-[260px] lg:max-w-[320px] text-right leading-snug">
-                      {term.content}
-                    </span>
-                  </FieldRow>
-                ))}
-              </div>
-            </div>
-          </section>
-
-          <section className="border-t border-gray-200 pt-8">
-            <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
-              <div className="lg:max-w-xl">
-                <h2
-                  className="text-[22px] font-medium text-black tracking-tight mb-2 sm:text-[28px]"
-                  style={{ fontFamily: "'Playfair Display', serif" }}
-                >
-                  {joinSectionTitle}
-                </h2>
-                <p className="text-[13px] text-gray-400 font-light leading-relaxed max-w-xs sm:max-w-md">
-                  {joinSectionDescription}
-                </p>
-              </div>
-
-              <div className="space-y-3 lg:w-full lg:max-w-sm">
-                <HushhTechCta
-                  variant={HushhTechCtaVariant.BLACK}
-                  onClick={handleCompleteProfile}
-                >
-                  {joinButtonLabel}
-                  <span className="material-symbols-outlined !text-[1.1rem]">
-                    arrow_forward
-                  </span>
-                </HushhTechCta>
-                <HushhTechCta
-                  variant={HushhTechCtaVariant.WHITE}
-                  onClick={() => navigate("/")}
-                >
-                  Back to Home
-                </HushhTechCta>
-              </div>
-            </div>
-          </section>
-
-          <p
-            className="text-[9px] text-gray-400 text-center leading-relaxed italic max-w-xs sm:max-w-lg lg:max-w-3xl mx-auto pb-4"
+        {/* ── Join / CTA ── */}
+        <section className="border-t border-gray-200 pt-8 mb-8">
+          <h2
+            className="text-[22px] font-medium text-black tracking-tight mb-2"
             style={{ fontFamily: "'Playfair Display', serif" }}
           >
-            Investing involves risk, including possible loss of principal. Past
-            performance does not guarantee future results. Hushh Technologies is an
-            SEC registered investment advisor.
+            {joinSectionTitle}
+          </h2>
+          <p className="text-[13px] text-gray-400 font-light leading-relaxed mb-8 max-w-xs">
+            {joinSectionDescription}
           </p>
-        </div>
+
+          <div className="space-y-3 lg:space-y-0 lg:flex lg:items-center lg:gap-3">
+            <div className="lg:w-1/2">
+              <HushhTechCta
+                variant={HushhTechCtaVariant.BLACK}
+                onClick={handleCompleteProfile}
+              >
+                {joinButtonLabel}
+                <span className="material-symbols-outlined !text-[1.1rem]">
+                  arrow_forward
+                </span>
+              </HushhTechCta>
+            </div>
+            <div className="lg:w-1/2">
+              <HushhTechCta
+                variant={HushhTechCtaVariant.WHITE}
+                onClick={() => navigate("/")}
+              >
+                Back to Home
+              </HushhTechCta>
+            </div>
+          </div>
+        </section>
+
+        {/* ── Disclaimer ── */}
+        <p
+          className="text-[9px] text-gray-400 text-center leading-relaxed italic max-w-xs mx-auto mb-4"
+          style={{ fontFamily: "'Playfair Display', serif" }}
+        >
+          Investing involves risk, including possible loss of principal. Past
+          performance does not guarantee future results. Hushh Technologies is an
+          SEC registered investment advisor.
+        </p>
       </main>
 
-      <div className="lg:hidden">
-        <HushhTechFooter activeTab={HushhFooterTab.FUND_A} />
-      </div>
+      {/* ═══ Footer Nav ═══ */}
+      <HushhTechFooter activeTab={HushhFooterTab.FUND_A} />
     </div>
   );
 };

--- a/src/pages/home/ui.tsx
+++ b/src/pages/home/ui.tsx
@@ -121,15 +121,11 @@ export default function HomePage() {
                     </div>
                   </div>
 
-                  <div
-                    className="pt-4 border-t border-white/10 group-hover:border-gray-300 flex items-center justify-between cursor-pointer transition-colors duration-700"
+                  <button
+                    type="button"
+                    className="w-full pt-4 border-t border-white/10 group-hover:border-gray-300 flex items-center justify-between cursor-pointer bg-transparent text-left transition-colors duration-700"
                     onClick={() => onNavigate("/discover-fund-a")}
-                    role="button"
-                    tabIndex={0}
                     aria-label="View performance details"
-                    onKeyDown={(e) => {
-                      activateOnKeyboard(e, () => onNavigate("/discover-fund-a"));
-                    }}
                   >
                     <span className="text-xs font-medium tracking-wide uppercase text-hushh-blue">
                       Performance Details
@@ -137,7 +133,7 @@ export default function HomePage() {
                     <span className="material-symbols-outlined thin-icon text-sm text-hushh-blue group-hover:translate-x-1 transition-transform">
                       arrow_forward
                     </span>
-                  </div>
+                  </button>
                 </div>
               </div>
             </div>
@@ -195,152 +191,39 @@ export default function HomePage() {
                   className="text-2xl font-medium mb-8 tracking-tight font-serif sm:text-3xl"
                   style={playfair}
                 >
-                  {primaryCTA.text}
-                  <span className="material-symbols-outlined thin-icon text-lg">
-                    arrow_forward
-                  </span>
-                </HushhTechCta>
-                <HushhTechCta
-                  onClick={() => onNavigate("/discover-fund-a")}
-                  variant={HushhTechCtaVariant.WHITE}
-                >
-                  Discover Fund A
-                </HushhTechCta>
-              </div>
-
-              <div className="border-t border-b border-gray-100 py-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between lg:flex-col lg:items-start">
-                <div className="flex items-center gap-2">
-                  <span className="material-symbols-outlined thin-icon text-lg text-ios-green">
-                    verified_user
-                  </span>
-                  <span className="text-[10px] font-medium tracking-widest uppercase text-gray-400">
-                    SEC Registered
-                  </span>
-                </div>
-                <div className="hidden sm:block w-1 h-1 bg-gray-300 rounded-full lg:hidden" />
-                <div className="flex items-center gap-2">
-                  <span className="material-symbols-outlined thin-icon text-lg text-hushh-blue">
-                    lock
-                  </span>
-                  <span className="text-[10px] font-medium tracking-widest uppercase text-gray-400">
-                    Bank Level Security
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <div className="relative mt-4 lg:mt-0 lg:col-span-8 xl:col-span-9">
-              <div className="bg-ios-dark text-white p-8 sm:p-10 lg:p-12 rounded-2xl relative overflow-hidden shadow-2xl">
-                <div className="absolute -top-10 -right-10 w-40 h-40 bg-hushh-blue/15 rounded-full blur-3xl" />
-                <div className="absolute bottom-0 left-0 w-full h-1/2 bg-gradient-to-t from-hushh-blue/5 to-transparent" />
-
-                <div className="relative z-10 flex flex-col gap-6">
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <span className="text-[10px] font-medium tracking-widest uppercase text-white/50 mb-1 block">
-                        Flagship Product
-                      </span>
-                      <h2
-                        className="text-3xl font-medium font-serif sm:text-4xl"
-                        style={playfair}
-                      >
-                        Fund A
-                      </h2>
-                    </div>
-                    <span className="self-start bg-hushh-blue/20 backdrop-blur-md px-3 py-1 rounded-full text-[10px] font-medium uppercase tracking-wider border border-hushh-blue/30 text-hushh-blue">
-                      High Growth
-                    </span>
-                  </div>
-
-                  <div className="space-y-4 my-2 sm:grid sm:grid-cols-2 sm:gap-8 sm:space-y-0">
-                    <div>
-                      <span className="text-xs text-white/50 block mb-1">
-                        Target Net IRR
-                      </span>
-                      <span
-                        className="text-[48px] font-serif font-light tracking-tighter text-ios-green leading-none sm:text-[56px]"
-                        style={playfair}
-                      >
-                        18-23%
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-xs text-white/50 block mb-1">
-                        Inception Year
-                      </span>
-                      <span
-                        className="font-serif text-[36px] leading-none sm:text-[44px]"
-                        style={playfair}
-                      >
-                        2024
-                      </span>
-                    </div>
-                  </div>
-
-                  <button
-                    type="button"
-                    className="w-full pt-4 border-t border-white/10 flex items-center justify-between group cursor-pointer bg-transparent text-left"
-                    onClick={() => onNavigate("/discover-fund-a")}
-                    aria-label="View performance details"
-                  >
-                    <span className="text-xs font-medium tracking-wide uppercase text-hushh-blue">
-                      Performance Details
-                    </span>
-                    <span className="material-symbols-outlined thin-icon text-sm text-hushh-blue group-hover:translate-x-1 transition-transform">
-                      arrow_forward
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className="lg:grid lg:grid-cols-12 lg:gap-10 lg:items-start">
-            <div className="lg:col-span-7 xl:col-span-8">
-              <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-2 font-medium">
-                Why Hushh
-              </p>
-              <h2
-                className="text-2xl font-medium mb-8 tracking-tight font-serif sm:text-3xl"
-                style={playfair}
-              >
-                The Hushh Advantage
-              </h2>
-              <div className="grid grid-cols-2 gap-x-4 gap-y-10 sm:grid-cols-4 lg:grid-cols-2 xl:grid-cols-4">
-                {[
-                  {
-                    icon: "analytics",
-                    color: "text-hushh-blue",
-                    bg: "bg-hushh-blue/10",
-                    title: "Data Driven",
-                    desc: "Decisions based on facts, not emotions.",
-                  },
-                  {
-                    icon: "savings",
-                    color: "text-ios-green",
-                    bg: "bg-ios-green/10",
-                    title: "Low Fees",
-                    desc: "More of your returns stay in your pocket.",
-                  },
-                  {
-                    icon: "workspace_premium",
-                    color: "text-ios-yellow",
-                    bg: "bg-ios-yellow/10",
-                    title: "Expert Vetted",
-                    desc: "Top-tier financial minds at work.",
-                  },
-                  {
-                    icon: "autorenew",
-                    color: "text-hushh-blue",
-                    bg: "bg-hushh-blue/10",
-                    title: "Automated",
-                    desc: "Set it and forget it peace of mind.",
-                  },
-                ].map((item) => (
-                  <div
-                    key={item.icon}
-                    className="flex flex-col items-center text-center gap-3"
-                  >
+                  The Hushh Advantage
+                </h2>
+                <div className="grid grid-cols-2 gap-x-4 gap-y-10 sm:grid-cols-4">
+                  {[
+                    {
+                      icon: "analytics",
+                      color: "text-hushh-blue",
+                      bg: "bg-hushh-blue/10",
+                      title: "Data Driven",
+                      desc: "Decisions based on facts, not emotions.",
+                    },
+                    {
+                      icon: "savings",
+                      color: "text-ios-green",
+                      bg: "bg-ios-green/10",
+                      title: "Low Fees",
+                      desc: "More of your returns stay in your pocket.",
+                    },
+                    {
+                      icon: "workspace_premium",
+                      color: "text-ios-yellow",
+                      bg: "bg-ios-yellow/10",
+                      title: "Expert Vetted",
+                      desc: "Top-tier financial minds at work.",
+                    },
+                    {
+                      icon: "autorenew",
+                      color: "text-hushh-blue",
+                      bg: "bg-hushh-blue/10",
+                      title: "Automated",
+                      desc: "Set it and forget it peace of mind.",
+                    },
+                  ].map((item) => (
                     <div
                       key={item.icon}
                       className="flex flex-col items-center text-center gap-3"

--- a/src/pages/home/ui.tsx
+++ b/src/pages/home/ui.tsx
@@ -20,15 +20,9 @@ export default function HomePage() {
       <HushhTechHeader />
 
       <main className="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-32 lg:pb-12 pt-4">
-        <div className="flex flex-col gap-12 lg:gap-16">
-          <section className="lg:grid lg:grid-cols-12 lg:gap-10 lg:items-start">
-            <div className="py-4 lg:col-span-5 xl:col-span-4">
-              <div className="inline-block px-3 py-1 mb-5 border border-hushh-blue/20 rounded-full bg-hushh-blue/5">
-                <span className="text-[10px] tracking-widest uppercase font-medium text-hushh-blue flex items-center gap-1">
-                  <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
-                  AI-Powered Investing
-                </span>
-              </div>
+        <div className="flex min-h-[calc(100vh-6rem)] flex-col gap-12 lg:gap-16">
+          <section className="grid grid-cols-1 gap-8 lg:min-h-[70vh] lg:grid-cols-2 lg:items-center lg:gap-12">
+            <div className="flex flex-col justify-center py-4 lg:min-h-[58vh]">
               <h1
                 className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight font-serif sm:text-[3.25rem] lg:text-[4rem]"
                 style={playfair}
@@ -40,9 +34,124 @@ export default function HomePage() {
                 The world's first AI-powered Berkshire Hathaway. Merging rigorous
                 data science with human wisdom.
               </p>
+              <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:max-w-md">
+                <HushhTechCta
+                  onClick={primaryCTA.action}
+                  disabled={primaryCTA.loading}
+                  variant={HushhTechCtaVariant.BLACK}
+                >
+                  {primaryCTA.text}
+                  <span className="material-symbols-outlined thin-icon text-lg">
+                    arrow_forward
+                  </span>
+                </HushhTechCta>
+                <HushhTechCta
+                  onClick={() => onNavigate("/discover-fund-a")}
+                  variant={HushhTechCtaVariant.WHITE}
+                >
+                  Discover Fund A
+                </HushhTechCta>
+              </div>
+              <div className="mt-6 border-t border-b border-gray-100 py-5 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-start sm:gap-8">
+                <div className="flex items-center gap-2">
+                  <span className="material-symbols-outlined thin-icon text-lg text-ios-green">
+                    verified_user
+                  </span>
+                  <span className="text-[10px] font-medium tracking-widest uppercase text-gray-400">
+                    SEC Registered
+                  </span>
+                </div>
+                <div className="hidden sm:block w-1 h-1 bg-gray-300 rounded-full" />
+                <div className="flex items-center gap-2">
+                  <span className="material-symbols-outlined thin-icon text-lg text-hushh-blue">
+                    lock
+                  </span>
+                  <span className="text-[10px] font-medium tracking-widest uppercase text-gray-400">
+                    Bank Level Security
+                  </span>
+                </div>
+              </div>
             </div>
 
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6 lg:col-span-7 xl:col-span-8 lg:pt-10">
+            <div className="relative mt-2 lg:mt-0">
+              <div className="group bg-ios-dark hover:bg-gray-100 text-white hover:text-gray-900 border border-white/10 hover:border-gray-300 p-8 sm:p-10 lg:p-12 rounded-2xl relative overflow-hidden shadow-2xl w-full lg:max-w-[520px] lg:ml-auto transition-all duration-700 ease-out hover:-rotate-[8deg]">
+                <div className="absolute -top-10 -right-10 w-40 h-40 bg-hushh-blue/15 rounded-full blur-3xl" />
+                <div className="absolute bottom-0 left-0 w-full h-1/2 bg-gradient-to-t from-hushh-blue/5 to-transparent" />
+
+                <div className="relative z-10 flex flex-col gap-6">
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <span className="text-[10px] font-medium tracking-widest uppercase text-white/50 group-hover:text-gray-500 mb-1 block transition-colors duration-700">
+                        Flagship Product
+                      </span>
+                      <h2
+                        className="text-3xl font-medium font-serif sm:text-4xl transition-colors duration-700"
+                        style={playfair}
+                      >
+                        Fund A
+                      </h2>
+                    </div>
+                    <span className="self-start bg-hushh-blue/20 backdrop-blur-md px-3 py-1 rounded-full text-[10px] font-medium uppercase tracking-wider border border-hushh-blue/30 text-hushh-blue">
+                      High Growth
+                    </span>
+                  </div>
+
+                  <div className="space-y-4 my-2 sm:grid sm:grid-cols-2 sm:gap-8 sm:space-y-0">
+                    <div>
+                      <span className="text-xs text-white/50 group-hover:text-gray-500 block mb-1 transition-colors duration-700">
+                        Target Net IRR
+                      </span>
+                      <span
+                        className="text-[48px] font-serif font-light tracking-tighter text-ios-green leading-none sm:text-[56px]"
+                        style={playfair}
+                      >
+                        18-23%
+                      </span>
+                    </div>
+                    <div>
+                      <span className="text-xs text-white/50 group-hover:text-gray-500 block mb-1 transition-colors duration-700">
+                        Inception Year
+                      </span>
+                      <span
+                        className="font-serif text-[36px] leading-none sm:text-[44px] transition-colors duration-700"
+                        style={playfair}
+                      >
+                        2024
+                      </span>
+                    </div>
+                  </div>
+
+                  <div
+                    className="pt-4 border-t border-white/10 group-hover:border-gray-300 flex items-center justify-between cursor-pointer transition-colors duration-700"
+                    onClick={() => onNavigate("/discover-fund-a")}
+                    role="button"
+                    tabIndex={0}
+                    aria-label="View performance details"
+                    onKeyDown={(e) => {
+                      activateOnKeyboard(e, () => onNavigate("/discover-fund-a"));
+                    }}
+                  >
+                    <span className="text-xs font-medium tracking-wide uppercase text-hushh-blue">
+                      Performance Details
+                    </span>
+                    <span className="material-symbols-outlined thin-icon text-sm text-hushh-blue group-hover:translate-x-1 transition-transform">
+                      arrow_forward
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="mt-auto space-y-12 lg:space-y-16">
+            <div className="inline-block px-3 py-1 border border-hushh-blue/20 rounded-full bg-hushh-blue/5">
+              <span className="text-[10px] tracking-widest uppercase font-medium text-hushh-blue flex items-center gap-1">
+                <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
+                AI-Powered Investing
+              </span>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
               <div className="bg-ios-gray-bg p-5 rounded-2xl border border-gray-200/60 flex flex-col justify-between min-h-[180px] sm:min-h-[220px] hover:border-hushh-blue/30 transition-colors">
                 <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-hushh-blue">
                   neurology
@@ -76,15 +185,15 @@ export default function HomePage() {
                 </div>
               </div>
             </div>
-          </section>
 
-          <section className="lg:grid lg:grid-cols-12 lg:gap-10 lg:items-start">
-            <div className="flex flex-col gap-6 lg:col-span-4 xl:col-span-3">
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
-                <HushhTechCta
-                  onClick={primaryCTA.action}
-                  disabled={primaryCTA.loading}
-                  variant={HushhTechCtaVariant.BLACK}
+            <div className="space-y-10 lg:space-y-12">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.2em] text-gray-400 mb-2 font-medium">
+                  Why Hushh
+                </p>
+                <h2
+                  className="text-2xl font-medium mb-8 tracking-tight font-serif sm:text-3xl"
+                  style={playfair}
                 >
                   {primaryCTA.text}
                   <span className="material-symbols-outlined thin-icon text-lg">
@@ -233,27 +342,32 @@ export default function HomePage() {
                     className="flex flex-col items-center text-center gap-3"
                   >
                     <div
-                      className={`w-12 h-12 rounded-full border border-gray-200/60 flex items-center justify-center ${item.bg}`}
+                      key={item.icon}
+                      className="flex flex-col items-center text-center gap-3"
                     >
-                      <span
-                        className={`material-symbols-outlined thin-icon ${item.color}`}
+                      <div
+                        className={`w-12 h-12 rounded-full border border-gray-200/60 flex items-center justify-center ${item.bg}`}
                       >
-                        {item.icon}
-                      </span>
+                        <span
+                          className={`material-symbols-outlined thin-icon ${item.color}`}
+                        >
+                          {item.icon}
+                        </span>
+                      </div>
+                      <div>
+                        <h3 className="font-medium text-sm mb-1">
+                          {item.title}
+                        </h3>
+                        <p className="text-[11px] text-gray-500 font-light max-w-[180px] mx-auto">
+                          {item.desc}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <h3 className="font-medium text-sm mb-1">{item.title}</h3>
-                      <p className="text-[11px] text-gray-500 font-light max-w-[180px] mx-auto">
-                        {item.desc}
-                      </p>
-                    </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
 
-            <div className="mt-10 flex flex-col gap-8 lg:col-span-5 xl:col-span-4 lg:mt-0">
-              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 lg:grid-cols-2">
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
                 {[
                   {
                     icon: "rocket_launch",
@@ -289,7 +403,7 @@ export default function HomePage() {
                     >
                       {item.icon}
                     </span>
-                    <h2 className="font-medium text-sm">{item.title}</h2>
+                    <h3 className="font-medium text-sm">{item.title}</h3>
                     <p className="text-[10px] text-gray-500 font-light">
                       {item.desc}
                     </p>
@@ -297,7 +411,7 @@ export default function HomePage() {
                 ))}
               </div>
 
-              <div className="flex flex-col gap-3 sm:flex-row lg:flex-col xl:flex-row">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
                 <HushhTechCta
                   onClick={() => onNavigate("/discover-fund-a")}
                   variant={HushhTechCtaVariant.BLACK}

--- a/tests/discoverFundAFooter.test.ts
+++ b/tests/discoverFundAFooter.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock("../src/pages/discover-fund-a/logic", () => ({
+  useDiscoverFundALogic: () => ({
+    heroTitle: "Hushh Fund A:",
+    heroSubtitle: "AI-Powered Multi-Strategy Alpha.",
+    heroDescription: "Fund description",
+    targetIRRLabel: "Target Net IRR",
+    targetIRRValue: "18-23%",
+    targetIRRPeriod: "Annually",
+    targetIRRDisclaimer: "Disclaimer",
+    philosophySectionTitle: "Investment Philosophy",
+    philosophyCards: [{ title: "Risk-First Architecture", description: "Risk" }],
+    edgeSectionTitle: "Our Edge",
+    sellTheWallHref: "/sell-the-wall",
+    edgeCards: [{ title: "Downside Protection", description: "Protection" }],
+    assetFocusSectionTitle: "Asset Focus",
+    assetFocusDescription: "Assets",
+    assetPillars: [{ title: "Cash & Equivalents", description: "Cash" }],
+    alphaStackSectionTitle: "Alpha Stack",
+    alphaStackSubtitle: "Breakdown",
+    alphaStackRows: [
+      { label: "Options Premium", value: "4-5%" },
+      { label: "Target Net IRR", value: "18-23%", isTotalRow: true },
+    ],
+    riskSectionTitle: "Risk Management",
+    riskCards: [{ title: "Hedging Framework", description: "Hedge" }],
+    keyTermsSectionTitle: "Key Terms",
+    keyTermsSubtitle: "Terms",
+    keyTerms: [{ title: "Liquidity", content: "Quarterly" }],
+    shareClasses: [
+      {
+        shareClass: "Class A",
+        minInvestment: "$25M",
+        managementFee: "1%",
+        performanceFee: "15%",
+        hurdleRate: "12%",
+      },
+    ],
+    joinSectionTitle: "Join",
+    joinSectionDescription: "Complete profile",
+    joinButtonLabel: "Complete Profile",
+    handleCompleteProfile: vi.fn(),
+  }),
+}));
+
+vi.mock("../src/components/hushh-tech-back-header/HushhTechBackHeader", () => ({
+  default: () => null,
+}));
+
+vi.mock("../src/components/hushh-tech-footer/HushhTechFooter", () => ({
+  HushhFooterTab: { FUND_A: "fund-a" },
+  default: ({ activeTab }: { activeTab: string }) => (
+    React.createElement("nav", {
+      "data-active-tab": activeTab,
+      "data-testid": "fund-a-footer",
+    })
+  ),
+}));
+
+import FundA from "../src/pages/discover-fund-a/ui";
+
+describe("FundA footer shell", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    navigateMock.mockClear();
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("keeps the mobile footer hidden on desktop breakpoints", async () => {
+    await act(async () => {
+      root.render(React.createElement(FundA));
+    });
+
+    const footer = container.querySelector('[data-testid="fund-a-footer"]');
+
+    expect(footer?.getAttribute("data-active-tab")).toBe("fund-a");
+    expect(footer?.parentElement?.className).toContain("lg:hidden");
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: changed file src/pages/discover-fund-a/ui.tsx and enhanced the ui
- why it changed: in previous ui all the elements were cluttered and hence better alignment was required 
- linked issue: `none - ui enhancement`
- acceptance criteria covered: all the elements in the discover-fund-a page is cleanly displayed and animations are added for better user experience 
- risk area touched: `ui`
- reviewer focus: Verify the discover-fund-a page visual layout and hover/focus behavior at mobile and desktop widths.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [x] `npm test`
- [x] `npx tsc --noEmit`
- [x] `npm run build:web`
- [x] `npm run env:check`
- [x] `npm run lint:ci`
- [x] relevant route or smoke checks
- [x] security checks when secrets, auth, infra, or deploy paths changed
- ran: `npm run env:check`; `node scripts/ci/check-ui-ux-guard.mjs` equivalent from the maintainer workspace; `npm run lint:ci`; `npm test`; `npx tsc --noEmit`; `npm run build:web`; GitHub Web Validation, Lint, DCO, Secret Scan, Env Contract Check, Security Audit, Semantic PR Guard, Reviewer Context and Signalkeeper all passed on current head.
- did not run: full manual cross-browser QA; this PR uses automated local checks and GitHub checks plus maintainer visual review.
- reviewer should verify: Home page at mobile and desktop widths, Fund A hover/focus behavior, Why Hushh section heading, CTA alignment, and that no duplicate sections or malformed wrappers remain.

## Notes

- deployment impact: Standard frontend rebuild only.
- migration or env requirements: None.
- rollback or release notes: Revert `src/pages/discover-fund-a/ui.tsx` to restore the previous Home layout.
- follow-up work if any: Consider extracting the Fund A hover treatment only if the pattern is reused elsewhere.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/design-system maintainers.

##Demo : Updated ui glimpse 


https://github.com/user-attachments/assets/3dce6248-6d02-4162-b2c2-b67fd1e3e8ad

