### PR TITLE
fix(ui): add message character limit and live counter to contact form

### DIFF
--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -55,6 +55,7 @@ const fieldChrome = {
 };
 
 const cardHoverBorder = "rgba(0, 102, 204, 0.3)";
+const MESSAGE_MAX_LENGTH = 2000;
 
 const reasonOptions = [
   "Infrastructure Consultation",
@@ -335,11 +336,15 @@ export default function Contact() {
                     placeholder="Tell us how we can help you..."
                     value={formData.message}
                     onChange={handleChange}
+                    maxLength={MESSAGE_MAX_LENGTH}
                     size="md"
                     minH="120px"
                     rows={4}
                     {...fieldChrome}
                   />
+                  <Text fontSize="xs" color={gray500} mt={1.5} textAlign="right">
+                    {MESSAGE_MAX_LENGTH - formData.message.length} characters remaining
+                  </Text>
                 </FormControl>
 
                 <FormControl isRequired>


### PR DESCRIPTION
## Summary

- what changed: Added `maxLength={2000}` to the message textarea in `Contact.tsx` and implemented a dynamic remaining-character counter in the UI while the user types.

- why it changed: To prevent excessively large message inputs that could cause downstream email delivery issues, template overflow, or unnecessary payload size increases.

- linked issue: `none - issue number 1001`

- acceptance criteria covered: Message textarea input is limited to 2000 characters ; remaining character counter is visible in UI ; counter updates correctly while typing ; input stops accepting characters at the limit boundary

- risk area touched: `ui` | `security`

- reviewer focus: Verify the message field is capped at 2000 characters, confirm remaining counter updates correctly at boundary conditions (2000, 1999, and 0 remaining), and ensure no UI/layout regressions in the contact form.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [x] security checks when secrets, auth, infra, or deploy paths changed

- ran: local lint verification for `Contact.tsx` ; manual smoke verification of textarea limit and counter behavior

- did not run: `npm run test` ; `npx tsc --noEmit` ; `npm run build:web` ; `npm run env:check` ; `npm run lint:ci`

- reviewer should verify: Typing stops exactly at 2000 characters ; remaining character counter updates correctly throughout input lifecycle ; no layout or responsiveness issues in Contact form UI

## Notes

- deployment impact: None; frontend-only UI/input validation change.

- migration or env requirements: None.

- rollback or release notes: Revert the `Contact.tsx` update if rollback is required.

- follow-up work if any: Consider adding backend/server-side validation to enforce the same character limit beyond client-side controls.

- reviewer callouts or CODEOWNERS you expect to review this: Frontend maintainers and form handling reviewers.

## Demo

<img width="1440" height="698" alt="Screenshot 2026-05-10 at 8 17 25 PM" src="https://github.com/user-attachments/assets/6c9253cc-9ba7-45b8-be78-3a2ecb03d205" />
