### PR TITLE
fix(ui): increase footer disclaimer contrast

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -206,8 +206,8 @@ export default function Footer() {
 
         {/* Disclaimer */}
         <div className="p-4 rounded-xl bg-[#161d2b]/50 border border-[#1F2937]/50">
-          <p className="text-gray-500 text-xs leading-5">
-            <span className="font-bold text-gray-400">Disclaimer:</span> Investment involves risk, including the possible loss of principal. Past performance does not guarantee future results. Please consult with a financial advisor before making investment decisions.
+          <p className="text-gray-300 text-xs leading-5">
+            <span className="font-bold text-gray-200">Disclaimer:</span> Investment involves risk, including the possible loss of principal. Past performance does not guarantee future results. Please consult with a financial advisor before making investment decisions.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- what changed: Updated the footer legal disclaimer text color to improve contrast and readability against the dark background.
- why it changed: The previous disclaimer text color had low contrast and reduced readability.
- linked issue: #1161
- acceptance criteria covered: Footer disclaimer text is more readable while preserving the existing footer design, layout, copy, and links.
- risk area touched: ui
- reviewer focus: Verify the footer disclaimer text is readable across desktop and mobile layouts.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [x] `npm run env:check`
- [x] `npm run lint:ci`
- [x] `npm test`
- [x] `npx tsc --noEmit`
- [x] `npm run build:web`
- [x] `npm run smoke:ci`
- [x] GitHub PR Validation is green after maintainer patch
- ran: Maintainer reran env contract, lint, typecheck, unit tests, production build, compact smoke, and GitHub validation.
- did not run: `npm run ux:guard` is not available in this checked-in branch.
- reviewer should verify: Footer disclaimer contrast remains improved without header/footer content or link changes.

## Notes

- deployment impact: none beyond normal web deploy
- migration or env requirements: none
- rollback or release notes: revert the two footer text color classes if needed
- follow-up work if any: none
- reviewer callouts or CODEOWNERS you expect to review this: frontend/design-system review completed by maintainer