### PR TITLE
feat(ui): align contact page styling with hushh website theme

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -32,7 +32,6 @@ const gray50 = "#F9FAFB";
 const gray100 = "#F3F4F6";
 const gray200 = "#E5E7EB";
 const gray300 = "#D1D5DB";
-const gray400 = "#9CA3AF";
 const gray500 = "#6B7280";
 const gray900 = "#111827";
 
@@ -50,7 +49,7 @@ const fieldChrome = {
   borderColor: gray200,
   bg: gray50,
   color: gray900,
-  _placeholder: { color: gray400 },
+  _placeholder: { color: gray500 },
   _hover: { borderColor: gray300 },
   _focusVisible: inputFocus,
 };
@@ -172,7 +171,7 @@ export default function Contact() {
               as="span"
               fontWeight="300"
               fontStyle="italic"
-              color={gray400}
+              color={gray500}
             >
               Touch
             </Text>
@@ -246,7 +245,7 @@ export default function Contact() {
             <form ref={form} onSubmit={handleSubmit}>
               <VStack spacing={5} align="stretch">
                 <FormControl isRequired>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     Full Name
                   </FormLabel>
                   <Input
@@ -261,7 +260,7 @@ export default function Contact() {
                 </FormControl>
 
                 <FormControl>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     Company
                   </FormLabel>
                   <Input
@@ -276,7 +275,7 @@ export default function Contact() {
                 </FormControl>
 
                 <FormControl isRequired>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     Email Address
                   </FormLabel>
                   <Input
@@ -292,7 +291,7 @@ export default function Contact() {
                 </FormControl>
 
                 <FormControl>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     Phone Number
                   </FormLabel>
                   <Input
@@ -307,7 +306,7 @@ export default function Contact() {
                 </FormControl>
 
                 <FormControl isRequired>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     Reason for Contact
                   </FormLabel>
                   <Select
@@ -328,7 +327,7 @@ export default function Contact() {
                 </FormControl>
 
                 <FormControl isRequired>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     Message
                   </FormLabel>
                   <Textarea
@@ -344,7 +343,7 @@ export default function Contact() {
                 </FormControl>
 
                 <FormControl isRequired>
-                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray500} mb={1.5}>
                     What is the sum of {num1} and {num2}?
                   </FormLabel>
                   <Input

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -19,10 +19,43 @@ import {
   FormControl,
   FormLabel,
   Icon,
-  Flex,
   Link as ChakraLink,
 } from "@chakra-ui/react";
-import { MapPin, Phone, Clock } from "lucide-react";
+import { MapPin, Phone, Clock, ArrowRight } from "lucide-react";
+
+/** Home-aligned serif for headings (Playfair). Body uses global Manrope from `index.css`. */
+const playfair = { fontFamily: "'Playfair Display', serif" };
+
+/** Greys aligned with `home/ui.tsx` Tailwind tokens (gray-*, ios-gray-bg). */
+const iosGrayBg = "#F5F5F7";
+const gray50 = "#F9FAFB";
+const gray100 = "#F3F4F6";
+const gray200 = "#E5E7EB";
+const gray300 = "#D1D5DB";
+const gray400 = "#9CA3AF";
+const gray500 = "#6B7280";
+const gray900 = "#111827";
+
+const pageBg = iosGrayBg;
+const brandBlue = "#0066CC";
+const cardBorder = "rgba(229, 231, 235, 0.6)";
+const inputFocus = {
+  borderColor: brandBlue,
+  boxShadow: `0 0 0 1px ${brandBlue}`,
+};
+
+/** Shared field chrome — matches home gray inputs / ios-gray-bg section. */
+const fieldChrome = {
+  borderRadius: "lg" as const,
+  borderColor: gray200,
+  bg: gray50,
+  color: gray900,
+  _placeholder: { color: gray400 },
+  _hover: { borderColor: gray300 },
+  _focusVisible: inputFocus,
+};
+
+const cardHoverBorder = "rgba(0, 102, 204, 0.3)";
 
 const reasonOptions = [
   "Infrastructure Consultation",
@@ -114,273 +147,381 @@ export default function Contact() {
   };
 
   return (
-    <Container maxW="container.xl" py={12} px={{ base: 4, md: 6 }}>
-      {/* Main Header */}
-      <Box textAlign="center" mb={8}>
-        <Heading 
-          as="h1" 
-          size={{ base: "2xl", md: "3xl" }} 
-          mb={4}
-          letterSpacing="tight"
-          fontWeight="500"
-        >
-          <Text as="span" color="black">Get in </Text>
-          <Text 
-            as="span" 
-            sx={{
-              WebkitBackgroundClip: "text",
-              backgroundClip: "text",
-              color: "transparent",
-              display: "inline",
-              backgroundImage: "linear-gradient(to right, #00A9E0, #6DD3EF)"
-            }}
+    <Box
+      bg={pageBg}
+      w="100%"
+      className="antialiased text-gray-900"
+    >
+      <Container maxW="7xl" py={{ base: 10, md: 14 }} px={{ base: 4, md: 6, lg: 8 }}>
+        {/* Main Header */}
+        <Box textAlign="center" mb={{ base: 8, md: 10 }}>
+          <Heading
+            as="h1"
+            size={{ base: "2xl", md: "3xl" }}
+            mb={4}
+            letterSpacing="tight"
+            lineHeight="1.15"
+            fontWeight="400"
+            color="black"
+            style={playfair}
           >
-            Touch
-          </Text>
-        </Heading>
-        
-        <Text 
-          fontSize={{ base: "md", md: "lg" }} 
-          maxW="3xl" 
-          mx="auto" 
-          color="gray.600"
-        >
-          Ready to transform your investment strategy? We'd love to hear from you.
-        </Text>
-        
-        <Text mt={4} fontSize={{ base: "md", md: "md" }} color="gray.600">
-          For career-related inquiries, please visit our{' '}
-          <ChakraLink
-            href="/career"
-            // target="_blank"
-            rel="noopener noreferrer"
-            color="#0AADBC"
-            fontWeight="medium"
-            _hover={{ textDecoration: 'underline' }}
-          >
-            Jobs page
-          </ChakraLink>. 
-          For all other inquiries, please submit the form below.
-        </Text>
-      </Box>
-
-      {/* Contact Form and Information */}
-      <Grid 
-        templateColumns={{ base: "1fr", md: "1fr 1fr" }} 
-        gap={8} 
-        mt={10}
-        maxW="container.lg"
-        mx="auto"
-      >
-        {/* Contact Form */}
-        <GridItem 
-          as={Box} 
-          p={8} 
-          borderWidth="1px" 
-          borderRadius="lg" 
-          borderColor="gray.200" 
-          bg="white"
-          boxShadow="sm"
-        >
-          <Heading as="h2" size="lg" mb={6}>
-            Send us a Message
-          </Heading>
-          
-          <form ref={form} onSubmit={handleSubmit}>
-            <VStack spacing={4} align="stretch">
-              <FormControl isRequired>
-                <FormLabel fontWeight="medium">Full Name</FormLabel>
-                <Input 
-                  name="name"
-                  placeholder="Enter your full name"
-                  value={formData.name}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                />
-              </FormControl>
-              
-              <FormControl>
-                <FormLabel fontWeight="medium">Company</FormLabel>
-                <Input 
-                  name="company"
-                  placeholder="Enter your company name (optional)"
-                  value={formData.company}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                />
-              </FormControl>
-              
-              <FormControl isRequired>
-                <FormLabel fontWeight="medium">Email Address</FormLabel>
-                <Input 
-                  name="email"
-                  type="email"
-                  placeholder="Enter your email address"
-                  value={formData.email}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                />
-              </FormControl>
-              
-              <FormControl>
-                <FormLabel fontWeight="medium">Phone Number</FormLabel>
-                <Input 
-                  name="phone"
-                  placeholder="Enter your phone number (optional)"
-                  value={formData.phone}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                />
-              </FormControl>
-              
-              <FormControl isRequired>
-                <FormLabel fontWeight="medium">Reason for Contact</FormLabel>
-                <Select 
-                  name="reason"
-                  placeholder="Select a reason"
-                  value={formData.reason}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                >
-                  {reasonOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </Select>
-              </FormControl>
-              
-              <FormControl isRequired>
-                <FormLabel fontWeight="medium">Message</FormLabel>
-                <Textarea 
-                  name="message"
-                  placeholder="Tell us how we can help you..."
-                  value={formData.message}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                  rows={4}
-                />
-              </FormControl>
-              
-              <FormControl isRequired>
-                <FormLabel fontWeight="medium">What is the sum of {num1} and {num2}?</FormLabel>
-                <Input 
-                  name="captcha"
-                  placeholder="Enter the answer"
-                  value={formData.captcha}
-                  onChange={handleChange}
-                  size="md"
-                  borderColor="gray.300"
-                  _hover={{ borderColor: "gray.400" }}
-                />
-                {captchaError && (
-                  <Text color="red.500" fontSize="sm" mt={1}>
-                    {captchaError}
-                  </Text>
-                )}
-              </FormControl>
-              
-              <Box pt={2}>
-                <Button 
-                  type="submit"
-                  bg="linear-gradient(to right, #00A9E0, #6DD3EF)"
-                  color="white"
-                  size="md"
-                  px={8}
-                  _hover={{ bg: "cyan.500" }}
-                  width="full"
-                >
-                  Submit Message
-                </Button>
-              </Box>
-            </VStack>
-          </form>
-        </GridItem>
-        
-        {/* Contact Information */}
-        <GridItem>
-          <Box 
-            p={8} 
-            borderWidth="1px" 
-            borderRadius="lg" 
-            borderColor="gray.200" 
-            bg="white"
-            boxShadow="sm"
-            mb={8}
-          >
-            <Heading as="h2" size="lg" mb={6}>
-              Contact Information
-            </Heading>
-            
-            <VStack spacing={6} align="start">
-              <HStack spacing={4} align="flex-start">
-                <Icon as={MapPin} color="red.400" boxSize={5} mt={1} />
-                <Box>
-                  <Text fontWeight="medium">Address</Text>
-                  <Text color="gray.600">1021 5th St W</Text>
-                  <Text color="gray.600">Kirkland, WA 98033</Text>
-                </Box>
-              </HStack>
-              
-              <HStack spacing={4} align="flex-start">
-                <Icon as={Phone} color="red.400" boxSize={5} mt={1} />
-                <Box>
-                  <Text fontWeight="medium">Phone</Text>
-                  <Text color="gray.600">(888) 462-1726</Text>
-                </Box>
-              </HStack>
-              
-              <HStack spacing={4} align="flex-start">
-                <Icon as={Clock} color="red.400" boxSize={5} mt={1} />
-                <Box>
-                  <Text fontWeight="medium">Office Hours</Text>
-                  <Text color="gray.600">Monday - Friday</Text>
-                  <Text color="gray.600">9:00 AM - 6:00 PM PST</Text>
-                </Box>
-              </HStack>
-            </VStack>
-          </Box>
-          
-          <Box 
-            p={8} 
-            borderRadius="lg" 
-            bgGradient="linear(to-r, #2A3B47, #1D2D35)"
-            color="white"
-            boxShadow="md"
-          >
-            <Heading as="h3" size="lg" mb={4}>
-              Ready to Invest?
-            </Heading>
-            <Text mb={6}>
-              Join forward-thinking investors who are already benefiting from our 
-              AI-driven approach to wealth creation.
+            <Text as="span" fontWeight="400">
+              Get in{" "}
             </Text>
-            <Button
-              bg="linear-gradient(to right, #00A9E0, #6DD3EF)"
-              color="white"
-              _hover={{ bg: "cyan.500" }}
-              size="md"
-              onClick={() => navigate('/about/leadership')}
+            <Text
+              as="span"
+              fontWeight="300"
+              fontStyle="italic"
+              color={gray400}
             >
-              Learn About Our Strategy
-            </Button>
-          </Box>
-        </GridItem>
-      </Grid>
-      
-      <ToastContainer />
-    </Container>
+              Touch
+            </Text>
+          </Heading>
+
+          <Text
+            fontSize={{ base: "md", md: "lg" }}
+            maxW="3xl"
+            mx="auto"
+            color={gray500}
+            fontWeight="300"
+            lineHeight="1.65"
+          >
+            Ready to transform your investment strategy? We'd love to hear from you.
+          </Text>
+
+          <Text
+            mt={4}
+            fontSize={{ base: "md", md: "md" }}
+            color={gray500}
+            fontWeight="400"
+            lineHeight="1.65"
+          >
+            For career-related inquiries, please visit our{" "}
+            <ChakraLink
+              href="/career"
+              // target="_blank"
+              rel="noopener noreferrer"
+              color={brandBlue}
+              fontWeight="600"
+              _hover={{ color: brandBlue, textDecoration: "underline" }}
+            >
+              Jobs page
+            </ChakraLink>
+            . For all other inquiries, please submit the form below.
+          </Text>
+        </Box>
+
+        {/* Contact Form and Information */}
+        <Grid
+          templateColumns={{ base: "1fr", lg: "1fr 1fr" }}
+          gap={{ base: 8, md: 10 }}
+          mt={{ base: 6, md: 8 }}
+          maxW="5xl"
+          mx="auto"
+          alignItems="start"
+        >
+          {/* Contact Form */}
+          <GridItem
+            as={Box}
+            p={{ base: 6, md: 8 }}
+            borderRadius="2xl"
+            borderWidth="1px"
+            borderColor={cardBorder}
+            bg="white"
+            boxShadow="0 8px 30px -4px rgba(0, 0, 0, 0.04)"
+            transition="border-color 0.2s ease"
+            _hover={{ borderColor: cardHoverBorder }}
+          >
+            <Heading
+              as="h2"
+              size="lg"
+              mb={6}
+              color="black"
+              fontWeight="500"
+              style={playfair}
+            >
+              Send us a Message
+            </Heading>
+
+            <form ref={form} onSubmit={handleSubmit}>
+              <VStack spacing={5} align="stretch">
+                <FormControl isRequired>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    Full Name
+                  </FormLabel>
+                  <Input
+                    name="name"
+                    placeholder="Enter your full name"
+                    value={formData.name}
+                    onChange={handleChange}
+                    size="lg"
+                    h="48px"
+                    {...fieldChrome}
+                  />
+                </FormControl>
+
+                <FormControl>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    Company
+                  </FormLabel>
+                  <Input
+                    name="company"
+                    placeholder="Enter your company name (optional)"
+                    value={formData.company}
+                    onChange={handleChange}
+                    size="lg"
+                    h="48px"
+                    {...fieldChrome}
+                  />
+                </FormControl>
+
+                <FormControl isRequired>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    Email Address
+                  </FormLabel>
+                  <Input
+                    name="email"
+                    type="email"
+                    placeholder="Enter your email address"
+                    value={formData.email}
+                    onChange={handleChange}
+                    size="lg"
+                    h="48px"
+                    {...fieldChrome}
+                  />
+                </FormControl>
+
+                <FormControl>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    Phone Number
+                  </FormLabel>
+                  <Input
+                    name="phone"
+                    placeholder="Enter your phone number (optional)"
+                    value={formData.phone}
+                    onChange={handleChange}
+                    size="lg"
+                    h="48px"
+                    {...fieldChrome}
+                  />
+                </FormControl>
+
+                <FormControl isRequired>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    Reason for Contact
+                  </FormLabel>
+                  <Select
+                    name="reason"
+                    placeholder="Select a reason"
+                    value={formData.reason}
+                    onChange={handleChange}
+                    size="lg"
+                    h="48px"
+                    {...fieldChrome}
+                  >
+                    {reasonOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl isRequired>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    Message
+                  </FormLabel>
+                  <Textarea
+                    name="message"
+                    placeholder="Tell us how we can help you..."
+                    value={formData.message}
+                    onChange={handleChange}
+                    size="md"
+                    minH="120px"
+                    rows={4}
+                    {...fieldChrome}
+                  />
+                </FormControl>
+
+                <FormControl isRequired>
+                  <FormLabel fontWeight="500" fontSize="sm" color={gray400} mb={1.5}>
+                    What is the sum of {num1} and {num2}?
+                  </FormLabel>
+                  <Input
+                    name="captcha"
+                    placeholder="Enter the answer"
+                    value={formData.captcha}
+                    onChange={handleChange}
+                    size="lg"
+                    h="48px"
+                    {...fieldChrome}
+                  />
+                  {captchaError && (
+                    <Text color="#FF3B30" fontSize="sm" mt={1}>
+                      {captchaError}
+                    </Text>
+                  )}
+                </FormControl>
+
+                <Box pt={6} mt={1} borderTopWidth="1px" borderTopColor={gray100}>
+                  <Button
+                    type="submit"
+                    width="full"
+                    size="lg"
+                    h="52px"
+                    borderRadius="lg"
+                    fontWeight="600"
+                    bg="gray.900"
+                    color="white"
+                    _hover={{ bg: "black" }}
+                    _active={{ bg: "black" }}
+                  >
+                    Submit Message
+                  </Button>
+                </Box>
+              </VStack>
+            </form>
+          </GridItem>
+
+          {/* Contact Information */}
+          <GridItem>
+            <Box
+              p={{ base: 6, md: 8 }}
+              borderRadius="2xl"
+              borderWidth="1px"
+              borderColor={cardBorder}
+              bg={iosGrayBg}
+              boxShadow="0 8px 30px -4px rgba(0, 0, 0, 0.03)"
+              mb={8}
+              transition="border-color 0.2s ease"
+              _hover={{ borderColor: cardHoverBorder }}
+            >
+              <Heading
+                as="h2"
+                size="lg"
+                mb={6}
+                color="black"
+                fontWeight="500"
+                style={playfair}
+              >
+                Contact Information
+              </Heading>
+
+              <VStack spacing={6} align="start">
+                <HStack spacing={4} align="flex-start">
+                  <Icon
+                    as={MapPin}
+                    color={brandBlue}
+                    boxSize={5}
+                    mt={1}
+                    strokeWidth={1.75}
+                  />
+                  <Box>
+                    <Text fontWeight="600" color="gray.900" fontSize="sm">
+                      Address
+                    </Text>
+                    <Text color={gray500} fontSize="sm" lineHeight="1.6" mt={0.5} fontWeight="300">
+                      1021 5th St W
+                    </Text>
+                    <Text color={gray500} fontSize="sm" lineHeight="1.6" fontWeight="300">
+                      Kirkland, WA 98033
+                    </Text>
+                  </Box>
+                </HStack>
+
+                <HStack spacing={4} align="flex-start">
+                  <Icon
+                    as={Phone}
+                    color={brandBlue}
+                    boxSize={5}
+                    mt={1}
+                    strokeWidth={1.75}
+                  />
+                  <Box>
+                    <Text fontWeight="600" color="gray.900" fontSize="sm">
+                      Phone
+                    </Text>
+                    <Text color={gray500} fontSize="sm" lineHeight="1.6" mt={0.5} fontWeight="300">
+                      (888) 462-1726
+                    </Text>
+                  </Box>
+                </HStack>
+
+                <HStack spacing={4} align="flex-start">
+                  <Icon
+                    as={Clock}
+                    color={brandBlue}
+                    boxSize={5}
+                    mt={1}
+                    strokeWidth={1.75}
+                  />
+                  <Box>
+                    <Text fontWeight="600" color="gray.900" fontSize="sm">
+                      Office Hours
+                    </Text>
+                    <Text color={gray500} fontSize="sm" lineHeight="1.6" mt={0.5} fontWeight="300">
+                      Monday - Friday
+                    </Text>
+                    <Text color={gray500} fontSize="sm" lineHeight="1.6" fontWeight="300">
+                      9:00 AM - 6:00 PM PST
+                    </Text>
+                  </Box>
+                </HStack>
+              </VStack>
+            </Box>
+
+            <Box
+              p={{ base: 6, md: 8 }}
+              borderRadius="2xl"
+              bg="#1D1D1F"
+              color="white"
+              boxShadow="0 20px 40px -12px rgba(0, 0, 0, 0.2)"
+              borderWidth="1px"
+              borderColor="rgba(255, 255, 255, 0.08)"
+            >
+              <Heading
+                as="h3"
+                size="lg"
+                mb={4}
+                fontWeight="500"
+                color="white"
+                style={playfair}
+              >
+                Ready to Invest?
+              </Heading>
+              <Text
+                mb={6}
+                color="rgba(255, 255, 255, 0.5)"
+                lineHeight="1.65"
+                fontSize="md"
+                fontWeight="300"
+              >
+                Join forward-thinking investors who are already benefiting from our
+                AI-driven approach to wealth creation.
+              </Text>
+              <Button
+                width="full"
+                size="lg"
+                h="52px"
+                borderRadius="lg"
+                bg="white"
+                color="gray.900"
+                fontWeight="600"
+                borderWidth="1px"
+                borderColor={gray200}
+                rightIcon={<Icon as={ArrowRight} boxSize={4} color={gray900} />}
+                _hover={{ bg: gray50 }}
+                _active={{ bg: gray100 }}
+                onClick={() => navigate("/about/leadership")}
+              >
+                Learn About Our Strategy
+              </Button>
+            </Box>
+          </GridItem>
+        </Grid>
+
+        <ToastContainer />
+      </Container>
+    </Box>
   );
 }


### PR DESCRIPTION
## Summary

- what changed: Updated `src/pages/Contact.tsx` to visually align the Contact page with the broader Hushh marketing website theme. Refined typography using Playfair Display headings, standardized grayscale styling (`ios-gray-bg`, gray scale surfaces, soft gray borders), updated card treatments, improved field/input chrome, and aligned link/icon styling with existing Hushh blue accent usage. Added cohesive spacing, responsive layout refinements, and themed white/tinted card sections while keeping the implementation scoped to the Contact page only.
- why it changed: To create a more cohesive and polished contact experience that visually matches the Home page and the broader Hushh design system without changing existing functionality or business logic.
- linked issue: `none - UI consistency and presentation-only alignment update`
- acceptance criteria covered: Contact page typography, spacing, card treatment, colors, and field styling visually align with the Home page theme; responsive behavior remains intact across mobile and desktop breakpoints; existing EmailJS submission flow, captcha behavior, navigation, and user-facing copy remain unchanged.
- risk area touched: `ui`
- reviewer focus: Verify visual consistency between the Contact page and Home page theme; confirm responsive spacing/layout behavior across breakpoints; validate form interactions, captcha behavior, toast notifications, and redirect/navigation flows remain unchanged.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: Manually reviewed the updated Contact page on mobile and desktop layouts; verified typography, spacing, card treatment, grayscale styling, icon/link accent behavior, form field styling, and responsive layout consistency against the Home page theme; validated incorrect captcha handling, successful form submission flow, success toast behavior, redirect to `/`, and “Learn About Our Strategy” navigation behavior.
- did not run: `npm run test`, `npx tsc --noEmit`, `npm run build:web`, `npm run env:check`, and `npm run lint:ci` were not executed locally in this chat environment and are expected to run in CI; security checks were not applicable because no auth, infrastructure, deployment, or secret-management paths were modified.
- reviewer should verify: Open `/contact` on both mobile and desktop breakpoints and compare typography, spacing, card styling, and grayscale treatment with the Home page; submit the form with an incorrect captcha and confirm the existing error behavior remains unchanged; submit with the correct captcha and confirm success toast plus redirect to `/`; verify “Learn About Our Strategy” still navigates correctly to `/about/leadership`.

## Notes

- deployment impact: None expected beyond a standard frontend rebuild; no backend APIs, deployment configuration, routing logic, or infrastructure behavior were modified.
- migration or env requirements: None. No environment variables, migrations, infrastructure updates, or route registrations are required.
- rollback or release notes: Safe rollback by reverting changes in `src/pages/Contact.tsx` to restore the previous Contact page presentation and styling.
- follow-up work if any: Consider extracting shared form/card styling primitives into reusable design-system components for consistency across additional marketing and informational pages.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI maintainers responsible for marketing pages, shared design-system consistency, and responsive styling behavior.

## Demo : Updated UI Glimpse 

## Before : 
<img width="1453" height="711" alt="Screenshot 2026-05-10 at 3 06 57 PM" src="https://github.com/user-attachments/assets/bf334c95-a48c-41c4-ab09-088266544ac7" />

## After : 
<img width="1448" height="836" alt="Screenshot 2026-05-10 at 3 03 19 PM" src="https://github.com/user-attachments/assets/aa16693c-615f-4793-8df8-efcd33b07f14" />
