### PR TITLE
fix(a11y): improve close button labeling in wallet preview modal

### DIFF
--- a/src/components/wallet/WalletCardPreviewModal.tsx
+++ b/src/components/wallet/WalletCardPreviewModal.tsx
@@ -191,6 +191,7 @@ export default function WalletCardPreviewModal({
       >
         <ModalHeader display="none" />
         <ModalCloseButton
+          aria-label="Close wallet preview"
           top={4}
           right={4}
           w={10}

--- a/tests/walletPreviewModal.test.ts
+++ b/tests/walletPreviewModal.test.ts
@@ -155,6 +155,9 @@ describe("WalletCardPreviewModal", () => {
       onAddToAppleWallet: () => undefined,
     });
 
+    expect(
+      document.body.querySelector('button[aria-label="Close wallet preview"]')
+    ).not.toBeNull();
     expect(document.body.textContent).toContain("Hushh Gold Pass");
     expect(document.body.textContent).toContain(
       "A polished gold preview of your Hushh investor membership card."


### PR DESCRIPTION
## Summary

- what changed: Improved close button accessibility labeling within the wallet preview modal by adding descriptive accessible naming for icon-only close interactions
- why it changed: Enhances accessibility support for screen readers and keyboard users by ensuring modal close controls communicate their purpose clearly to assistive technologies
- linked issue: none - standalone accessibility enhancement focused on improving semantic interaction quality within the wallet preview modal
- acceptance criteria covered: Wallet preview modal close controls expose meaningful accessible labels existing modal behavior remains unchanged visual presentation remains consistent
- risk area touched: ui
- reviewer focus: Confirm wallet preview modal close controls expose accurate accessible labels verify modal interactions continue functioning normally ensure no visual or interaction regressions were introduced

## Validation

- [x] Verified wallet preview modal close controls expose descriptive accessible labels
- [x] Verified existing modal interactions continue functioning normally
- [x] Verified keyboard accessibility remains stable
- [x] Verified visual presentation remains unchanged
- [x] No runtime rendering or interaction errors introduced

- ran: Manual accessibility inspection keyboard navigation verification local rendering validation browser accessibility tree inspection code review for aria-label consistency
- did not run: Automated accessibility scanning and assistive technology integration testing can be added in a follow-up PR if maintainers request expanded accessibility coverage
- reviewer should verify: Open the wallet preview modal confirm close controls expose descriptive accessible labels verify keyboard navigation and modal interactions remain stable and visually unchanged

## Notes

- deployment impact: Low risk frontend accessibility enhancement no backend or API changes purely semantic accessibility improvements for modal interaction controls
- migration or env requirements: None required no environment variables or infrastructure changes
- rollback or release notes: Safe to rollback if needed restores previous modal close-control semantics without affecting application functionality
- follow-up work if any: Consider introducing shared accessible modal interaction utilities and automated accessibility linting for icon-only controls in future improvements
- reviewer callouts or codeowners you expect to review this: This is a frontend accessibility enhancement focused on improving semantic interaction clarity and assistive technology compatibility within wallet preview modal experiences