### PR TITLE
feat(ui): align a2a setup screen styling with hushh website theme

### DIFF
--- a/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
+++ b/src/components/a2aPlayground/A2AScenarioSetupScreen.tsx
@@ -22,30 +22,29 @@ import {
   FormControl,
   FormLabel,
   Divider,
-  Icon,
   Badge,
-  InputGroup,
-  InputLeftAddon,
+  SimpleGrid,
 } from '@chakra-ui/react';
-import { keyframes } from '@emotion/react';
 import {
   A2AScenarioConfig,
   A2AScenarioSetupProps,
   DemoUserIdentifiers,
   ScenarioOperations,
-  RelyingParty,
   DEMO_RELYING_PARTIES,
   DEFAULT_SCENARIO_CONFIG,
 } from '../../types/a2aPlayground';
 
-// =====================================================
-// Animations
-// =====================================================
+/** Match `src/pages/home/ui.tsx` hero typography */
+const playfair = { fontFamily: "'Playfair Display', serif" };
+const manrope =
+  '"Manrope", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
 
-const pulseGlow = keyframes`
-  0%, 100% { box-shadow: 0 0 20px rgba(159, 122, 234, 0.3); }
-  50% { box-shadow: 0 0 40px rgba(159, 122, 234, 0.6); }
-`;
+/** Home `border-gray-200/60` + iOS hairline */
+const borderHairline = 'rgba(229, 231, 235, 0.6)';
+const borderIos = '#E5E5EA';
+/** Home feature cards: `bg-ios-gray-bg` */
+const surfacePage = '#F5F5F7';
+const hushhBlue = '#0066CC';
 
 // =====================================================
 // Country Options
