### PR TITLE
fix(auth): prevent stale session restore on boot

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -108,7 +108,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.571Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -185,14 +185,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -213,7 +213,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -227,14 +227,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -255,7 +255,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -276,7 +276,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.574Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -290,14 +290,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -346,728 +346,728 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-market-updates</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10mar</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11feb</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu12feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu15apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu16apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu17apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu18feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu1april</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu22apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu23apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24feb</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.568Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25feb</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25mar</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu2apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu30may</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.569Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu8apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu9apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/marekt-update2</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-outlook-mid2025</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update10feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update19feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update20feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.570Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update5feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.571Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update6feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.571Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update7feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.571Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.571Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-performance</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-updates-jan</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-funds</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/kyc-fund-updates</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/wire-transformation</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-skill-testing</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-driven-personal-agents</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.563Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-infrastructure</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-powered-berkshire</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27cash-flow-monarchy</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27india-strategic-plan</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha-agents-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fcf-aces-of-aces-portfolio-update_corrected</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/growth-plan</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/head-of-quants</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/holy-grail-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.564Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-employee-handbook</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-pda</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-renaissance-ainative</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-tech-prospectus</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-ventures</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/investment-perspective</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/medallion-model-india</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/pattern-of-alpha</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/perpetual-alpha-engine</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/renaissance-aifirst-fund</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-context</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.565Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-featured</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-walle-master-class</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/selle-wall</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/delta-allocation-report</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/exhibit-lpa</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investor-update</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-news</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-questionnaire</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/limited-partnership-agreement</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/profit-margin-report</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.566Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-a</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-b</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-c</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-cshares</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.567Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/hushh-product-updates</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.573Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/products-update</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.573Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.574Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/set-walls</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:14:11.574Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>

