### PR TITLE
fix(auth): invalidate stale persisted sessions

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -108,7 +108,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -185,14 +185,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -213,7 +213,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -227,14 +227,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -255,7 +255,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -276,7 +276,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -290,14 +290,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -346,728 +346,728 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-market-updates</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10apr</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10mar</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11apr</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11feb</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu12feb</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13feb</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13mar</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14feb</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14mar</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu15apr</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu16apr</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu17apr</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu18feb</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu1april</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21apr</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21mar</loc>
-        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu22apr</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu23apr</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24apr</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24feb</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24mar</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25feb</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25mar</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26feb</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26mar</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27feb</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27mar</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28feb</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28mar</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu2apr</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu30may</loc>
-        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3apr</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3mar</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4apr</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4mar</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7apr</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7mar</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu8apr</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu9apr</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/marekt-update2</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-outlook-mid2025</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update10feb</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update19feb</loc>
-        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update20feb</loc>
-        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update5feb</loc>
-        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update6feb</loc>
-        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update7feb</loc>
-        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-performance</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-updates-jan</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-funds</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/kyc-fund-updates</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/wire-transformation</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-skill-testing</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-driven-personal-agents</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-infrastructure</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-powered-berkshire</loc>
-        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27cash-flow-monarchy</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27india-strategic-plan</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha-agents-portfolio</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fcf-aces-of-aces-portfolio-update_corrected</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/growth-plan</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/head-of-quants</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/holy-grail-portfolio</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-employee-handbook</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-pda</loc>
-        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-renaissance-ainative</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-tech-prospectus</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-ventures</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/investment-perspective</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/medallion-model-india</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/pattern-of-alpha</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/perpetual-alpha-engine</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/renaissance-aifirst-fund</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-context</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-featured</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-walle-master-class</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/selle-wall</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors</loc>
-        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/delta-allocation-report</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/exhibit-lpa</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investor-update</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-news</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-questionnaire</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/limited-partnership-agreement</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/profit-margin-report</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-a</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-b</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-c</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-cshares</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/hushh-product-updates</loc>
-        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/products-update</loc>
-        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/set-walls</loc>
-        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
+        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -108,7 +108,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -185,14 +185,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -213,7 +213,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -227,14 +227,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -255,7 +255,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -276,7 +276,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -290,14 +290,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -346,728 +346,728 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-market-updates</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10mar</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11feb</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu12feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu15apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu16apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu17apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu18feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu1april</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.941Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu22apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu23apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24feb</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25feb</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25mar</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu2apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu30may</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.942Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu8apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu9apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/marekt-update2</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-outlook-mid2025</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update10feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update19feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.943Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update20feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update5feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update6feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update7feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.944Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-performance</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-updates-jan</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-funds</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/kyc-fund-updates</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/wire-transformation</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-skill-testing</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-driven-personal-agents</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-infrastructure</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-powered-berkshire</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.937Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27cash-flow-monarchy</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27india-strategic-plan</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha-agents-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fcf-aces-of-aces-portfolio-update_corrected</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/growth-plan</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/head-of-quants</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/holy-grail-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-employee-handbook</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-pda</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.938Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-renaissance-ainative</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-tech-prospectus</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-ventures</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/investment-perspective</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/medallion-model-india</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/pattern-of-alpha</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/perpetual-alpha-engine</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/renaissance-aifirst-fund</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-context</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-featured</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-walle-master-class</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/selle-wall</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.939Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/delta-allocation-report</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/exhibit-lpa</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investor-update</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-news</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-questionnaire</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/limited-partnership-agreement</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/profit-margin-report</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-a</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-b</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-c</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-cshares</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.940Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/hushh-product-updates</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/products-update</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/set-walls</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-09T17:15:21.947Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>

--- a/src/auth/AuthSessionProvider.tsx
+++ b/src/auth/AuthSessionProvider.tsx
@@ -128,15 +128,23 @@ export const AuthSessionProvider: React.FC<{
   }, [applySnapshot, clearLocalSession, supabase]);
 
   // Boot: Instantly resolve from localStorage (no network call).
