### PR TITLE
feat(ui): align privacy policy page with hushh marketing theme

### DIFF
--- a/src/pages/privacy-policy/index.tsx
+++ b/src/pages/privacy-policy/index.tsx
@@ -1,223 +1,312 @@
 import React from "react";
 import {
-  Container,
   Box,
   Heading,
   Text,
-  Divider,
   VStack,
 } from "@chakra-ui/react";
 
+const playfair = { fontFamily: "'Playfair Display', serif" } as const;
+
+/** Community list controls + Contact cards: gradient surface, soft border, blue hover */
+const sectionCard =
+  "rounded-3xl border border-gray-200/70 bg-gradient-to-b from-white to-ios-gray-bg p-5 sm:p-8 shadow-soft hover:border-hushh-blue/25 transition-colors duration-200 ease-out";
+
+/** Contact page body / subtitles: gray-500, light weight */
+const bodyText =
+  "text-[13px] sm:text-sm text-gray-500 font-light leading-relaxed font-sans";
+
+/** Contact form section titles: Playfair, medium weight, black */
+const sectionTitleClass =
+  "font-serif text-xl sm:text-2xl font-medium text-black tracking-tight";
+
+/** Contact form labels: small medium gray-500 */
+const subsectionTitleClass =
+  "font-sans text-sm font-medium text-gray-500 tracking-normal";
+
 const PrivacyPolicyPage: React.FC = () => {
   return (
-    <>
-    <Box textAlign="center" mt={{md:'5rem',base:'2rem'}} mb={10}>
-        <Heading as="h1" size="2xl" fontWeight={'500'} className="blue-gradient-text" my={{md:'5rem',base:'2rem'}}>
-          Website Privacy Policy
+    <Box
+      className="bg-ios-gray-bg antialiased text-gray-900 min-h-screen selection:bg-hushh-blue selection:text-white"
+      pb={{ base: 12, md: 16 }}
+    >
+      <Box className="max-w-4xl mx-auto px-6 lg:px-10 w-full pt-8 md:pt-12 text-center">
+        <Box className="inline-flex items-center gap-1.5 px-3 py-1.5 border border-hushh-blue/20 rounded-full mb-6">
+          <span className="w-1.5 h-1.5 bg-hushh-blue rounded-full" />
+          <span className="text-[10px] tracking-[0.15em] uppercase font-medium text-hushh-blue">
+            Privacy
+          </span>
+        </Box>
+        <Heading
+          as="h1"
+          className="text-[4.125rem] leading-[1.1] font-normal text-black tracking-tight font-serif lg:text-[4.875rem]"
+          style={playfair}
+          mb={{ base: 8, md: 10 }}
+        >
+          Website Privacy<br />{" "}
+          <span className="text-gray-400 italic font-light">Policy</span>
         </Heading>
       </Box>
-    <Container maxW="container.lg" py={10} px={4}>
-      {/* Page Header */}
-      
 
-      <VStack spacing={8} align="stretch">
+      <Box className="max-w-4xl mx-auto px-6 lg:px-10 w-full">
+        <VStack spacing={{ base: 5, md: 6 }} align="stretch">
         {/* Introduction */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Introduction
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             This website privacy policy (the “Policy”) describes how Hushh Technologies LLC and its affiliates (“Hushh”) treat personal information collected on the HushhTech.com website (the “Website”). This Policy does not apply to information that Hushh may collect through other means.
           </Text>
         </Box>
-        <Divider />
 
         {/* Information That Hushh Collects */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Information That Hushh Collects
           </Heading>
           <Box ml={4}>
-            <Heading as="h3" size="md" mb={2}>
+            <Heading
+              as="h3"
+              mb={2}
+              className={subsectionTitleClass}
+            >
               Personal Information
             </Heading>
-            <Text mb={4}>
+            <Text mb={4} className={bodyText}>
               When you visit the Website, Hushh may collect certain personal information about you, such as your name, address, and email address, as well as any other personal information that you may provide, for example, through submission of forms or other documents.
             </Text>
-            <Heading as="h3" size="md" mb={2}>
+            <Heading
+              as="h3"
+              mb={2}
+              className={subsectionTitleClass}
+            >
               Nonpersonal Information
             </Heading>
-            <Text>
+            <Text className={bodyText}>
               Hushh will also collect the following nonpersonal information about your visit(s):
             </Text>
-            <Box pl={4} mt={2}>
-              <Text>• The IP address and domain name used (the IP address is a numerical identifier assigned either to your internet service provider or directly to your computer);</Text>
-              <Text>• The type of browser and operating system you use;</Text>
-              <Text>• The date, time, and duration for which you visit the Website, the number of times you have visited the Website, and where you come from.</Text>
+            <Box pl={4} mt={2} className="space-y-2">
+              <Text className={bodyText}>• The IP address and domain name used (the IP address is a numerical identifier assigned either to your internet service provider or directly to your computer);</Text>
+              <Text className={bodyText}>• The type of browser and operating system you use;</Text>
+              <Text className={bodyText}>• The date, time, and duration for which you visit the Website, the number of times you have visited the Website, and where you come from.</Text>
             </Box>
-            <Text mt={4}>
+            <Text mt={4} className={bodyText}>
               For purposes of collecting some of the above-referenced information, Hushh uses tracking tools on its Website, such as browser cookies and web beacons. A cookie and a web beacon are pieces of data stored on your device containing information about your visit.
             </Text>
           </Box>
         </Box>
-        <Divider />
 
         {/* How Hushh Uses Information */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             How Hushh Uses Information That It Collects
           </Heading>
-          <Text mb={4}>
+          <Text mb={4} className={bodyText}>
             Hushh uses information it collects in the following ways:
           </Text>
-          <Box pl={4}>
-            <Text>• To respond to your requests or questions;</Text>
-            <Text>• To inform you about Hushh;</Text>
-            <Text>• To communicate with you about your relationship with us;</Text>
-            <Text>• To improve the Website and the services provided;</Text>
-            <Text>• For security purposes.</Text>
+          <Box pl={4} className="space-y-2">
+            <Text className={bodyText}>• To respond to your requests or questions;</Text>
+            <Text className={bodyText}>• To inform you about Hushh;</Text>
+            <Text className={bodyText}>• To communicate with you about your relationship with us;</Text>
+            <Text className={bodyText}>• To improve the Website and the services provided;</Text>
+            <Text className={bodyText}>• For security purposes.</Text>
           </Box>
-          <Text mt={4}>
+          <Text mt={4} className={bodyText}>
             In addition, Hushh may use your information as otherwise permitted by law.
           </Text>
         </Box>
-        <Divider />
 
         {/* Sharing of Information */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Hushh May Share Your Information in Limited Circumstances
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             Hushh may share your information with its employees, agents, or third-party service providers who need to know such information for purposes of performing their jobs, including to respond to requests or questions that you may have. In addition, Hushh may share your information with third parties for purposes of complying with legal requirements or to respond to legal requests, such as in the case of a court order or subpoena or in connection with a regulatory investigation. Finally, Hushh might also share information that it collects with others when it is investigating potential fraud or for other reasons as permitted by law.
           </Text>
         </Box>
-        <Divider />
 
         {/* Protection of Information */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Protection of Information
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             Hushh is strongly committed to protecting any personal information collected through the Website against unauthorized access, use, or disclosure. Hushh will not sell or otherwise disclose any personal information collected from the Website, other than as described herein.
           </Text>
-          <Text mt={4}>
+          <Text mt={4} className={bodyText}>
             In addition, Hushh has implemented procedures to safeguard the integrity of its information technology assets, including but not limited to authentication, monitoring, auditing, and encryption. These security procedures have been integrated into the design, implementation, and day-to-day operations of the Website as part of a continuing commitment to the security of electronic content as well as the electronic transmission of information. However, no method of safeguarding information is completely secure. While Hushh uses measures designed to protect personal information, it cannot guarantee that our safeguards will be effective or sufficient.
           </Text>
-          <Text mt={4}>
+          <Text mt={4} className={bodyText}>
             For security purposes, Hushh employs software to monitor traffic to identify unauthorized attempts to upload or change information or otherwise damage the Website. Any information that an individual provides to Hushh by visiting the Website will be stored within the United States. If you live outside of the United States, you understand and agree that Hushh may store your information in the United States. The Website is subject to United States laws, which may or may not afford the same level of protection as those in your country.
           </Text>
         </Box>
-        <Divider />
 
         {/* Retention of Personal Information */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Retention of Personal Information
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             Hushh retains personal information to the extent Hushh deems necessary to carry out the processing activities described above, including but not limited to compliance with applicable laws, regulations, rules, and requests of relevant law enforcement and/or other governmental agencies, and to the extent Hushh reasonably deems necessary to protect its and its partners’ rights, property, or safety and the rights, property, and safety of its users and other third parties.
           </Text>
         </Box>
-        <Divider />
 
         {/* Cookies and Tracking Tools */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Cookies and Tracking Tools
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             As indicated above, Hushh collects nonpersonal information on its Website through the use of tracking tools, such as browser cookies. These cookies are necessary to allow you to browse the Website and access certain pages. Necessary cookies are required for the functionality of the Website so that it works properly. Hushh does not use these cookies to collect personal information about you.
           </Text>
-          <Text mt={4}>
+          <Text mt={4} className={bodyText}>
             Your browser may give you the ability to control cookies. Certain browsers can be set to reject cookies. Options you select are browser and device specific. If you block or delete cookies, not all of the tracking that we have described in this Policy will stop.
           </Text>
-          <Text mt={4}>
+          <Text mt={4} className={bodyText}>
             Hushh does not engage in automated decision-making for the processing of any personal information it collects.
           </Text>
         </Box>
-        <Divider />
 
         {/* Children and the Website */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Children and the Website
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             The Website is meant for adults. Hushh does not knowingly collect personally identifiable information from children under age 16. If you are a parent or legal guardian of a child under 16 who believes that child may have visited the Website, please contact us at the address below. By using the services provided by the Website, you represent that you are 16 years of age or older.
           </Text>
         </Box>
-        <Divider />
 
         {/* Business Transfer */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Business Transfer
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             Hushh may, in the future, sell or otherwise transfer some or all of its business, operations, or assets to a third party, whether by merger, acquisition, or otherwise. Personal information Hushh obtains from or about you through the Website may be disclosed to any potential or actual third-party acquirers and may be among those assets transferred.
           </Text>
         </Box>
-        <Divider />
 
         {/* Links to Other Sites or Third-Party Services */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Links to Other Sites or Third-Party Services
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             If a link to a third-party site is included on the Website and you click on it, you will be taken to a website Hushh does not control. This Policy does not apply to the privacy practices of that website. Read the privacy policy of other websites carefully. Hushh is not responsible for these third-party sites.
           </Text>
         </Box>
-        <Divider />
 
         {/* Disclaimer and Policy Updates */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Disclaimer and Policy Updates
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             This Policy should not be construed as giving business, legal, or other advice or warranting as failproof the security of information provided through the Website. Hushh will notify you of any material changes in this Policy by posting an updated copy on the Website.
           </Text>
         </Box>
-        <Divider />
 
         {/* Modifications and Updates */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Modifications and Updates to this Privacy Policy
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             This Policy replaces all previous disclosures. We reserve the right, at any time, to modify, alter, and/or update this Policy. Any such modifications will be effective upon our posting of the revised Policy.
           </Text>
         </Box>
-        <Divider />
 
         {/* Contact Information */}
-        <Box>
-          <Heading as="h2" size="lg" mb={4}>
+        <Box className={sectionCard}>
+          <Heading
+            as="h2"
+            mb={4}
+            className={sectionTitleClass}
+            style={playfair}
+          >
             Contact Information
           </Heading>
-          <Text>
+          <Text className={bodyText}>
             For questions regarding this Policy, please contact{" "}
-            <Text as="span" fontWeight="500">
+            <Text as="span" className="font-semibold text-hushh-blue font-sans">
             ir@hushh.ai
             </Text>
             .
           </Text>
         </Box>
-        <Divider />
 
         {/* Last Updated */}
-        <Box textAlign="center">
-          <Text fontSize="sm" color="gray.600">
+        <Box textAlign="center" className="pt-4 pb-6 border-t border-gray-200/80 mt-2">
+          <Text className="text-[13px] text-gray-400 font-light font-sans">
             Last Updated: February 5, 2025
           </Text>
         </Box>
       </VStack>
-    </Container>
-    </>
+      </Box>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary

- what changed: Updated the presentation layer of `src/pages/privacy-policy/index.tsx` to visually align the Privacy Policy page with the broader Hushh marketing website theme. Added `ios-gray-bg` page surfaces, refined responsive spacing/padding to match Community and Contact pages, introduced a Community-style hero label pill, updated the hero heading with Playfair typography and italic gray accent styling, wrapped policy sections in rounded gradient-backed cards with soft borders/shadows and subtle hover states, and refined typography hierarchy using Playfair section headings with muted gray body styling.
- why it changed: To create a more cohesive and polished legal/documentation experience that visually matches the Hushh marketing pages while improving readability, spacing consistency, and content hierarchy across mobile and desktop layouts.
- linked issue: `none - UI consistency and presentation-only alignment update`
- acceptance criteria covered: Privacy Policy page visually matches the Hushh marketing theme, responsive layout and spacing render correctly across breakpoints, section cards display proper hover styling and hierarchy, hero typography matches marketing pages, and all legal copy/content remains unchanged.
- risk area touched: `ui`
- reviewer focus: Verify visual consistency with Community/Contact marketing pages; confirm responsive layout behavior across mobile and desktop breakpoints; validate section card hover states, typography hierarchy, spacing, and grayscale styling; ensure no policy text or content structure was unintentionally modified.

## Validation

- [x] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [ ] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: Manually reviewed the updated `/privacy-policy` page on mobile and desktop layouts; verified responsive spacing, Playfair hero styling, gradient-backed section cards, hover states, typography hierarchy, muted grayscale styling, contact/email emphasis, and layout consistency against existing Community and Contact marketing pages.
- did not run: `npm run test`, `npx tsc --noEmit`, `npm run build:web`, `npm run env:check`, and `npm run lint:ci` were not executed locally in this chat environment and are expected to run in CI; security checks were not applicable because no auth, infrastructure, deployment, or secret-management paths were modified.
- reviewer should verify: Open `/privacy-policy` on both mobile and desktop breakpoints and confirm readability, spacing consistency, and absence of layout overflow; validate section cards render correctly with hover states and soft shadows; compare policy text against the previous version to confirm no legal wording/content changes were introduced.

## Notes

- deployment impact: None expected beyond a standard frontend rebuild; no backend APIs, routing logic, deployment configuration, or infrastructure behavior were modified.
- migration or env requirements: None. No environment variables, migrations, infrastructure updates, or route registrations are required.
- rollback or release notes: Safe rollback by reverting changes in `src/pages/privacy-policy/index.tsx` to restore the previous Privacy Policy page presentation and styling.
- follow-up work if any: Consider extracting shared legal-page surface and hero styling into reusable marketing/documentation layout primitives for consistency across additional policy or informational pages.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI maintainers responsible for marketing pages, legal/documentation surfaces, and shared design-system consistency.

## Demo : Updated UI Glimpse 

## Before : 
<img width="1454" height="838" alt="Screenshot 2026-05-11 at 12 03 22 AM" src="https://github.com/user-attachments/assets/e4910da2-18de-469b-bb78-d85a9a639bf3" />

## After : 
<img width="1454" height="837" alt="Screenshot 2026-05-11 at 12 00 05 AM" src="https://github.com/user-attachments/assets/584615ce-ac96-40c8-9eaa-5ef60bd834a2" />