@@ -104,349 +103,438 @@ export const A2AScenarioSetupScreen: React.FC<A2AScenarioSetupProps> = ({
     operations.confirmKeyMatch || 
     operations.exportKycProfile;
 
+  const fieldFocus = {
+    borderColor: hushhBlue,
+    boxShadow: `0 0 0 1px ${hushhBlue}`,
+  };
+
+  const inputSurface = {
+    bg: 'white',
+    border: '1px solid',
+    borderColor: 'gray.200',
+    color: 'gray.900',
+    borderRadius: 'xl',
+    fontFamily: manrope,
+    _placeholder: { color: 'gray.400' },
+    _hover: { borderColor: 'gray.400', bg: 'white' },
+    _focus: { ...fieldFocus, bg: 'white' },
+  };
+
+  const selectSurface = {
+    ...inputSurface,
+    bgGradient: 'linear(to-b, gray.100, white)',
+  };
+
   return (
     <Box
       minH="100vh"
-      bg="white"
-      py={8}
+      bg={surfacePage}
+      py={{ base: 8, md: 10 }}
+      fontFamily={manrope}
+      className="antialiased text-gray-900 selection:bg-[#0066CC] selection:text-white"
     >
-      <Container maxW="lg">
-        {/* Header */}
-        <VStack spacing={2} mb={8} textAlign="center">
+      <Container maxW="6xl" px={{ base: 4, md: 6 }}>
+        {/* Header — Playfair hero + Manrope body (home page pattern) */}
+        <VStack spacing={3} mb={{ base: 8, md: 10 }} textAlign="center">
           <Badge
-            colorScheme="purple"
             px={3}
             py={1}
             borderRadius="full"
-            fontSize="xs"
+            fontSize="10px"
+            fontWeight="600"
+            letterSpacing="0.14em"
+            textTransform="uppercase"
+            bg="rgba(0, 102, 204, 0.1)"
+            color={hushhBlue}
+            border="1px solid"
+            borderColor="rgba(0, 102, 204, 0.25)"
           >
             A2A PROTOCOL DEMO
           </Badge>
           <Text
-            fontSize={{ base: '2xl', md: '3xl' }}
-            fontWeight="600"
-            color="black"
+            as="h1"
+            fontSize={{ base: '2.25rem', sm: '2.75rem', md: '3.25rem' }}
+            lineHeight={1.1}
+            fontWeight="normal"
+            color="gray.900"
+            letterSpacing="tight"
+            style={playfair}
           >
-            Agent-to-Agent KYC Playground
+            Agent-to-Agent <br />
+            <Text
+              as="span"
+              color="gray.400"
+              fontStyle="italic"
+              fontWeight="light"
+              style={playfair}
+            >
+              KYC Playground
+            </Text>
           </Text>
-          <Text color="gray.600" fontSize="sm" maxW="md">
+          <Text color="gray.500" fontSize={{ base: 'sm', md: 'md' }} fontWeight="light" maxW="lg" lineHeight="relaxed">
             Watch Bank KYC Copilot and Hushh KYC Agent collaborate 
             in real-time to verify identity and export KYC data.
           </Text>
         </VStack>
 
-        {/* Main Form Card */}
+        {/* Main form card — white on home `ios-gray-bg` + home-style border */}
         <Box
-          bg="gray.50"
-          border="1px solid"
-          borderColor="gray.200"
+          bg="white"
           borderRadius="2xl"
-          p={6}
-          boxShadow="sm"
+          p={{ base: 5, md: 8 }}
+          border="1px solid"
+          borderColor={borderHairline}
+          boxShadow="0 8px 30px -4px rgba(0, 0, 0, 0.04)"
         >
-          <VStack spacing={6} align="stretch">
-            {/* Section 1: Relying Party */}
-            <Box>
-              <Text
-                fontSize="sm"
-                fontWeight="600"
-                color="purple.600"
-                mb={3}
-                textTransform="uppercase"
-                letterSpacing="wide"
-              >
-                1. Choose Relying Party
-              </Text>
-              
-              <FormControl>
-                <FormLabel color="gray.700" fontSize="sm">
-                  Bank or Financial Institution
-                </FormLabel>
-                <Select
-                  value={selectedPartyId}
-                  onChange={(e) => setSelectedPartyId(e.target.value)}
-                  bg="white"
-                  border="1px solid"
-                  borderColor="gray.300"
-                  color="black"
-                  _hover={{ borderColor: 'purple.500' }}
-                  _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
+          <SimpleGrid columns={{ base: 1, lg: 2 }} spacing={{ base: 8, lg: 10 }} alignItems="start">
+            <VStack
+              spacing={8}
+              align="stretch"
+              bg="gray.50"
+              borderRadius="xl"
+              p={{ base: 5, md: 6 }}
+              border="1px solid"
+              borderColor="gray.100"
+            >
+              {/* Section 1: Relying Party */}
+              <Box>
+                <Text
+                  fontSize="10px"
+                  fontWeight="600"
+                  color="gray.400"
+                  mb={3}
+                  textTransform="uppercase"
+                  letterSpacing="0.16em"
                 >
-                  {DEMO_RELYING_PARTIES.map((party) => (
-                    <option 
-                      key={party.id} 
-                      value={party.id}
-                    >
-                      {party.name} {party.description ? `– ${party.description}` : ''}
-                    </option>
-                  ))}
-                </Select>
-              </FormControl>
-            </Box>
+                  1. Choose Relying Party
+                </Text>
 
-            <Divider borderColor="gray.200" />
-
-            {/* Section 2: User to Verify */}
-            <Box>
-              <Text
-                fontSize="sm"
-                fontWeight="600"
-                color="purple.600"
-                mb={3}
-                textTransform="uppercase"
-                letterSpacing="wide"
-              >
-                2. User to Verify
-              </Text>
-
-              <VStack spacing={4}>
-                {/* Full Name */}
                 <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Full Name
-                  </FormLabel>
-                  <Input
-                    value={user.fullName}
-                    onChange={(e) => setUser({ ...user, fullName: e.target.value })}
-                    placeholder="Enter full name"
-                    bg="white"
-                    border="1px solid"
-                    borderColor="gray.300"
-                    color="black"
-                    _placeholder={{ color: 'gray.400' }}
-                    _hover={{ borderColor: 'purple.500' }}
-                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
-                  />
-                </FormControl>
-
-                {/* Phone */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Phone Number
-                  </FormLabel>
-                  <HStack>
-                    <Select
-                      value={user.phoneCountryCode}
-                      onChange={(e) => setUser({ ...user, phoneCountryCode: e.target.value })}
-                      bg="white"
-                      border="1px solid"
-                      borderColor="gray.300"
-                      color="black"
-                      w="140px"
-                      _hover={{ borderColor: 'purple.500' }}
-                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
-                    >
-                      {PHONE_CODES.map((code) => (
-                        <option 
-                          key={code.value} 
-                          value={code.value}
-                        >
-                          {code.label}
-                        </option>
-                      ))}
-                    </Select>
-                    <Input
-                      value={user.phoneNumber}
-                      onChange={(e) => setUser({ ...user, phoneNumber: e.target.value })}
-                      placeholder="Phone number"
-                      bg="white"
-                      border="1px solid"
-                      borderColor="gray.300"
-                      color="black"
-                      _placeholder={{ color: 'gray.400' }}
-                      _hover={{ borderColor: 'purple.500' }}
-                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
-                    />
-                  </HStack>
-                </FormControl>
-
-                {/* Country */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Country
+                  <FormLabel color="gray.500" fontSize="sm" fontWeight="500" mb={2}>
+                    Bank or Financial Institution
                   </FormLabel>
                   <Select
-                    value={user.country}
-                    onChange={(e) => setUser({ ...user, country: e.target.value })}
-                    bg="white"
-                    border="1px solid"
-                    borderColor="gray.300"
-                    color="black"
-                    _hover={{ borderColor: 'purple.500' }}
-                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
+                    {...selectSurface}
+                    value={selectedPartyId}
+                    onChange={(e) => setSelectedPartyId(e.target.value)}
                   >
-                    {COUNTRY_OPTIONS.map((country) => (
+                    {DEMO_RELYING_PARTIES.map((party) => (
                       <option 
-                        key={country.value} 
-                        value={country.value}
+                        key={party.id} 
+                        value={party.id}
                       >
-                        {country.label}
+                        {party.name} {party.description ? `– ${party.description}` : ''}
                       </option>
                     ))}
                   </Select>
                 </FormControl>
+              </Box>
 
-                {/* Email (Optional) */}
-                <FormControl>
-                  <FormLabel color="gray.700" fontSize="sm">
-                    Email (Optional)
-                  </FormLabel>
-                  <Input
-                    value={user.email || ''}
-                    onChange={(e) => setUser({ ...user, email: e.target.value })}
-                    placeholder="email@example.com"
-                    type="email"
-                    bg="white"
-                    border="1px solid"
-                    borderColor="gray.300"
-                    color="black"
-                    _placeholder={{ color: 'gray.400' }}
-                    _hover={{ borderColor: 'purple.500' }}
-                    _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
-                  />
-                </FormControl>
+              <Divider borderColor="gray.200" display={{ base: 'block', lg: 'none' }} opacity={0.7} />
 
-                {/* SSN Last 4 (for key match demo) */}
-                {operations.confirmKeyMatch && (
+              {/* Section 2: User to Verify */}
+              <Box>
+                <Text
+                  fontSize="10px"
+                  fontWeight="600"
+                  color="gray.400"
+                  mb={3}
+                  textTransform="uppercase"
+                  letterSpacing="0.16em"
+                >
+                  2. User to Verify
+                </Text>
+
+                <VStack spacing={4}>
+                  {/* Full Name */}
                   <FormControl>
-                    <FormLabel color="gray.700" fontSize="sm">
-                      SSN Last 4 Digits (for key match demo)
+                    <FormLabel color="gray.500" fontSize="sm" fontWeight="500" mb={2}>
+                      Full Name
                     </FormLabel>
                     <Input
-                      value={user.ssnLast4 || ''}
-                      onChange={(e) => setUser({ ...user, ssnLast4: e.target.value })}
-                      placeholder="1234"
-                      maxLength={4}
-                      bg="white"
-                      border="1px solid"
-                      borderColor="gray.300"
-                      color="black"
-                      _placeholder={{ color: 'gray.400' }}
-                      _hover={{ borderColor: 'purple.500' }}
-                      _focus={{ borderColor: 'purple.500', boxShadow: '0 0 0 1px #805AD5' }}
+                      {...inputSurface}
+                      value={user.fullName}
+                      onChange={(e) => setUser({ ...user, fullName: e.target.value })}
+                      placeholder="Enter full name"
                     />
-                    <Text fontSize="xs" color="gray.600" mt={1}>
-                      🔒 This is only used to demo VerifyFieldMatch – never shared in clear
-                    </Text>
                   </FormControl>
-                )}
-              </VStack>
-            </Box>
 
-            <Divider borderColor="gray.200" />
+                  {/* Phone */}
+                  <FormControl>
+                    <FormLabel color="gray.500" fontSize="sm" fontWeight="500" mb={2}>
+                      Phone Number
+                    </FormLabel>
+                    <HStack align="start">
+                      <Select
+                        {...selectSurface}
+                        value={user.phoneCountryCode}
+                        onChange={(e) => setUser({ ...user, phoneCountryCode: e.target.value })}
+                        w="140px"
+                        flexShrink={0}
+                      >
+                        {PHONE_CODES.map((code) => (
+                          <option 
+                            key={code.value} 
+                            value={code.value}
+                          >
+                            {code.label}
+                          </option>
+                        ))}
+                      </Select>
+                      <Input
+                        {...inputSurface}
+                        value={user.phoneNumber}
+                        onChange={(e) => setUser({ ...user, phoneNumber: e.target.value })}
+                        placeholder="Phone number"
+                        flex={1}
+                      />
+                    </HStack>
+                  </FormControl>
 
-            {/* Section 3: Operations */}
-            <Box>
-              <Text
-                fontSize="sm"
+                  {/* Country */}
+                  <FormControl>
+                    <FormLabel color="gray.500" fontSize="sm" fontWeight="500" mb={2}>
+                      Country
+                    </FormLabel>
+                    <Select
+                      {...inputSurface}
+                      value={user.country}
+                      onChange={(e) => setUser({ ...user, country: e.target.value })}
+                    >
+                      {COUNTRY_OPTIONS.map((country) => (
+                        <option 
+                          key={country.value} 
+                          value={country.value}
+                        >
+                          {country.label}
+                        </option>
+                      ))}
+                    </Select>
+                  </FormControl>
+
+                  {/* Email (Optional) */}
+                  <FormControl>
+                    <FormLabel color="gray.500" fontSize="sm" fontWeight="500" mb={2}>
+                      Email (Optional)
+                    </FormLabel>
+                    <Input
+                      {...inputSurface}
+                      value={user.email || ''}
+                      onChange={(e) => setUser({ ...user, email: e.target.value })}
+                      placeholder="email@example.com"
+                      type="email"
+                    />
+                  </FormControl>
+
+                  {/* SSN Last 4 (for key match demo) */}
+                  {operations.confirmKeyMatch && (
+                    <FormControl>
+                      <FormLabel color="gray.500" fontSize="sm" fontWeight="500" mb={2}>
+                        SSN Last 4 Digits (for key match demo)
+                      </FormLabel>
+                      <Input
+                        {...inputSurface}
+                        value={user.ssnLast4 || ''}
+                        onChange={(e) => setUser({ ...user, ssnLast4: e.target.value })}
+                        placeholder="1234"
+                        maxLength={4}
+                      />
+                      <Text fontSize="xs" color="gray.500" mt={1.5} lineHeight="short">
+                        🔒 This is only used to demo VerifyFieldMatch – never shared in clear
+                      </Text>
+                    </FormControl>
+                  )}
+                </VStack>
+              </Box>
+            </VStack>
+
+            <VStack
+              spacing={6}
+              align="stretch"
+              bg="gray.50"
+              borderRadius="xl"
+              p={{ base: 5, md: 6 }}
+              border="1px solid"
+              borderColor="gray.100"
+            >
+              {/* Section 3: Operations */}
+              <Box>
+                <Text
+                  fontSize="10px"
+                  fontWeight="600"
+                  color="gray.400"
+                  mb={3}
+                  textTransform="uppercase"
+                  letterSpacing="0.16em"
+                >
+                  3. What should agents do?
+                </Text>
+
+                <VStack align="stretch" spacing={3}>
+                  <Box
+                    border="1px solid"
+                    borderColor={borderHairline}
+                    borderRadius="xl"
+                    px={4}
+                    py={3}
+                    bg="white"
+                    boxShadow="inset 0 0 0 0.5px rgba(0, 0, 0, 0.03)"
+                  >
+                    <Checkbox
+                      isChecked={operations.verifyKycStatus}
+                      onChange={(e) => setOperations({ 
+                        ...operations, 
+                        verifyKycStatus: e.target.checked 
+                      })}
+                      colorScheme="blue"
+                      size="lg"
+                      sx={{
+                        '.chakra-checkbox__control': {
+                          borderColor: borderIos,
+                          _checked: {
+                            bg: hushhBlue,
+                            borderColor: hushhBlue,
+                          },
+                        },
+                      }}
+                    >
+                      <VStack align="start" spacing={0} ml={1}>
+                        <Text color="gray.900" fontSize="sm" fontWeight="600">
+                          Verify KYC Status
+                        </Text>
+                        <Text color="gray.500" fontSize="xs" lineHeight="short" fontWeight="light">
+                          CheckKYCStatus – Is this user verified?
+                        </Text>
+                      </VStack>
+                    </Checkbox>
+                  </Box>
+
+                  <Box
+                    border="1px solid"
+                    borderColor={borderHairline}
+                    borderRadius="xl"
+                    px={4}
+                    py={3}
+                    bg="white"
+                    boxShadow="inset 0 0 0 0.5px rgba(0, 0, 0, 0.03)"
+                  >
+                    <Checkbox
+                      isChecked={operations.confirmKeyMatch}
+                      onChange={(e) => setOperations({ 
+                        ...operations, 
+                        confirmKeyMatch: e.target.checked 
+                      })}
+                      colorScheme="blue"
+                      size="lg"
+                      sx={{
+                        '.chakra-checkbox__control': {
+                          borderColor: borderIos,
+                          _checked: {
+                            bg: hushhBlue,
+                            borderColor: hushhBlue,
+                          },
+                        },
+                      }}
+                    >
+                      <VStack align="start" spacing={0} ml={1}>
+                        <Text color="gray.900" fontSize="sm" fontWeight="600">
+                          Confirm Key Match
+                        </Text>
+                        <Text color="gray.500" fontSize="xs" lineHeight="short" fontWeight="light">
+                          VerifyFieldMatch – Does SSN last4 match?
+                        </Text>
+                      </VStack>
+                    </Checkbox>
+                  </Box>
+
+                  <Box
+                    border="1px solid"
+                    borderColor={borderHairline}
+                    borderRadius="xl"
+                    px={4}
+                    py={3}
+                    bg="white"
+                    boxShadow="inset 0 0 0 0.5px rgba(0, 0, 0, 0.03)"
+                  >
+                    <Checkbox
+                      isChecked={operations.exportKycProfile}
+                      onChange={(e) => setOperations({ 
+                        ...operations, 
+                        exportKycProfile: e.target.checked 
+                      })}
+                      colorScheme="blue"
+                      size="lg"
+                      sx={{
+                        '.chakra-checkbox__control': {
+                          borderColor: borderIos,
+                          _checked: {
+                            bg: hushhBlue,
+                            borderColor: hushhBlue,
+                          },
+                        },
+                      }}
+                    >
+                      <VStack align="start" spacing={0} ml={1}>
+                        <Text color="gray.900" fontSize="sm" fontWeight="600">
+                          Export KYC Profile
+                        </Text>
+                        <Text color="gray.500" fontSize="xs" lineHeight="short" fontWeight="light">
+                          ExportKYCProfile – Get normalized JSON profile
+                        </Text>
+                      </VStack>
+                    </Checkbox>
+                  </Box>
+                </VStack>
+              </Box>
+
+              <Button
+                size="lg"
+                onClick={handleRun}
+                isDisabled={!user.fullName || !hasOperation}
+                w="100%"
+                h="56px"
+                fontSize="md"
                 fontWeight="600"
-                color="purple.600"
-                mb={3}
-                textTransform="uppercase"
                 letterSpacing="wide"
+                borderRadius="xl"
+                bg="black"
+                color="white"
+                fontFamily={manrope}
+                _hover={{
+                  bg: 'blackAlpha.900',
+                  transform: 'translateY(-1px)',
+                  boxShadow: 'lg',
+                }}
+                _active={{ bg: 'black', transform: 'translateY(0)' }}
+                _disabled={{
+                  bg: 'gray.200',
+                  color: 'gray.500',
+                  cursor: 'not-allowed',
+                  opacity: 1,
+                }}
+                transition="all 0.2s ease-out"
               >
-                3. What should agents do?
+                🚀 Run A2A KYC Scenario
+              </Button>
+
+              <Text 
+                fontSize="xs" 
+                color="gray.500" 
+                textAlign="center"
+                lineHeight="short"
+              >
+                This will simulate a real A2A conversation between {selectedParty.name} 
+                and Hushh KYC Agent.
               </Text>
-
-              <VStack align="stretch" spacing={3}>
-                <Checkbox
-                  isChecked={operations.verifyKycStatus}
-                  onChange={(e) => setOperations({ 
-                    ...operations, 
-                    verifyKycStatus: e.target.checked 
-                  })}
-                  colorScheme="purple"
-                  size="lg"
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text color="black" fontSize="sm" fontWeight="500">
-                      Verify KYC Status
-                    </Text>
-                    <Text color="gray.600" fontSize="xs">
-                      CheckKYCStatus – Is this user verified?
-                    </Text>
-                  </VStack>
-                </Checkbox>
-
-                <Checkbox
-                  isChecked={operations.confirmKeyMatch}
-                  onChange={(e) => setOperations({ 
-                    ...operations, 
-                    confirmKeyMatch: e.target.checked 
-                  })}
-                  colorScheme="purple"
-                  size="lg"
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text color="black" fontSize="sm" fontWeight="500">
-                      Confirm Key Match
-                    </Text>
-                    <Text color="gray.600" fontSize="xs">
-                      VerifyFieldMatch – Does SSN last4 match?
-                    </Text>
-                  </VStack>
-                </Checkbox>
-
-                <Checkbox
-                  isChecked={operations.exportKycProfile}
-                  onChange={(e) => setOperations({ 
-                    ...operations, 
-                    exportKycProfile: e.target.checked 
-                  })}
-                  colorScheme="purple"
-                  size="lg"
-                >
-                  <VStack align="start" spacing={0}>
-                    <Text color="black" fontSize="sm" fontWeight="500">
-                      Export KYC Profile
-                    </Text>
-                    <Text color="gray.600" fontSize="xs">
-                      ExportKYCProfile – Get normalized JSON profile
-                    </Text>
-                  </VStack>
-                </Checkbox>
-              </VStack>
-            </Box>
-
-            <Divider borderColor="gray.200" />
-
-            {/* Run Button */}
-            <Button
-              size="lg"
-              colorScheme="purple"
-              onClick={handleRun}
-              isDisabled={!user.fullName || !hasOperation}
-              w="100%"
-              h="56px"
-              fontSize="md"
-              fontWeight="600"
-              _hover={{
-                transform: 'translateY(-2px)',
-                boxShadow: '0 8px 25px rgba(159, 122, 234, 0.4)',
-              }}
-              transition="all 0.2s"
-            >
-              🚀 Run A2A KYC Scenario
-            </Button>
-
-            {/* Help Text */}
-            <Text 
-              fontSize="xs" 
-              color="gray.600" 
-              textAlign="center"
-            >
-              This will simulate a real A2A conversation between {selectedParty.name} 
-              and Hushh KYC Agent.
-            </Text>
-          </VStack>
+            </VStack>
+          </SimpleGrid>
         </Box>
 
-        {/* Footer */}
         <Text 
           fontSize="xs" 
-          color="gray.500" 
+          color="gray.400" 
           textAlign="center" 
-          mt={6}
+          mt={8}
         >
           A2A Protocol Demo • Hushh KYC Network • ADFW 2025
         </Text>


### PR DESCRIPTION
## Summary

- what changed: Updated `src/components/a2aPlayground/A2AScenarioSetupScreen.tsx` to visually align the Agent-to-Agent KYC setup experience with the broader Hushh website theme. Added Playfair Display hero typography, standardized grayscale surfaces/borders using the same `ios-gray-bg` and gray palette patterns used on the Home page, refined section spacing and layout hierarchy, updated checkbox row styling, improved form field chrome/focus states, and introduced a responsive two-column layout for larger breakpoints.
- why it changed: To create a more cohesive and polished A2A demo experience that visually matches the Home page and broader Hushh design system while preserving all existing demo functionality and scenario logic.
- linked issue: `none - UI consistency and presentation-only alignment update`
- acceptance criteria covered: A2A setup screen visually matches the Hushh Home page theme, hero typography follows the same heading pattern, form controls and checkbox rows render with updated styling/focus states, responsive layout works across mobile and desktop breakpoints, and existing scenario configuration/run behavior remains unchanged.
- risk area touched: `ui`
- reviewer focus: Verify visual consistency between the A2A setup screen and Home page theme; confirm responsive layout behavior across breakpoints; validate form controls, checkbox rows, conditional SSN field rendering, and Run Scenario interactions continue functioning correctly.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: Manually reviewed the updated A2A playground setup screen on mobile and desktop layouts; verified Playfair hero styling, grayscale surface/border consistency, responsive two-column layout behavior, checkbox row styling, form focus/hover states, CTA rendering, conditional SSN field visibility, and scenario run interactions inside `src/components/a2aPlayground/A2AScenarioSetupScreen.tsx`.
- did not run: `npm run test`, `npx tsc --noEmit`, `npm run build:web`, `npm run env:check`, and `npm run lint:ci` were not executed locally in this chat environment and are expected to run in CI; security checks were not applicable because no auth, infrastructure, deployment, or secret-management paths were modified.
- reviewer should verify: Open the A2A playground route and confirm all form fields, checkboxes, conditional SSN field rendering, and Run Scenario behavior continue functioning correctly; resize between mobile and desktop breakpoints and verify responsive layout behavior, hover/focus states, spacing, and visual consistency with the Home page theme.

## Notes

- deployment impact: None expected beyond a standard frontend rebuild; no backend APIs, routing logic, deployment configuration, or infrastructure behavior were modified.
- migration or env requirements: None. No environment variables, migrations, infrastructure updates, or route registrations are required.
- rollback or release notes: Safe rollback by reverting changes in `src/components/a2aPlayground/A2AScenarioSetupScreen.tsx` to restore the previous A2A setup screen presentation and styling.
- follow-up work if any: Consider extracting shared form, hero, and surface styling patterns into reusable design-system primitives for consistency across additional onboarding/demo flows.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI maintainers responsible for A2A playground surfaces, shared design-system consistency, and responsive styling behavior.

## Demo 

## Before : 
<img width="1452" height="837" alt="Screenshot 2026-05-10 at 3 15 37 PM" src="https://github.com/user-attachments/assets/32a5d88a-3020-4bee-a9b1-739eb21ed002" />

## After : 
<img width="1451" height="836" alt="Screenshot 2026-05-10 at 3 21 39 PM" src="https://github.com/user-attachments/assets/d68a5d4d-817f-4e4b-9f53-d4aff4bb4b2b" />
<img width="1450" height="837" alt="Screenshot 2026-05-10 at 3 21 59 PM" src="https://github.com/user-attachments/assets/18b41efb-bed5-4a4d-a4b7-0dc082d2a8ff" />