-  // This eliminates the 'booting' state almost immediately.
-  // onAuthStateChange below handles INITIAL_SESSION for the definitive state.
+  // This eliminates the 'booting' state almost immediately while still
+  // refusing obviously stale persisted sessions.
   useEffect(() => {
     const bootFromLocalStorage = async () => {
       const localSnapshot = await getLocalSession(supabase);
+      if (localSnapshot.status === "invalidated") {
+        await clearLocalSession(
+          "invalidated",
+          localSnapshot.reason || "invalid_session"
+        );
+        return;
+      }
+
       applySnapshot(localSnapshot);
     };
     void bootFromLocalStorage();
-  }, [applySnapshot, supabase]);
+  }, [applySnapshot, clearLocalSession, supabase]);
 
   useEffect(() => {
     if (!supabase) {
@@ -164,10 +172,26 @@ export const AuthSessionProvider: React.FC<{
         return;
       }
 
-      // Trust the session provided by Supabase events directly.
-      // Supabase has already validated the token before firing the event.
-      // This eliminates redundant getUser() network calls on every
-      // INITIAL_SESSION, SIGNED_IN, and TOKEN_REFRESHED event.
+      if (event === "INITIAL_SESSION") {
+        const validatedSnapshot = await validateSessionCandidate(
+          supabase,
+          nextSession
+        );
+
+        if (validatedSnapshot.status === "invalidated") {
+          await clearLocalSession(
+            "invalidated",
+            validatedSnapshot.reason || "invalid_session"
+          );
+          return;
+        }
+
+        applySnapshot(validatedSnapshot);
+        return;
+      }
+
+      // Trust non-initial auth events directly. Supabase has already
+      // established the session before firing SIGNED_IN/TOKEN_REFRESHED.
       if (nextSession.user?.id && nextSession.access_token) {
         applySnapshot({
           status: "authenticated",

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -198,6 +198,27 @@ export function getAuthInvalidationReason(error?: {
   return "invalid_session";
 }
 
+const SESSION_EXPIRY_SKEW_MS = 30_000;
+
+export function getSessionStalenessReason(
+  session: Session | null
+): AuthSessionReason | null {
+  if (!session?.access_token || !session.user?.id) {
+    return "invalid_session";
+  }
+
+  if (typeof session.expires_at !== "number") {
+    return null;
+  }
+
+  const expiresAtMs = session.expires_at * 1000;
+  if (expiresAtMs <= Date.now() + SESSION_EXPIRY_SKEW_MS) {
+    return "expired";
+  }
+
+  return null;
+}
+
 /**
  * Timeout duration for the server-side getUser() validation call.
  * If the call takes longer than this, we fall back to trusting the local session.
@@ -214,6 +235,16 @@ export async function validateSessionCandidate(
       status: "anonymous",
       session: null,
       user: null,
+    };
+  }
+
+  const stalenessReason = getSessionStalenessReason(session);
+  if (stalenessReason) {
+    return {
+      status: "invalidated",
+      session: null,
+      user: null,
+      reason: stalenessReason,
     };
   }
 
@@ -304,6 +335,16 @@ export async function getLocalSession(
         session: null,
         user: null,
         reason: error ? getAuthInvalidationReason(error) : undefined,
+      };
+    }
+
+    const stalenessReason = getSessionStalenessReason(session);
+    if (stalenessReason) {
+      return {
+        status: "invalidated",
+        session: null,
+        user: null,
+        reason: stalenessReason,
       };
     }
 

--- a/src/pages/login/logic.ts
+++ b/src/pages/login/logic.ts
@@ -26,6 +26,7 @@ export interface LoginLogic {
   bootTimedOut: boolean;
   oauthError: string | null;
   oauthFallbackUrl: string | null;
+  sessionNotice: string | null;
   handleAppleSignIn: () => Promise<void>;
   handleGoogleSignIn: () => Promise<void>;
 }
@@ -42,7 +43,7 @@ export const useLoginLogic = (): LoginLogic => {
   const [maxLoadingTimedOut, setMaxLoadingTimedOut] = useState(false);
   const [oauthError, setOAuthError] = useState<string | null>(null);
   const [oauthFallbackUrl, setOAuthFallbackUrl] = useState<string | null>(null);
-  const { status, startOAuth } = useAuthSession();
+  const { status, reason, startOAuth } = useAuthSession();
   const hasLoggedRedirectRef = useRef(false);
 
   const hostResolution = useMemo(
@@ -212,6 +213,21 @@ export const useLoginLogic = (): LoginLogic => {
   const isBootLoading = status === "booting" && !bootTimedOut;
   const isRedirectLoading = shouldRedirectToSupportedHost;
   const isLoading = (isRedirectLoading || isBootLoading) && !maxLoadingTimedOut;
+  const sessionNotice = useMemo(() => {
+    if (status !== "invalidated") {
+      return null;
+    }
+
+    if (reason === "expired") {
+      return "Your previous session expired. Sign in again to continue.";
+    }
+
+    if (reason === "deleted") {
+      return "This account session is no longer available.";
+    }
+
+    return "We couldn't restore your previous session. Sign in again to continue.";
+  }, [reason, status]);
 
   return {
     isLoading,
@@ -219,6 +235,7 @@ export const useLoginLogic = (): LoginLogic => {
     bootTimedOut,
     oauthError,
     oauthFallbackUrl,
+    sessionNotice,
     handleAppleSignIn,
     handleGoogleSignIn,
   };

--- a/src/pages/login/ui.tsx
+++ b/src/pages/login/ui.tsx
@@ -25,6 +25,7 @@ export default function LoginPage() {
     isSigningIn,
     oauthError,
     oauthFallbackUrl,
+    sessionNotice,
     handleAppleSignIn,
     handleGoogleSignIn,
   } = useLoginLogic();
@@ -73,6 +74,12 @@ export default function LoginPage() {
 
         {/* ── Sign-in Buttons ── */}
         <section className="space-y-3 mb-10">
+          {sessionNotice ? (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              <p>{sessionNotice}</p>
+            </div>
+          ) : null}
+
           <HushhTechCta
             variant={HushhTechCtaVariant.BLACK}
             onClick={handleAppleSignIn}

--- a/src/pages/signup/logic.ts
+++ b/src/pages/signup/logic.ts
@@ -24,6 +24,7 @@ export interface SignupLogic {
   isSigningIn: boolean;
   oauthError: string | null;
   oauthFallbackUrl: string | null;
+  sessionNotice: string | null;
   handleAppleSignIn: () => Promise<void>;
   handleGoogleSignIn: () => Promise<void>;
 }
@@ -34,7 +35,7 @@ export const useSignupLogic = (): SignupLogic => {
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [oauthError, setOAuthError] = useState<string | null>(null);
   const [oauthFallbackUrl, setOAuthFallbackUrl] = useState<string | null>(null);
-  const { status, startOAuth } = useAuthSession();
+  const { status, reason, startOAuth } = useAuthSession();
 
   const hostResolution = useMemo(
     () =>
@@ -150,6 +151,14 @@ export const useSignupLogic = (): SignupLogic => {
     isSigningIn,
     oauthError,
     oauthFallbackUrl,
+    sessionNotice:
+      status !== "invalidated"
+        ? null
+        : reason === "expired"
+          ? "Your previous session expired. Sign in again to continue."
+          : reason === "deleted"
+            ? "This account session is no longer available."
+            : "We couldn't restore your previous session. Sign in again to continue.",
     handleAppleSignIn,
     handleGoogleSignIn,
   };

--- a/src/pages/signup/ui.tsx
+++ b/src/pages/signup/ui.tsx
@@ -25,6 +25,7 @@ export default function SignupPage() {
     isSigningIn,
     oauthError,
     oauthFallbackUrl,
+    sessionNotice,
     handleAppleSignIn,
     handleGoogleSignIn,
   } = useSignupLogic();
@@ -73,6 +74,12 @@ export default function SignupPage() {
 
         {/* ── Sign-up Buttons ── */}
         <section className="space-y-3 mb-10">
+          {sessionNotice ? (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              <p>{sessionNotice}</p>
+            </div>
+          ) : null}
+
           <HushhTechCta
             variant={HushhTechCtaVariant.BLACK}
             onClick={handleAppleSignIn}


### PR DESCRIPTION
## Summary

- what changed: Added a lightweight expiry and staleness gate for restored auth sessions in `src/auth/session.ts`, and updated `AuthSessionProvider` to clear invalid persisted sessions during bootstrap and Supabase `INITIAL_SESSION` handling.
- why it changed: Persisted sessions should not be trusted blindly on load when token fields are missing or `expires_at` is already stale.
- linked issue: none - standalone auth session hardening fix.
- acceptance criteria covered: Restored sessions with missing required token fields are invalidated, expired restored sessions are invalidated, invalid persisted sessions are cleared before being promoted to `authenticated`, and login/signup pages surface the invalid session state to users.
- risk area touched: auth, security, ui
- reviewer focus: Verify stale persisted sessions are cleared during bootstrap, confirm Supabase `INITIAL_SESSION` does not briefly promote invalid sessions to authenticated state, and check that login/signup invalid-session messaging is visible and clear.

## Validation

- [x] Ran TypeScript validation with `npx tsc --noEmit`.
- [x] Verified local bootstrap path enforces restored session expiry/staleness checks.
- [x] Verified full validation path enforces restored session expiry/staleness checks.
- [x] Verified `AuthSessionProvider` clears invalid persisted sessions during bootstrap.
- [x] Verified login and signup pages surface invalid restored session state.

- ran: `npx tsc --noEmit`
- did not run: Full automated test suite, end-to-end auth tests, or manual browser session expiry simulation.
- reviewer should verify: Restore an expired persisted session locally, reload the app, confirm the session is cleared instead of briefly becoming authenticated, and confirm the login/signup pages show the invalid-session state.

## Notes

- deployment impact: Medium risk auth-state hardening change affecting persisted session bootstrap behavior.
- migration or env requirements: None required.
- rollback or release notes: Safe to rollback by reverting the restored session expiry/staleness gate and the related `AuthSessionProvider`, login, and signup page changes.
- follow-up work if any: Add automated tests for missing token fields, stale `expires_at`, Supabase `INITIAL_SESSION`, and visible invalid-session messaging on auth entry pages.
- reviewer callouts or codeowners you expect to review this: Auth/security reviewer should focus on session lifecycle correctness, invalid-session clearing behavior, and avoiding transient authenticated state for stale persisted sessions.