### PR TITLE
feat(ui): add dark/light theme toggle to navbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14255,9 +14255,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,8 +1,23 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
-import { FiMenu, FiX, FiChevronDown, FiUser, FiTrash2, FiChevronDown as FiArrowDown } from "react-icons/fi";
-import { useTranslation } from "react-i18next";
-import { Image, useToast, useBreakpointValue, useDisclosure } from "@chakra-ui/react";
+import { 
+  FiMenu, 
+  FiX, 
+  FiChevronDown, 
+  FiUser, 
+  FiTrash2, 
+  FiMoon, 
+  FiSun,
+  FiChevronDown as FiArrowDown 
+} from "react-icons/fi";import { useTranslation } from "react-i18next";
+import { 
+  Image, 
+  useToast, 
+  useBreakpointValue, 
+  useDisclosure,
+  IconButton,
+  useColorMode
+} from "@chakra-ui/react";
 import hushhLogo from "../components/images/Hushhogo.png";
 import LanguageSwitcher from "./LanguageSwitcher";
 import DeleteAccountModal from "./DeleteAccountModal";
@@ -48,6 +63,7 @@ const TickerChip = ({ quote, isLoading }: { quote: StockQuote; isLoading?: boole
 
 export default function Navbar() {
   const { t, i18n } = useTranslation();
+  const { colorMode, toggleColorMode } = useColorMode();
   const [isOpen, setIsOpen] = useState(false);
   const [toastShown, setToastShown] = useState(false);
   const previousUserIdRef = useRef<string | null>(null);
@@ -257,6 +273,13 @@ export default function Navbar() {
           <div className="flex items-center gap-3">
             {/* Language Selector */}
             <LanguageSwitcher variant="light" />
+            <IconButton
+  aria-label="Toggle theme"
+  icon={colorMode === "light" ? <FiMoon /> : <FiSun />}
+  onClick={toggleColorMode}
+  variant="ghost"
+  size="md"
+/>
 
             {/* Desktop Utility Actions */}
             {isDesktop && (


### PR DESCRIPTION
## Summary

what changed: Added a dark/light theme toggle button to the Navbar using Chakra UI color mode support. Added dynamic Sun/Moon icon rendering based on the active theme.

why it changed: Users previously had no visible way to switch between dark and light themes. This improves accessibility and overall user experience.

linked issue: Ticket #1137 — Add dark/light theme toggle to Navbar

acceptance criteria covered: Theme toggle button appears in the Navbar. Users can switch between dark and light themes. Theme updates correctly when clicked.

risk area touched: ui

reviewer focus: Verify the Navbar theme toggle switches correctly between dark and light themes and displays the correct icon for each mode.

## Validation

ran: Ran local development server using npm run dev. Verified Navbar rendering after changes. Tested theme toggle functionality manually.

did not run: none

reviewer should verify: Open the application and verify the theme toggle button changes the UI correctly between light and dark themes.

## Notes

- Used Chakra UI built-in useColorMode functionality.
- No external libraries were added.