### PR TITLE
feat(ui): align faq page styling with hushh marketing theme

### DIFF
--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -70,6 +70,10 @@ const faqs: FaqItem[] = [
   }
 ];
 
+const playfair = "'Playfair Display', serif";
+const bodyFont =
+  '"Manrope", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+
 const FaqPage: React.FC = () => {
   const [openIndex, setOpenIndex] = React.useState<number | null>(0);
 
@@ -78,85 +82,145 @@ const FaqPage: React.FC = () => {
   };
 
   return (
-    <Container maxW="container.xl" py={12} px={{ base: 4, md: 6 }}>
-      {/* Main Header */}
-      <Box textAlign="center" mb={16}>
-        <Heading 
-          as="h1" 
-          size={{ base: "2xl", md: "3xl" }} 
-          mb={4}
-          letterSpacing="tight"
-          // fontWeight="500"
-        >
-          <Text as="span" fontWeight="300" color="black">Frequently Asked </Text><br/>
-          <Text as="span" fontWeight="500" className="blue-gradient-text">Questions</Text>
-        </Heading>
-        
-        <Text 
-          fontSize={{ base: "lg", md: "xl" }} 
-          maxW="3xl" 
-          mx="auto" 
-          color="gray.600"
-          mt={4}
-        >
-          Find answers to common questions about our investment strategies, processes, and
-          services.
-        </Text>
-      </Box>
-
-      {/* FAQ Items */}
-      <VStack spacing={6} align="stretch" maxW="container.lg" mx="auto">
-        {faqs.map((faq, index: number) => (
-          <Box 
-            key={index}
-            bg="white" 
-            borderRadius="lg" 
-            boxShadow={openIndex === index ? "lg" : "md"}
-            transition="all 0.2s"
-            overflow="hidden"
-            borderWidth="1px"
-            borderColor="gray.200"
+    <Box
+      bg="gray.50"
+      color="gray.900"
+      fontFamily={bodyFont}
+      sx={{ WebkitFontSmoothing: "antialiased", MozOsxFontSmoothing: "grayscale" }}
+    >
+      <Container maxW="7xl" py={{ base: 10, md: 14, lg: 16 }} px={{ base: 4, sm: 6, lg: 8 }}>
+        <Box textAlign="center" mb={{ base: 12, md: 14 }}>
+          <Heading
+            as="h1"
+            fontFamily={playfair}
+            fontWeight="normal"
+            fontSize={{ base: "2.75rem", sm: "3.25rem", lg: "4rem" }}
+            lineHeight="1.1"
+            letterSpacing="-0.02em"
+            color="black"
           >
-            <Flex 
-              p={6}
-              cursor="pointer"
-              onClick={() => toggleAccordion(index)}
-              justify="space-between"
-              align="center"
+            <Text as="span" display="block">
+              Frequently Asked
+            </Text>
+            <Text
+              as="span"
+              display="block"
+              color="gray.400"
+              fontStyle="italic"
+              fontWeight="300"
+              fontFamily={playfair}
             >
-              <Heading 
-                as="h3" 
-                size={{ base: "sm", md: "md" }} 
-                fontWeight="500"
-                color="gray.800"
+              Questions
+            </Text>
+          </Heading>
+
+          <Text
+            fontSize={{ base: "sm", sm: "md" }}
+            fontWeight="300"
+            maxW="lg"
+            mx="auto"
+            color="gray.500"
+            mt={4}
+            lineHeight="relaxed"
+          >
+            Find answers to common questions about our investment strategies, processes, and
+            services.
+          </Text>
+        </Box>
+
+        <VStack
+          spacing={{ base: 5, md: 6 }}
+          align="stretch"
+          maxW="4xl"
+          mx="auto"
+          w="100%"
+        >
+          {faqs.map((faq, index: number) => (
+            <Box
+              key={index}
+              bg="white"
+              borderRadius="2xl"
+              overflow="hidden"
+              borderWidth="1px"
+              borderColor="gray.100"
+              boxShadow={
+                openIndex === index
+                  ? "0 4px 24px rgba(0, 0, 0, 0.08)"
+                  : "0 2px 12px rgba(0, 0, 0, 0.06)"
+              }
+              transition="box-shadow 0.2s ease, border-color 0.2s ease"
+              _hover={{
+                borderColor: "gray.200",
+                boxShadow: "0 4px 20px rgba(0, 0, 0, 0.07)",
+              }}
+            >
+              <Flex
+                role="group"
+                px={{ base: 5, md: 6 }}
+                py={{ base: 5, md: 6 }}
+                cursor="pointer"
+                onClick={() => toggleAccordion(index)}
+                justify="space-between"
+                align="flex-start"
+                gap={4}
+                transition="background-color 0.2s ease, box-shadow 0.2s ease"
+                borderTopRadius="2xl"
+                _hover={{
+                  bg: "gray.50",
+                  boxShadow: "inset 0 0 0 1px rgba(0, 0, 0, 0.04)",
+                }}
+                _active={{
+                  bg: "gray.100",
+                }}
               >
-                {faq.question}
-              </Heading>
-              <Icon
-                as={openIndex === index ? ChevronUpIcon : ChevronDownIcon}
-                w={6}
-                h={6}
-                color="gray.500"
-                transition="transform 0.2s"
-              />
-            </Flex>
-            
-            {openIndex === index && (
-              <Box 
-                px={6} 
-                pb={6} 
-                pt={0}
-                color="gray.600"
-                fontSize={{ base: "md", md: "lg" }}
-                lineHeight="tall"
-              >
-                {faq.answer}
-              </Box>
-            )}
-          </Box>
-        ))}
-      </VStack>
-    </Container>
+                <Heading
+                  as="h3"
+                  fontFamily={bodyFont}
+                  fontSize={{ base: "0.95rem", md: "1rem" }}
+                  fontWeight="600"
+                  color="gray.900"
+                  lineHeight="snug"
+                  pr={1}
+                  transition="color 0.2s ease"
+                  _groupHover={{ color: "black" }}
+                >
+                  {faq.question}
+                </Heading>
+                <Icon
+                  as={openIndex === index ? ChevronUpIcon : ChevronDownIcon}
+                  w={5}
+                  h={5}
+                  mt={0.5}
+                  flexShrink={0}
+                  color="gray.400"
+                  transition="color 0.2s ease, transform 0.2s ease"
+                  _groupHover={{
+                    color: "gray.600",
+                    transform: openIndex === index ? "translateY(-1px)" : "translateY(2px)",
+                  }}
+                />
+              </Flex>
+
+              {openIndex === index && (
+                <Box
+                  px={{ base: 5, md: 6 }}
+                  pb={{ base: 5, md: 6 }}
+                  pt={4}
+                  borderTopWidth="1px"
+                  borderTopColor="gray.100"
+                  color="gray.600"
+                  fontSize={{ base: "0.9375rem", md: "1rem" }}
+                  fontWeight="400"
+                  lineHeight="tall"
+                >
+                  {faq.answer}
+                </Box>
+              )}
+            </Box>
+          ))}
+        </VStack>
+      </Container>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary

- what changed: Updated `src/pages/faq.tsx` to visually align the FAQ page with the broader Hushh marketing website theme. Added Playfair-style hero typography, standardized body styling using the existing marketing typography stack, refined subtitle/body color treatment, introduced a light grayscale background with white accordion cards, converted the layout into a centered single-column stack for improved readability, and enhanced FAQ question-row hover/active states with tinted backgrounds, subtle inset edge treatment, chevron transitions, and improved text emphasis.
- why it changed: To create a more cohesive and polished FAQ experience that visually matches the Home/marketing pages while improving readability, spacing consistency, and accordion interaction quality across devices.
- linked issue: `none - UI consistency and presentation-only alignment update`
- acceptance criteria covered: FAQ page visually matches the Hushh marketing theme, accordion cards render in a centered single-column layout, hover/active states display correctly on question rows, responsive layout behavior works across mobile and desktop breakpoints, and existing FAQ content and accordion behavior remain unchanged.
- risk area touched: `ui`
- reviewer focus: Verify visual consistency with the marketing/Home page theme; confirm single-column layout readability across breakpoints; validate accordion expand/collapse interactions, hover/focus states, chevron transitions, and responsive spacing behavior remain smooth and functional.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: Manually reviewed the updated FAQ page on mobile and desktop layouts; verified centered single-column rendering, accordion expand/collapse behavior, hover/focus states, chevron motion, typography hierarchy, grayscale card styling, and spacing consistency within `src/pages/faq.tsx`.
- did not run: `npm run test`, `npx tsc --noEmit`, `npm run build:web`, `npm run env:check`, and `npm run lint:ci` were not executed locally in this chat environment and are expected to run in CI; security checks were not applicable because no auth, infrastructure, deployment, or secret-management paths were modified.
- reviewer should verify: Open `/faq` on both mobile and desktop breakpoints and confirm the FAQ list renders in a centered single-column flow; validate accordion expand/collapse interactions continue functioning correctly; verify hover/focus states, card shadows, chevron transitions, and typography align visually with the Hushh marketing theme.

## Notes

- deployment impact: None expected beyond a standard frontend rebuild; no backend APIs, routing logic, deployment configuration, or infrastructure behavior were modified.
- migration or env requirements: None. No environment variables, migrations, infrastructure updates, or route registrations are required.
- rollback or release notes: Safe rollback by reverting changes in `src/pages/faq.tsx` to restore the previous FAQ page presentation and styling.
- follow-up work if any: Consider extracting reusable accordion and marketing-page surface styles into shared design-system primitives for consistency across informational pages.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI maintainers responsible for marketing pages, accordion interactions, and shared design-system consistency.

## Demo : Updated UI Glimpse 

## Before : 
<img width="1450" height="711" alt="Screenshot 2026-05-10 at 3 43 27 PM" src="https://github.com/user-attachments/assets/134bf7af-fbc5-4f5f-98cc-817965307ee8" />


## After : 
<img width="1453" height="836" alt="Screenshot 2026-05-10 at 3 39 32 PM" src="https://github.com/user-attachments/assets/1a5ea528-b16e-491c-9dd5-8de1134fe082" />