--- a/src/auth/AuthSessionProvider.tsx
+++ b/src/auth/AuthSessionProvider.tsx
@@ -54,6 +54,7 @@ export const AuthSessionProvider: React.FC<{
   const [snapshot, setSnapshot] =
     useState<AuthSessionSnapshot>(INITIAL_SNAPSHOT);
   const pendingSignedOutStateRef = useRef<PendingSignedOutState | null>(null);
+  const bootValidationRunRef = useRef(0);
 
   const applySnapshot = useCallback((nextSnapshot: AuthSessionSnapshot) => {
     setSnapshot((currentSnapshot) => {
@@ -128,15 +129,41 @@ export const AuthSessionProvider: React.FC<{
   }, [applySnapshot, clearLocalSession, supabase]);
 
   // Boot: Instantly resolve from localStorage (no network call).
-  // This eliminates the 'booting' state almost immediately.
-  // onAuthStateChange below handles INITIAL_SESSION for the definitive state.
+  // This eliminates the 'booting' state almost immediately, then upgrades to a
+  // definitive server-validated snapshot in the background.
   useEffect(() => {
+    let cancelled = false;
+
     const bootFromLocalStorage = async () => {
       const localSnapshot = await getLocalSession(supabase);
+      if (cancelled) {
+        return;
+      }
       applySnapshot(localSnapshot);
+
+      const runId = ++bootValidationRunRef.current;
+      const validatedSnapshot = await getValidatedSession(supabase);
+      if (cancelled || runId !== bootValidationRunRef.current) {
+        return;
+      }
+
+      if (validatedSnapshot.status === "invalidated") {
+        await clearLocalSession(
+          "invalidated",
+          validatedSnapshot.reason || "invalid_session"
+        );
+        return;
+      }
+
+      applySnapshot(validatedSnapshot);
     };
+
     void bootFromLocalStorage();
-  }, [applySnapshot, supabase]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [applySnapshot, clearLocalSession, supabase]);
 
   useEffect(() => {
     if (!supabase) {
@@ -151,6 +178,10 @@ export const AuthSessionProvider: React.FC<{
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, nextSession) => {
+      if (event === "INITIAL_SESSION") {
+        return;
+      }
+
       if (event === "SIGNED_OUT" || !nextSession) {
         const pendingState = pendingSignedOutStateRef.current;
         pendingSignedOutStateRef.current = null;

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -194,14 +194,14 @@ const AuthCallback: React.FC = () => {
                 size="lg"
                 onClick={() => navigate('/user-registration')}
               >
-                Set us your profile
+                Set up your profile
               </Button>
               <Button
                 variant="outline"
                 size="lg"
                 onClick={() => navigate('/community')}
               >
-                Checkout communnity posts
+                Checkout community posts
               </Button>
             </Flex>
           </Flex>

--- a/tests/authCallback.test.ts
+++ b/tests/authCallback.test.ts
@@ -128,6 +128,8 @@ describe("AuthCallback", () => {
     expect(mockExchangeCodeForSession).toHaveBeenCalledWith("fresh-code");
     expect(revalidateSessionMock).toHaveBeenCalled();
     expect(replaceStateSpy).toHaveBeenCalled();
+    expect(container.textContent).toContain("Set up your profile");
+    expect(container.textContent).toContain("Checkout community posts");
 
     await act(async () => {
       vi.runAllTimers();

--- a/tests/authSessionProvider.test.ts
+++ b/tests/authSessionProvider.test.ts
@@ -28,6 +28,9 @@ const mockOnAuthStateChange = vi.fn();
 const mockSignOut = vi.fn();
 const mockSignInWithOAuth = vi.fn();
 const unsubscribeMock = vi.fn();
+let authStateChangeHandler:
+  | ((event: string, session: typeof MOCK_SESSION | null) => void | Promise<void>)
+  | null = null;
 
 vi.mock("../src/resources/config/config", () => ({
   default: {
@@ -118,14 +121,18 @@ describe("AuthSessionProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    authStateChangeHandler = null;
 
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
 
-    mockOnAuthStateChange.mockImplementation(() => ({
-      data: { subscription: { unsubscribe: unsubscribeMock } },
-    }));
+    mockOnAuthStateChange.mockImplementation((callback) => {
+      authStateChangeHandler = callback;
+      return {
+        data: { subscription: { unsubscribe: unsubscribeMock } },
+      };
+    });
     mockSignOut.mockResolvedValue({ error: null });
   });
 
@@ -159,8 +166,7 @@ describe("AuthSessionProvider", () => {
     );
   });
 
-  // TODO: Fix race condition — getUser 401 resolves after getSession restores "authenticated"
-  it.skip("invalidates a stale persisted session and clears it locally", async () => {
+  it("invalidates a stale persisted session and clears it locally", async () => {
     mockGetSession.mockResolvedValue({
       data: { session: MOCK_SESSION },
       error: null,
@@ -182,6 +188,34 @@ describe("AuthSessionProvider", () => {
       "expired"
     );
     expect(mockSignOut).toHaveBeenCalledWith({ scope: "local" });
+  });
+
+  it("does not let INITIAL_SESSION restore auth after boot validation invalidates it", async () => {
+    mockGetSession.mockResolvedValue({
+      data: { session: MOCK_SESSION },
+      error: null,
+    });
+    mockGetUser.mockResolvedValue({
+      data: { user: null },
+      error: { status: 401, message: "JWT expired" },
+    });
+
+    await act(async () => {
+      root.render(renderWithProvider(React.createElement(AuthHarness)));
+    });
+    await flush();
+
+    await act(async () => {
+      await authStateChangeHandler?.("INITIAL_SESSION", MOCK_SESSION);
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe(
+      "invalidated"
+    );
+    expect(container.querySelector('[data-testid="reason"]')?.textContent).toBe(
+      "expired"
+    );
   });
 
   it("broadcast-driven deletion invalidates another tab immediately", async () => {


### PR DESCRIPTION
## Summary

- what changed: Fixed a race in `AuthSessionProvider` so boot-time server validation cannot be overwritten by Supabase’s `INITIAL_SESSION` event from local storage, corrected copy typos on the `AuthCallback` success screen, and added regression test coverage
- why it changed: Prevents stale or expired persisted Supabase sessions from incorrectly restoring the UI to `authenticated` after server validation has already determined the session is invalid
- linked issue: not applicable - bug fix for auth session invalidation race and callback UI copy
- acceptance criteria covered: App performs background server validation on boot, invalidated state is preserved when the server rejects the token, stale local auth state no longer restores the session, success page displays `Set up your profile`, success page displays `community`
- risk area touched: auth, ui
- reviewer focus: Confirm stale persisted sessions end in `invalidated` rather than `authenticated`, verify `INITIAL_SESSION` no longer restores invalid auth state, review that normal `SIGNED_IN` and `TOKEN_REFRESHED` flows remain intact, confirm corrected AuthCallback copy

## Validation

- [x] Enabled the previously skipped stale-session invalidation unit test
- [x] Added a regression test proving `INITIAL_SESSION` cannot restore auth after boot validation invalidates it
- [x] Updated auth callback test assertions for corrected success copy
- [x] Verified `AuthSessionProvider` now performs local boot plus background server validation
- [x] Verified `INITIAL_SESSION` is ignored as an authoritative restore event
- [x] No backend, API, database, secrets, or environment variable changes introduced

- ran: Code review of auth boot flow, targeted test updates, diff review
- did not run: Automated test execution in this workspace because local dependencies are not installed and `vitest` is unavailable
- reviewer should verify: Reproduce with a stale Supabase local session, refresh the app, confirm auth remains invalidated after server rejection, and confirm the AuthCallback success UI shows the corrected text

## Notes

- deployment impact: Low to moderate risk frontend-only auth state handling change with no backend or infrastructure changes
- migration or env requirements: None required
- rollback or release notes: Safe to rollback by reverting the `AuthSessionProvider`, `AuthCallback`, and related test updates
- follow-up work if any: Once dependencies are installed, run the targeted Vitest files and optionally expand auth boot coverage to include valid `INITIAL_SESSION` plus `TOKEN_REFRESHED` scenarios
- reviewer callouts or codeowners you expect to review this: Frontend/auth reviewer should focus on session lifecycle behavior, regression risk around sign-in refresh flows, and UI copy correctness

The CI failure was specifically from:
- title format: fixed by using `fix(auth): ...`
- risk area values: fixed by using only supported values `auth, ui`