### PR TITLE
fix(accessibility): improve keyboard visibility for payment modal clo…

### DIFF
--- a/src/components/ChatPaymentModal.tsx
+++ b/src/components/ChatPaymentModal.tsx
@@ -32,7 +32,10 @@ export function ChatPaymentModal({ isOpen, onClose, onPayment, isProcessing = fa
     <Modal isOpen={isOpen} onClose={onClose} size="md" isCentered>
       <ModalOverlay backdropFilter="blur(4px)" />
       <ModalContent borderRadius="16px" mx={4}>
-        <ModalCloseButton />
+        <ModalCloseButton
+          aria-label="Close payment modal"
+        className="focus-visible:ring-2 focus-visible:ring-offset-2"
+        />
         <ModalHeader pt={6} pb={2}>
           <HStack spacing={2}>
             <Icon as={MessageCircle} boxSize={6} color="blue.500" />

--- a/src/components/ChatPaymentModal.tsx
+++ b/src/components/ChatPaymentModal.tsx
@@ -34,7 +34,10 @@ export function ChatPaymentModal({ isOpen, onClose, onPayment, isProcessing = fa
       <ModalContent borderRadius="16px" mx={4}>
         <ModalCloseButton
           aria-label="Close payment modal"
-        className="focus-visible:ring-2 focus-visible:ring-offset-2"
+          _focusVisible={{
+            boxShadow: "0 0 0 2px var(--chakra-colors-blue-500)",
+            outline: "none",
+          }}
         />
         <ModalHeader pt={6} pb={2}>
           <HStack spacing={2}>

--- a/tests/chatPaymentModalA11y.test.ts
+++ b/tests/chatPaymentModalA11y.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { ChakraProvider } from "@chakra-ui/react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatPaymentModal } from "../src/components/ChatPaymentModal";
+
+describe("ChatPaymentModal accessibility", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes a named close button without changing payment actions", async () => {
+    const onClose = vi.fn();
+    const onPayment = vi.fn();
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          ChakraProvider,
+          null,
+          React.createElement(ChatPaymentModal, {
+            isOpen: true,
+            onClose,
+            onPayment,
+          }),
+        ),
+      );
+    });
+
+    const closeButton = document.querySelector(
+      'button[aria-label="Close payment modal"]',
+    ) as HTMLButtonElement | null;
+    const paymentButton = Array.from(document.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Pay $1 with Stripe"),
+    );
+
+    expect(closeButton).not.toBeNull();
+    expect(paymentButton).not.toBeNull();
+
+    await act(async () => {
+      closeButton?.click();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onPayment).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: added an explicit accessible name and Chakra-native focus-visible styling to the `ChatPaymentModal` close button, plus a focused regression test for the close/payment actions.
- why it changed: keyboard and screen-reader users need a clearly named modal close control with visible focus feedback, especially inside payment-adjacent UI.
- linked issue: none - standalone payment modal accessibility improvement.
- acceptance criteria covered: the close button is named `Close payment modal`, focus styling is implemented through Chakra props, the payment action remains separate, and the modal close action still calls `onClose` only.
- risk area touched: ui
- reviewer focus: verify the payment modal close button remains visually consistent, receives visible keyboard focus, and does not change payment flow behavior.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [x] `npx vitest run tests/chatPaymentModalA11y.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run env:check`
- [x] `npm run lint:ci`
- [x] `npm run ux:guard` equivalent via enforced UI/UX guard script
- [ ] `npm run build:web`
- [x] security checks when secrets, auth, infra, or deploy paths changed: not applicable because this is UI-only and touches no secret/auth/API/env/deploy surface.

- ran: `npx vitest run tests/chatPaymentModalA11y.test.ts`, `npx tsc --noEmit`, `npm run env:check`, `npm run lint:ci`, `UI_UX_GUARD_MODE=enforced UI_UX_GUARD_BASE=origin/main UI_UX_GUARD_REPORT_PATH=tmp/ci/ui-ux-guard-report.json node scripts/ci/check-ui-ux-guard.mjs`.
- did not run: `npm run build:web` locally for the maintainer patch; PR Validation / merge queue will run build freshness before merge.
- reviewer should verify: keyboard tab focus visibly reaches the payment modal close button and existing payment actions remain unchanged.

## Notes

- deployment impact: none beyond normal frontend release.
- migration or env requirements: none.
- rollback or release notes: revert the modal close button accessibility/focus patch if a visual regression appears.
- follow-up work if any: audit other modal close buttons for the same accessible naming/focus pattern.
- reviewer callouts or CODEOWNERS you expect to review this: frontend/ui maintainers.
