### PR TITLE
feat(ui): redesign a2a scenario setup screen to match hushh website theme

### DIFF
--- a/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
+++ b/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
@@ -1,33 +1,10 @@
 /**
- * A2A Scenario Setup Screen (Screen 1)
- * 
- * Demo operator selects:
- * - Relying party (bank)
- * - User to verify (Ankit, etc.)
- * - Which A2A operations to demo
+ * A2A Scenario Setup Screen (Screen 1) — theme aligned with Home / Login / Signup
  */
 'use client';
 
 import React, { useState } from 'react';
-import {
-  Box,
-  Container,
-  VStack,
-  HStack,
-  Text,
-  Input,
-  Select,
-  Checkbox,
-  Button,
-  FormControl,
-  FormLabel,
-  Divider,
-  Icon,
-  Badge,
-  InputGroup,
-  InputLeftAddon,
-} from '@chakra-ui/react';
-import { keyframes } from '@emotion/react';
+import HushhTechCta, { HushhTechCtaVariant } from '../hushh-tech-cta/HushhTechCta';
 import {
   A2AScenarioConfig,
   A2AScenarioSetupProps,
@@ -38,18 +15,7 @@ import {
   DEFAULT_SCENARIO_CONFIG,
 } from '../../types/a2aPlayground';
 
-// =====================================================
-// Animations
-// =====================================================
-
-const pulseGlow = keyframes`
-  0%, 100% { box-shadow: 0 0 20px rgba(159, 122, 234, 0.3); }
-  50% { box-shadow: 0 0 40px rgba(159, 122, 234, 0.6); }
-`;
-
-// =====================================================
-// Country Options
-// =====================================================
+const playfair = { fontFamily: "'Playfair Display', serif" };
 
 const COUNTRY_OPTIONS = [
   { value: 'US', label: 'United States' },
@@ -67,391 +33,196 @@ const PHONE_CODES = [
   { value: '+65', label: '+65 (SG)' },
 ];
 
-// =====================================================
-// Component
-// =====================================================
+const inputClass =
+  'w-full h-12 px-4 rounded-2xl border border-gray-200 bg-white text-[13px] text-black placeholder:text-gray-400 font-light focus:outline-none focus:border-hushh-blue transition-colors';
 
-export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
-  onRunScenario,
-}) => {
-  // Form state
-  const [selectedPartyId, setSelectedPartyId] = useState(
-    DEFAULT_SCENARIO_CONFIG.relyingParty.id
-  );
-  const [user, setUser] = useState<DemoUserIdentifiers>(
-    DEFAULT_SCENARIO_CONFIG.user
-  );
-  const [operations, setOperations] = useState<ScenarioOperations>(
-    DEFAULT_SCENARIO_CONFIG.operations
-  );
+const sectionLabel = 'text-[10px] tracking-[0.2em] uppercase text-gray-400 font-medium mb-3';
 
-  // Get selected relying party
-  const selectedParty = DEMO_RELYING_PARTIES.find(p => p.id === selectedPartyId) 
-    || DEMO_RELYING_PARTIES[0];
+export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({ onRunScenario }) => {
+  const [selectedPartyId, setSelectedPartyId] = useState(DEFAULT_SCENARIO_CONFIG.relyingParty.id);
+  const [user, setUser] = useState<DemoUserIdentifiers>(DEFAULT_SCENARIO_CONFIG.user);
+  const [operations, setOperations] = useState<ScenarioOperations>(DEFAULT_SCENARIO_CONFIG.operations);
 
-  // Handle form submission
+  const selectedParty: RelyingParty =
+    DEMO_RELYING_PARTIES.find((p) => p.id === selectedPartyId) || DEMO_RELYING_PARTIES[0];
+
   const handleRun = () => {
-    const config: A2AScenarioConfig = {
+    onRunScenario({
       relyingParty: selectedParty,
       user,
       operations,
-    };
-    onRunScenario(config);
+    });
   };
 
-  // Check if at least one operation is selected
-  const hasOperation = operations.verifyKycStatus || 
-    operations.confirmKeyMatch || 
-    operations.exportKycProfile;
+  const hasOperation =
+    operations.verifyKycStatus || operations.confirmKeyMatch || operations.exportKycProfile;
+
+  const opRow = (
+    checked: boolean,
+    onChange: (v: boolean) => void,
+    title: string,
+    subtitle: string
+  ) => (
+    <label className="flex items-start gap-3 cursor-pointer group rounded-2xl border border-gray-200 bg-white p-4 hover:border-gray-300 transition-colors">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-1 h-4 w-4 rounded border-gray-300 text-black focus:ring-hushh-blue"
+      />
+      <span className="min-w-0">
+        <span className="block text-[13px] font-medium text-black">{title}</span>
+        <span className="block text-[11px] text-gray-500 font-light mt-0.5 leading-relaxed">{subtitle}</span>
+      </span>
+    </label>
+  );
 
   return (
-    <Box
-      minH="100vh"
-      bg="white"
-      py={8}
-    >
-      <Container maxW="lg">
-        {/* Header */}
-        <VStack spacing={2} mb={8} textAlign="center">
-          <Badge
-            colorScheme="purple"
-            px={3}
-            py={1}
-            borderRadius="full"
-            fontSize="xs"
-          >
-            A2A PROTOCOL DEMO
-          </Badge>
-          <Text
-            fontSize={{ base: '2xl', md: '3xl' }}
-            fontWeight="600"
-            color="black"
-          >
-            Agent-to-Agent KYC Playground
-          </Text>
-          <Text color="gray.600" fontSize="sm" maxW="md">
-            Watch Bank KYC Copilot and Hushh KYC Agent collaborate 
-            in real-time to verify identity and export KYC data.
-          </Text>
-        </VStack>
-
-        {/* Main Form Card */}
-        <Box
-          bg="gray.50"
-          border="1px solid"
-          borderColor="gray.200"
-          borderRadius="2xl"
-          p={6}
-          boxShadow="sm"
+    <div className="w-full bg-white py-8 lg:py-12 px-4 sm:px-6 lg:px-40">
+      <div className="mb-10 lg:mb-14">
+        <div className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-hushh-blue/20 rounded-full bg-hushh-blue/5 mb-5">
+          <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
+          <span className="text-[10px] tracking-[0.15em] uppercase font-medium text-hushh-blue">
+            A2A Protocol Demo
+          </span>
+        </div>
+        <h1
+          className="text-[2.5rem] leading-[1.1] font-normal text-black tracking-tight lg:text-[3.5rem]"
+          style={playfair}
         >
-          <VStack spacing={6} align="stretch">
-            {/* Section 1: Relying Party */}
-            <Box>
-              <Text
-                fontSize="sm"
-                fontWeight="600"
-                color="purple.600"
-                mb={3}
-                textTransform="uppercase"
-                letterSpacing="wide"
+          Agent-to-Agent <br />
+          <span className="text-gray-400 italic font-light">KYC Playground.</span>
+        </h1>
+        <p className="text-gray-500 text-sm font-light mt-4 leading-relaxed max-w-lg">
+          Watch Bank KYC Copilot and Hushh KYC Agent collaborate in real-time to verify identity and export KYC data.
+        </p>
+      </div>
+
+      <div className="rounded-3xl border border-gray-200/80 bg-gradient-to-b from-white to-[#F5F5F7] p-5 md:p-8 lg:p-10 shadow-sm">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12">
+          <div className="space-y-8">
+            <section>
+              <p className={sectionLabel}>1. Choose Relying Party</p>
+              <label className="block text-[11px] text-gray-500 font-medium mb-2">Bank or Financial Institution</label>
+              <select
+                value={selectedPartyId}
+                onChange={(e) => setSelectedPartyId(e.target.value)}
+                className={inputClass}
               >
-                1. Choose Relying Party
-              </Text>
-              
-              <FormControl>
-                <FormLabel color="gray.700" fontSize="sm">
-                  Bank or Financial Institution
-                </FormLabel>
-                <Select
-                  value={selectedPartyId}
-                  onChange={(e) => setSelectedPartyId(e.target.value)}
-                  bg="white"
-                  border="1px solid"
-                  borderColor="gray.300"
-                  color="black"
-                  _hover={{ borderColor: 'purple.500' }}
-                  _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
-                >
-                  {DEMO_RELYING_PARTIES.map((party) => (
-                    <option 
-                      key={party.id} 
-                      value={party.id}
-                    >
-                      {party.name} {party.description ? `– ${party.description}` : ''}
-                    </option>
-                  ))}
-                </Select>
-              </FormControl>
-            </Box>
+                {DEMO_RELYING_PARTIES.map((party) => (
+                  <option key={party.id} value={party.id}>
+                    {party.name}
+                    {party.description ? ` – ${party.description}` : ''}
+                  </option>
+                ))}
+              </select>
+            </section>
 
-            <Divider borderColor="gray.200" />
+            <div className="h-px bg-gray-200/80" />
 
-            {/* Section 2: User to Verify */}
-            <Box>
-              <Text
-                fontSize="sm"
-                fontWeight="600"
-                color="purple.600"
-                mb={3}
-                textTransform="uppercase"
-                letterSpacing="wide"
-              >
-                2. User to Verify
-              </Text>
-
-              <VStack spacing={4}>
-                {/* Full Name */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Full Name
-                  </FormLabel>
-                  <Input
+            <section>
+              <p className={sectionLabel}>2. User to Verify</p>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-[11px] text-gray-500 font-medium mb-2">Full Name</label>
+                  <input
+                    className={inputClass}
                     value={user.fullName}
                     onChange={(e) => setUser({ ...user, fullName: e.target.value })}
                     placeholder="Enter full name"
-                    bg="white"
-                    border="1px solid"
-                    borderColor="gray.300"
-                    color="black"
-                    _placeholder={{ color: 'gray.400' }}
-                    _hover={{ borderColor: 'purple.500' }}
-                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                   />
-                </FormControl>
-
-                {/* Phone */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Phone Number
-                  </FormLabel>
-                  <HStack>
-                    <Select
+                </div>
+                <div>
+                  <label className="block text-[11px] text-gray-500 font-medium mb-2">Phone Number</label>
+                  <div className="flex flex-col sm:flex-row gap-3">
+                    <select
                       value={user.phoneCountryCode}
                       onChange={(e) => setUser({ ...user, phoneCountryCode: e.target.value })}
-                      bg="white"
-                      border="1px solid"
-                      borderColor="gray.300"
-                      color="black"
-                      w="140px"
-                      _hover={{ borderColor: 'purple.500' }}
-                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
+                      className={`${inputClass} sm:w-36 shrink-0`}
                     >
                       {PHONE_CODES.map((code) => (
-                        <option 
-                          key={code.value} 
-                          value={code.value}
-                        >
+                        <option key={code.value} value={code.value}>
                           {code.label}
                         </option>
                       ))}
-                    </Select>
-                    <Input
+                    </select>
+                    <input
+                      className={inputClass}
                       value={user.phoneNumber}
                       onChange={(e) => setUser({ ...user, phoneNumber: e.target.value })}
                       placeholder="Phone number"
-                      bg="white"
-                      border="1px solid"
-                      borderColor="gray.300"
-                      color="black"
-                      _placeholder={{ color: 'gray.400' }}
-                      _hover={{ borderColor: 'purple.500' }}
-                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     />
-                  </HStack>
-                </FormControl>
-
-                {/* Country */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Country
-                  </FormLabel>
-                  <Select
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-[11px] text-gray-500 font-medium mb-2">Country</label>
+                  <select
                     value={user.country}
                     onChange={(e) => setUser({ ...user, country: e.target.value })}
-                    bg="white"
-                    border="1px solid"
-                    borderColor="gray.300"
-                    color="black"
-                    _hover={{ borderColor: 'purple.500' }}
-                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
+                    className={inputClass}
                   >
                     {COUNTRY_OPTIONS.map((country) => (
-                      <option 
-                        key={country.value} 
-                        value={country.value}
-                      >
+                      <option key={country.value} value={country.value}>
                         {country.label}
                       </option>
                     ))}
-                  </Select>
-                </FormControl>
-
-                {/* Email (Optional) */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Email (Optional)
-                  </FormLabel>
-                  <Input
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-[11px] text-gray-500 font-medium mb-2">Email (Optional)</label>
+                  <input
+                    type="email"
+                    className={inputClass}
                     value={user.email || ''}
                     onChange={(e) => setUser({ ...user, email: e.target.value })}
                     placeholder="email@example.com"
-                    type="email"
-                    bg="white"
-                    border="1px solid"
-                    borderColor="gray.300"
-                    color="black"
-                    _placeholder={{ color: 'gray.400' }}
-                    _hover={{ borderColor: 'purple.500' }}
-                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                   />
-                </FormControl>
-
-                {/* SSN Last 4 (for key match demo) */}
+                </div>
                 {operations.confirmKeyMatch && (
-                  <FormControl>
-                    <FormLabel color="gray.700" fontSize="sm">
+                  <div>
+                    <label className="block text-[11px] text-gray-500 font-medium mb-2">
                       SSN Last 4 Digits (for key match demo)
-                    </FormLabel>
-                    <Input
+                    </label>
+                    <input
+                      className={inputClass}
                       value={user.ssnLast4 || ''}
                       onChange={(e) => setUser({ ...user, ssnLast4: e.target.value })}
                       placeholder="1234"
                       maxLength={4}
-                      bg="white"
-                      border="1px solid"
-                      borderColor="gray.300"
-                      color="black"
-                      _placeholder={{ color: 'gray.400' }}
-                      _hover={{ borderColor: 'purple.500' }}
-                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
                     />
-                    <Text fontSize="xs" color="gray.600" mt={1}>
-                      🔒 This is only used to demo VerifyFieldMatch – never shared in clear
-                    </Text>
-                  </FormControl>
+                    <p className="text-[11px] text-gray-500 font-light mt-2">
+                      This is only used to demo VerifyFieldMatch – never shared in clear
+                    </p>
+                  </div>
                 )}
-              </VStack>
-            </Box>
+              </div>
+            </section>
+          </div>
 
-            <Divider borderColor="gray.200" />
+          <div className="space-y-6">
+            <section>
+              <p className={sectionLabel}>3. What should agents do?</p>
+              <div className="space-y-3">
+                {opRow(operations.verifyKycStatus, (v) => setOperations({ ...operations, verifyKycStatus: v }), 'Verify KYC Status', 'CheckKYCStatus – Is this user verified?')}
+                {opRow(operations.confirmKeyMatch, (v) => setOperations({ ...operations, confirmKeyMatch: v }), 'Confirm Key Match', 'VerifyFieldMatch – Does SSN last4 match?')}
+                {opRow(operations.exportKycProfile, (v) => setOperations({ ...operations, exportKycProfile: v }), 'Export KYC Profile', 'ExportKYCProfile – Get normalized JSON profile')}
+              </div>
+            </section>
 
-            {/* Section 3: Operations */}
-            <Box>
-              <Text
-                fontSize="sm"
-                fontWeight="600"
-                color="purple.600"
-                mb={3}
-                textTransform="uppercase"
-                letterSpacing="wide"
-              >
-                3. What should agents do?
-              </Text>
+            <HushhTechCta variant={HushhTechCtaVariant.BLACK} onClick={handleRun} disabled={!user.fullName || !hasOperation}>
+              <span>Run A2A KYC Scenario</span>
+              <span className="material-symbols-outlined thin-icon text-lg">arrow_forward</span>
+            </HushhTechCta>
 
-              <VStack align="stretch" spacing={3}>
-                <Checkbox
-                  isChecked={operations.verifyKycStatus}
-                  onChange={(e) => setOperations({ 
-                    ...operations, 
-                    verifyKycStatus: e.target.checked 
-                  })}
-                  colorScheme="purple"
-                  size="lg"
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text color="black" fontSize="sm" fontWeight="500">
-                      Verify KYC Status
-                    </Text>
-                    <Text color="gray.600" fontSize="xs">
-                      CheckKYCStatus – Is this user verified?
-                    </Text>
-                  </VStack>
-                </Checkbox>
+            <p className="text-[11px] text-gray-500 font-light text-center lg:text-left leading-relaxed">
+              This will simulate a real A2A conversation between {selectedParty.name} and Hushh KYC Agent.
+            </p>
+          </div>
+        </div>
+      </div>
 
-                <Checkbox
-                  isChecked={operations.confirmKeyMatch}
-                  onChange={(e) => setOperations({ 
-                    ...operations, 
-                    confirmKeyMatch: e.target.checked 
-                  })}
-                  colorScheme="purple"
-                  size="lg"
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text color="black" fontSize="sm" fontWeight="500">
-                      Confirm Key Match
-                    </Text>
-                    <Text color="gray.600" fontSize="xs">
-                      VerifyFieldMatch – Does SSN last4 match?
-                    </Text>
-                  </VStack>
-                </Checkbox>
-
-                <Checkbox
-                  isChecked={operations.exportKycProfile}
-                  onChange={(e) => setOperations({ 
-                    ...operations, 
-                    exportKycProfile: e.target.checked 
-                  })}
-                  colorScheme="purple"
-                  size="lg"
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text color="black" fontSize="sm" fontWeight="500">
-                      Export KYC Profile
-                    </Text>
-                    <Text color="gray.600" fontSize="xs">
-                      ExportKYCProfile – Get normalized JSON profile
-                    </Text>
-                  </VStack>
-                </Checkbox>
-              </VStack>
-            </Box>
-
-            <Divider borderColor="gray.200" />
-
-            {/* Run Button */}
-            <Button
-              size="lg"
-              colorScheme="purple"
-              onClick={handleRun}
-              isDisabled={!user.fullName || !hasOperation}
-              w="100%"
-              h="56px"
-              fontSize="md"
-              fontWeight="600"
-              _hover={{
-                transform: 'translateY(-2px)',
-                boxShadow: '0 8px 25px rgba(159, 122, 234, 0.4)',
-              }}
-              transition="all 0.2s"
-            >
-              🚀 Run A2A KYC Scenario
-            </Button>
-
-            {/* Help Text */}
-            <Text 
-              fontSize="xs" 
-              color="gray.600" 
-              textAlign="center"
-            >
-              This will simulate a real A2A conversation between {selectedParty.name} 
-              and Hushh KYC Agent.
-            </Text>
-          </VStack>
-        </Box>
-
-        {/* Footer */}
-        <Text 
-          fontSize="xs" 
-          color="gray.500" 
-          textAlign="center" 
-          mt={6}
-        >
-          A2A Protocol Demo • Hushh KYC Network • ADFW 2025
-        </Text>
-      </Container>
-    </Box>
+      <p className="text-[11px] text-gray-400 text-center font-light mt-10">A2A Protocol Demo • Hushh KYC Network • ADFW 2025</p>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary

- what changed: Updated `src/components/a2aPlayground/A2AScenarioSetupScreen.tsx` to align the A2A playground setup experience with the broader Hushh website design system and UI language. Redesigned the screen with responsive spacing, Playfair Display typography, rounded gradient-backed card sections, standardized form input styling, and improved visual hierarchy throughout the scenario configuration flow. Added structured section labeling, responsive form layouts for user details and phone number inputs, modernized operation selection cards with hover states, and updated CTA styling using shared `HushhTechCta` components.
- why it changed: To create a more cohesive and polished A2A demo experience that visually matches the rest of the Hushh platform while improving readability, responsiveness, and interaction consistency across desktop and mobile devices.
- linked issue: `none - UI consistency and design-system alignment update`
- acceptance criteria covered: A2A scenario setup screen visually matches the Hushh website theme, form controls and CTA styling are consistent with shared design-system components, responsive layouts render correctly across breakpoints, operation selection cards display clean hover/focus behavior, and existing scenario setup functionality remains operational.
- risk area touched: `ui`
- reviewer focus: Verify responsive layout behavior across mobile and desktop breakpoints; confirm all form fields, dropdowns, and operation selectors render correctly with consistent spacing/styling; validate CTA/button behavior and disabled state logic; ensure scenario execution flow and conditional SSN field rendering continue functioning correctly.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: Manually reviewed the updated A2A Scenario Setup screen across mobile and desktop breakpoints; verified responsive layout alignment, form input styling, section hierarchy, operation selection card interactions, CTA rendering, disabled-state behavior, and conditional SSN field visibility within `src/components/a2aPlayground/A2AScenarioSetupScreen.tsx`.
- did not run: `npm run test`, `npx tsc --noEmit`, `npm run build:web`, `npm run env:check`, and `npm run lint:ci` were not executed locally in this chat environment and are expected to run in CI; security checks were not applicable because no auth, infrastructure, deployment, or secret-management paths were modified.
- reviewer should verify: Open the A2A playground setup screen and confirm visual consistency with the Hushh website theme; validate responsive spacing and two-column layout behavior at `lg/xl` breakpoints; ensure operation selection cards and CTA interactions behave correctly; verify conditional SSN field rendering when “Confirm Key Match” is enabled; confirm scenario execution flow still works as expected.

## Notes

- deployment impact: None expected beyond a standard frontend rebuild; no backend APIs, routing logic, deployment configuration, or data models were modified.
- migration or env requirements: None. No environment variables, schema migrations, infrastructure updates, or route registrations are required.
- rollback or release notes: Safe rollback by reverting changes in `src/components/a2aPlayground/A2AScenarioSetupScreen.tsx` to restore the previous A2A setup screen layout and styling.
- follow-up work if any: Consider extracting the shared form section and operation-card styling into reusable design-system primitives for consistency across future onboarding/demo flows.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI maintainers responsible for `src/components/**`, A2A playground surfaces, and shared design-system consistency.

## Demo : Updated UI Glimpse 
- Before : 
<img width="1470" height="837" alt="Screenshot 2026-05-09 at 7 21 12 AM" src="https://github.com/user-attachments/assets/e6f74096-6dea-4c51-b750-6bf25c079037" />

- After : 
<img width="1470" height="836" alt="Screenshot 2026-05-09 at 7 16 44 AM" src="https://github.com/user-attachments/assets/58c57067-7779-4490-a273-6c787c537b36" />
<img width="1470" height="836" alt="Screenshot 2026-05-09 at 7 17 02 AM" src="https://github.com/user-attachments/assets/5998ea37-7366-4a3f-89c0-b29257ae95e2" />
