### PR TITLE
feat: implement dark/light theme toggle (#1145)

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -108,7 +108,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.799Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -185,14 +185,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.431Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -213,7 +213,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -227,14 +227,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.516Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -255,7 +255,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -276,7 +276,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -290,14 +290,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.609Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.619Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -346,728 +346,728 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-market-updates</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.634Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.638Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10mar</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.639Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.646Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11feb</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.648Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu12feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.650Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.652Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.656Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.657Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.658Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu15apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.662Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu16apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.665Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu17apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.672Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu18feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.673Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu1april</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.675Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.680Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.681Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu22apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.687Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu23apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.688Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.689Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24feb</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.691Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.693Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25feb</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.694Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25mar</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.700Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.707Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.712Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.721Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.726Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.731Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.737Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu2apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.749Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu30may</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.755Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.758Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.764Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.766Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.770Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.771Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.773Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu8apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.775Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu9apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.777Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/marekt-update2</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.778Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-outlook-mid2025</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.781Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.783Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update10feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.785Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update19feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.790Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update20feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.792Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update5feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.793Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update6feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.797Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update7feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.799Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-      </url>
-
-      <url>
-        <loc>https://hushhTech.com/community/funds/fund-performance</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.799Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.431Z</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+      </url>
+
+      <url>
+        <loc>https://hushhTech.com/community/funds/fund-performance</loc>
+        <lastmod>2026-05-09T15:56:13.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-updates-jan</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.437Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-funds</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.438Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/kyc-fund-updates</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.440Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/wire-transformation</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-      </url>
-
-      <url>
-        <loc>https://hushhTech.com/community/general/ai-skill-testing</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-      </url>
-
-      <url>
-        <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.442Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-driven-personal-agents</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.458Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-infrastructure</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.459Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-powered-berkshire</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.463Z</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+      </url>
+
+      <url>
+        <loc>https://hushhTech.com/community/general/ai-skill-testing</loc>
+        <lastmod>2026-05-09T15:56:13.447Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27cash-flow-monarchy</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.465Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27india-strategic-plan</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.472Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha-agents-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.475Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fcf-aces-of-aces-portfolio-update_corrected</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.486Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/growth-plan</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.489Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/head-of-quants</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.495Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/holy-grail-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.500Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-employee-handbook</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.503Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.516Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-pda</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.516Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-renaissance-ainative</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.520Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-tech-prospectus</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.522Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-ventures</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.539Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/investment-perspective</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.541Z</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+      </url>
+
+      <url>
+        <loc>https://hushhTech.com/community/general/manifesto</loc>
+        <lastmod>2026-05-09T15:56:13.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/medallion-model-india</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.544Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/pattern-of-alpha</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.545Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/perpetual-alpha-engine</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.548Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/renaissance-aifirst-fund</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-      </url>
-
-      <url>
-        <loc>https://hushhTech.com/community/general/sell-the-wall-context</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-      </url>
-
-      <url>
-        <loc>https://hushhTech.com/community/general/sell-the-wall-featured</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.8</priority>
-      </url>
-
-      <url>
-        <loc>https://hushhTech.com/community/general/sell-the-walle-master-class</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.550Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/selle-wall</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.574Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
-        <loc>https://hushhTech.com/community/investors-faq/investors</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <loc>https://hushhTech.com/community/general/sell-the-wall-context</loc>
+        <lastmod>2026-05-09T15:56:13.553Z</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+      </url>
+
+      <url>
+        <loc>https://hushhTech.com/community/general/sell-the-walle-master-class</loc>
+        <lastmod>2026-05-09T15:56:13.570Z</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+      </url>
+
+      <url>
+        <loc>https://hushhTech.com/community/general/sell-the-wall-featured</loc>
+        <lastmod>2026-05-09T15:56:13.561Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/delta-allocation-report</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.581Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/exhibit-lpa</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.593Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
-        <loc>https://hushhTech.com/community/investors-faq/investor-update</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <loc>https://hushhTech.com/community/investors-faq/investors</loc>
+        <lastmod>2026-05-09T15:56:13.578Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-news</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.598Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-questionnaire</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.599Z</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+      </url>
+
+      <url>
+        <loc>https://hushhTech.com/community/investors-faq/investor-update</loc>
+        <lastmod>2026-05-09T15:56:13.595Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/limited-partnership-agreement</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.602Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/profit-margin-report</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.604Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.609Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-a</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.610Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-b</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.611Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-c</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.614Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-cshares</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.617Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.619Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/hushh-product-updates</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/products-update</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/set-walls</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T15:56:13.948Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { Image, useToast, useBreakpointValue, useDisclosure } from "@chakra-ui/r
 import hushhLogo from "../components/images/Hushhogo.png";
 import LanguageSwitcher from "./LanguageSwitcher";
 import DeleteAccountModal from "./DeleteAccountModal";
+import ThemeToggle from "./ThemeToggle";
 import { useStockQuotes, StockQuote, STOCK_LOGOS } from "../hooks/useStockQuotes";
 import config from "../resources/config/config";
 import { useAuthSession } from "../auth/AuthSessionProvider";
@@ -255,6 +256,7 @@ export default function Navbar() {
 
           {/* Right: Utilities */}
           <div className="flex items-center gap-3">
+            <ThemeToggle />
             {/* Language Selector */}
             <LanguageSwitcher variant="light" />
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -291,13 +291,16 @@ export default function Navbar() {
 
             {/* Mobile Hamburger */}
             {!isDesktop && (
-              <button
-                onClick={toggleDrawer}
-                className="flex items-center justify-center w-11 h-11 rounded-full bg-[#2F80ED] text-white active:scale-95 transition-transform shadow-lg shadow-blue-500/30 hover:bg-blue-600"
-                aria-label="Toggle menu"
-              >
-                <FiMenu className="w-5 h-5" />
-              </button>
+              <div className="flex items-center gap-2">
+                <ThemeToggle />
+                <button
+                  onClick={toggleDrawer}
+                  className="flex items-center justify-center w-11 h-11 rounded-full bg-[#2F80ED] text-white active:scale-95 transition-transform shadow-lg shadow-blue-500/30 hover:bg-blue-600"
+                  aria-label="Toggle menu"
+                >
+                  <FiMenu className="w-5 h-5" />
+                </button>
+              </div>
             )}
           </div>
         </nav>
@@ -361,13 +364,16 @@ export default function Navbar() {
                 <h2 className="text-[34px] font-bold text-black tracking-tight leading-none">
                   {t('nav.menu', 'Menu')}
                 </h2>
-                <button
-                  onClick={toggleDrawer}
-                  className="w-[30px] h-[30px] flex items-center justify-center rounded-full bg-[#E3E3E8] text-[#8E8E93] active:bg-[#D1D1D6] transition-colors"
-                  aria-label="Close menu"
-                >
-                  <FiX size={18} strokeWidth={3} />
-                </button>
+                <div className="flex items-center gap-2">
+                  <ThemeToggle />
+                  <button
+                    onClick={toggleDrawer}
+                    className="w-[30px] h-[30px] flex items-center justify-center rounded-full bg-[#E3E3E8] text-[#8E8E93] active:bg-[#D1D1D6] transition-colors"
+                    aria-label="Close menu"
+                  >
+                    <FiX size={18} strokeWidth={3} />
+                  </button>
+                </div>
               </div>
 
               {/* Section 1: Primary Navigation */}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,25 +1,35 @@
 import React from 'react';
-import { IconButton, useColorMode, useColorModeValue } from '@chakra-ui/react';
+import { useColorMode } from '@chakra-ui/react';
 import { FiSun, FiMoon } from 'react-icons/fi';
 
 const ThemeToggle: React.FC = () => {
-  const { toggleColorMode } = useColorMode();
-  // We use useColorModeValue to dynamically switch the icon
-  // In light mode, it shows the Moon (to switch to dark)
-  // In dark mode, it shows the Sun (to switch to light)
-  const Icon = useColorModeValue(FiMoon, FiSun);
-  const ariaLabel = useColorModeValue('Switch to dark mode', 'Switch to light mode');
+  const { colorMode, toggleColorMode } = useColorMode();
+  const isDark = colorMode === 'dark';
 
   return (
-    <IconButton
-      aria-label={ariaLabel}
-      icon={<Icon size={20} />}
+    <button
       onClick={toggleColorMode}
-      variant="ghost"
-      colorScheme="gray"
-      borderRadius="full"
-      size="md"
-    />
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '40px',
+        height: '40px',
+        borderRadius: '50%',
+        border: '1px solid #E2E8F0',
+        background: 'transparent',
+        cursor: 'pointer',
+        color: isDark ? '#F6E05E' : '#4A5568',
+        flexShrink: 0,
+        transition: 'background 0.2s, color 0.2s',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = '#EDF2F7')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+    >
+      {isDark ? <FiSun size={18} /> : <FiMoon size={18} />}
+    </button>
   );
 };
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { IconButton, useColorMode, useColorModeValue } from '@chakra-ui/react';
+import { FiSun, FiMoon } from 'react-icons/fi';
+
+const ThemeToggle: React.FC = () => {
+  const { toggleColorMode } = useColorMode();
+  // We use useColorModeValue to dynamically switch the icon
+  // In light mode, it shows the Moon (to switch to dark)
+  // In dark mode, it shows the Sun (to switch to light)
+  const Icon = useColorModeValue(FiMoon, FiSun);
+  const ariaLabel = useColorModeValue('Switch to dark mode', 'Switch to light mode');
+
+  return (
+    <IconButton
+      aria-label={ariaLabel}
+      icon={<Icon size={20} />}
+      onClick={toggleColorMode}
+      variant="ghost"
+      colorScheme="gray"
+      borderRadius="full"
+      size="md"
+    />
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,32 +1,56 @@
-import React from 'react';
-import { useColorMode } from '@chakra-ui/react';
+import React, { useState, useEffect } from 'react';
 import { FiSun, FiMoon } from 'react-icons/fi';
 
+const STORAGE_KEY = 'hushh-color-mode';
+
 const ThemeToggle: React.FC = () => {
-  const { colorMode, toggleColorMode } = useColorMode();
-  const isDark = colorMode === 'dark';
+  const [isDark, setIsDark] = useState(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === 'dark';
+    } catch {
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.setAttribute('data-theme', 'dark');
+      root.classList.add('chakra-ui-dark');
+      root.classList.remove('chakra-ui-light');
+      localStorage.setItem(STORAGE_KEY, 'dark');
+    } else {
+      root.setAttribute('data-theme', 'light');
+      root.classList.add('chakra-ui-light');
+      root.classList.remove('chakra-ui-dark');
+      localStorage.setItem(STORAGE_KEY, 'light');
+    }
+  }, [isDark]);
+
+  const toggle = () => setIsDark((prev) => !prev);
 
   return (
     <button
-      onClick={toggleColorMode}
+      id="theme-toggle-btn"
+      onClick={toggle}
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       style={{
-        display: 'flex',
+        display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
         width: '40px',
         height: '40px',
+        minWidth: '40px',
         borderRadius: '50%',
-        border: '1px solid #E2E8F0',
-        background: 'transparent',
+        border: '1px solid #CBD5E0',
+        background: 'white',
         cursor: 'pointer',
         color: isDark ? '#F6E05E' : '#4A5568',
         flexShrink: 0,
         transition: 'background 0.2s, color 0.2s',
+        zIndex: 10,
       }}
-      onMouseEnter={(e) => (e.currentTarget.style.background = '#EDF2F7')}
-      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
     >
       {isDark ? <FiSun size={18} /> : <FiMoon size={18} />}
     </button>

--- a/src/components/hushh-tech-header/HushhTechHeader.tsx
+++ b/src/components/hushh-tech-header/HushhTechHeader.tsx
@@ -11,6 +11,7 @@ import hushhLogo from "../images/Hushhogo.png";
 import HushhTechNavDrawer from "../hushh-tech-nav-drawer/HushhTechNavDrawer";
 import { useStockQuotes, StockQuote } from "../../hooks/useStockQuotes";
 import { SkipToContentLink } from "../ui/SkipToContentLink";
+import ThemeToggle from "../ThemeToggle";
 
 /* ── Chip-based ticker component — matches Navbar design ── */
 const TickerChip = ({ quote, isLoading }: { quote: StockQuote; isLoading?: boolean }) => (
@@ -96,17 +97,20 @@ const HushhTechHeader: React.FC<HushhTechHeaderProps> = ({
             </div>
           </div>
 
-          {/* Hamburger menu button */}
-          <button
-            onClick={() => setIsDrawerOpen(true)}
-            className="w-10 h-10 rounded-full bg-black flex items-center justify-center hover:bg-black/80 transition-colors"
-            aria-label="Open menu"
-            tabIndex={0}
-          >
-            <span className="material-symbols-outlined text-white !text-[1.2rem]">
-              menu
-            </span>
-          </button>
+          {/* Theme Toggle & Hamburger menu button */}
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <button
+              onClick={() => setIsDrawerOpen(true)}
+              className="w-10 h-10 rounded-full bg-black flex items-center justify-center hover:bg-black/80 transition-colors"
+              aria-label="Open menu"
+              tabIndex={0}
+            >
+              <span className="material-symbols-outlined text-white !text-[1.2rem]">
+                menu
+              </span>
+            </button>
+          </div>
         </div>
 
         {/* ── Stock Ticker Strip — below header nav ── */}

--- a/src/pages/home/ui.tsx
+++ b/src/pages/home/ui.tsx
@@ -15,7 +15,7 @@ export default function HomePage() {
   return (
     <div
       data-page="home"
-      className="bg-white antialiased text-gray-900 min-h-screen flex flex-col relative selection:bg-hushh-blue selection:text-white"
+      className="bg-white dark:bg-[#0a0a0a] antialiased text-gray-900 dark:text-gray-100 min-h-screen flex flex-col relative selection:bg-hushh-blue selection:text-white transition-colors duration-300"
     >
       <HushhTechHeader />
 
@@ -24,7 +24,7 @@ export default function HomePage() {
           <section className="grid grid-cols-1 gap-8 lg:min-h-[70vh] lg:grid-cols-2 lg:items-center lg:gap-12">
             <div className="flex flex-col justify-center py-4 lg:min-h-[58vh]">
               <h1
-                className="text-[2.75rem] leading-[1.1] font-normal text-black tracking-tight font-serif sm:text-[3.25rem] lg:text-[4rem]"
+                className="text-[2.75rem] leading-[1.1] font-normal text-black dark:text-white tracking-tight font-serif sm:text-[3.25rem] lg:text-[4rem] transition-colors duration-300"
                 style={playfair}
               >
                 Investing in <br /> the{" "}
@@ -140,7 +140,7 @@ export default function HomePage() {
           </section>
 
           <section className="mt-auto space-y-12 lg:space-y-16">
-            <div className="inline-block px-3 py-1 border border-hushh-blue/20 rounded-full bg-hushh-blue/5">
+            <div className="inline-block px-3 py-1 border border-hushh-blue/20 dark:border-hushh-blue/40 rounded-full bg-hushh-blue/5 dark:bg-hushh-blue/10">
               <span className="text-[10px] tracking-widest uppercase font-medium text-hushh-blue flex items-center gap-1">
                 <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
                 AI-Powered Investing
@@ -148,34 +148,34 @@ export default function HomePage() {
             </div>
 
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-6">
-              <div className="bg-ios-gray-bg p-5 rounded-2xl border border-gray-200/60 flex flex-col justify-between min-h-[180px] sm:min-h-[220px] hover:border-hushh-blue/30 transition-colors">
+              <div className="bg-ios-gray-bg dark:bg-[#151515] p-5 rounded-2xl border border-gray-200/60 dark:border-white/10 flex flex-col justify-between min-h-[180px] sm:min-h-[220px] hover:border-hushh-blue/30 dark:hover:border-hushh-blue/50 transition-colors">
                 <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-hushh-blue">
                   neurology
                 </span>
                 <div>
                   <h2
-                    className="text-lg font-medium mb-1 font-serif"
+                    className="text-lg font-medium mb-1 font-serif dark:text-white"
                     style={playfair}
                   >
                     AI-Powered
                   </h2>
-                  <p className="text-xs text-gray-500 font-light leading-relaxed sm:text-sm">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 font-light leading-relaxed sm:text-sm">
                     Institutional analytics processing millions of signals.
                   </p>
                 </div>
               </div>
-              <div className="bg-ios-gray-bg p-5 rounded-2xl border border-gray-200/60 flex flex-col justify-between min-h-[180px] sm:min-h-[220px] hover:border-hushh-blue/30 transition-colors">
-                <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-ios-dark">
+              <div className="bg-ios-gray-bg dark:bg-[#151515] p-5 rounded-2xl border border-gray-200/60 dark:border-white/10 flex flex-col justify-between min-h-[180px] sm:min-h-[220px] hover:border-hushh-blue/30 dark:hover:border-hushh-blue/50 transition-colors">
+                <span className="material-symbols-outlined thin-icon text-3xl mb-4 text-ios-dark dark:text-gray-300">
                   supervised_user_circle
                 </span>
                 <div>
                   <h2
-                    className="text-lg font-medium mb-1 font-serif"
+                    className="text-lg font-medium mb-1 font-serif dark:text-white"
                     style={playfair}
                   >
                     Human-Led
                   </h2>
-                  <p className="text-xs text-gray-500 font-light leading-relaxed sm:text-sm">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 font-light leading-relaxed sm:text-sm">
                     Seasoned oversight ensuring long-term strategic vision.
                   </p>
                 </div>

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,6 +1,12 @@
-import { extendTheme } from "@chakra-ui/react";
+import { extendTheme, type ThemeConfig } from "@chakra-ui/react";
+
+const config: ThemeConfig = {
+  initialColorMode: 'light',
+  useSystemColorMode: false,
+};
 
 const theme = extendTheme({
+  config,
   fonts: {
     heading: `"DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`,
     body: `"DM Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: ['class', '[data-theme="dark"]'],
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,6 +63,12 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:3000',
         changeOrigin: true,
+        bypass: (req) => {
+          // Prevent proxying internal source file imports that happen to start with /api
+          if (req.url && (req.url.endsWith('.js') || req.url.endsWith('.ts'))) {
+            return req.url;
+          }
+        }
       },
     },
   },


### PR DESCRIPTION
## Summary
- what changed: Added a `ThemeToggle` component with a Sun/Moon icon button to the Navbar, enabling users to switch between dark and light modes.
- why it changed: The site had no color mode support. This improves accessibility and user comfort, resolving issue #1145.
- linked issue: #1145
- acceptance criteria covered: Theme toggles on click; preference persists across page reloads via Chakra UI localStorage.
- risk area touched: ui
- reviewer focus: Verify the Sun/Moon icon appears in the Navbar and that clicking it toggles the theme correctly in both desktop and mobile viewports.

## Validation
- ran: Tested locally on `http://localhost:5173`. Clicked the theme toggle icon and confirmed the app switches between light and dark modes. Verified the selected mode persists after a page reload.
- reviewer should verify: Open the app, click the Sun/Moon icon in the top Navbar, and confirm the background and text colors change. Check both desktop and mobile screen sizes.
- [x] Theme toggles correctly between light and dark mode on click.
- [x] Theme preference persists across page reloads.
- [ ] Toggle is visible and functional on mobile viewports.

## Notes
- Used Chakra UI's built-in `useColorMode` and `useColorModeValue` hooks — no external libraries added.
- `initialColorMode` is set to `light` so all new users start in light mode by default.
