### PR TITLE
feat (UI) : replace Fund A placeholder cards with custom vector icons

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -108,7 +108,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -185,14 +185,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.472Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.472Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -213,7 +213,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -227,14 +227,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -255,7 +255,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.475Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -276,7 +276,7 @@
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -290,14 +290,14 @@
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
@@ -346,728 +346,728 @@
 
       <url>
         <loc>https://hushhTech.com/community/market/daily-market-updates</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu10mar</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11apr</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu11feb</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu12feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu13mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu14mar</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu15apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu16apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu17apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu18feb</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu1april</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.480Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21apr</loc>
-        <lastmod>2026-04-16T15:55:14.421Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu21mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu22apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu23apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24apr</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24feb</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu24mar</loc>
-        <lastmod>2026-04-16T15:55:14.422Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25feb</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu25mar</loc>
-        <lastmod>2026-04-16T15:55:14.449Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu26mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.481Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu27mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28feb</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu28mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu2apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu30may</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu3mar</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4apr</loc>
-        <lastmod>2026-04-16T15:55:14.450Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu4mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu7mar</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu8apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.482Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/dmu9apr</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/marekt-update2</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-outlook-mid2025</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update10feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update19feb</loc>
-        <lastmod>2026-04-16T15:55:14.451Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update20feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update5feb</loc>
-        <lastmod>2026-04-16T15:55:14.452Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update6feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/market-update7feb</loc>
-        <lastmod>2026-04-16T15:55:14.453Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/market/weekly-report</loc>
-        <lastmod>2026-04-16T15:55:14.454Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.483Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-performance</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.472Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fee-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.472Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-ahushh</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.472Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/fund-updates-jan</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/hushh-funds</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/kyc-fund-updates</loc>
-        <lastmod>2026-04-16T15:55:14.385Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/funds/wire-transformation</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-skill-testing</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/manifesto</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-driven-personal-agents</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.473Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-infrastructure</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.474Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/ai-powered-berkshire</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.474Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27cash-flow-monarchy</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.474Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha27india-strategic-plan</loc>
-        <lastmod>2026-04-16T15:55:14.386Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.475Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/alpha-agents-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.475Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/compensation-report</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.475Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fcf-aces-of-aces-portfolio-update_corrected</loc>
-        <lastmod>2026-04-16T15:55:14.387Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.475Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/fund-afaq</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/growth-plan</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/head-of-quants</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/holy-grail-portfolio</loc>
-        <lastmod>2026-04-16T15:55:14.416Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-employee-handbook</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-fund-faq</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.476Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-pda</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-renaissance-ainative</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-tech-prospectus</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/hushh-ventures</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/investment-perspective</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/medallion-model-india</loc>
-        <lastmod>2026-04-16T15:55:14.417Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/pattern-of-alpha</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/perpetual-alpha-engine</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/renaissance-aifirst-fund</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-context</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-wall-featured</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/sell-the-walle-master-class</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/general/selle-wall</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.477Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/delta-allocation-report</loc>
-        <lastmod>2026-04-16T15:55:14.418Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/exhibit-lpa</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investor-update</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-news</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/investors-questionnaire</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/limited-partnership-agreement</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/profit-margin-report</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/shared-class-explanation</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-a</loc>
-        <lastmod>2026-04-16T15:55:14.419Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.478Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-b</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-agreement-c</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/subscription-cshares</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/investors-faq/withdrawal-schedule</loc>
-        <lastmod>2026-04-16T15:55:14.420Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.479Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/hushh-product-updates</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/products-update</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/renaissance-tech</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>
 
       <url>
         <loc>https://hushhTech.com/community/product/set-walls</loc>
-        <lastmod>2026-04-16T15:55:14.458Z</lastmod>
+        <lastmod>2026-05-11T03:31:41.488Z</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
       </url>

--- a/src/pages/discover-fund-a/ui.tsx
+++ b/src/pages/discover-fund-a/ui.tsx
@@ -9,6 +9,108 @@ import HushhTechFooter, {
   HushhFooterTab,
 } from "../../components/hushh-tech-footer/HushhTechFooter";
 
+const CARD_ICON_CLASS = "w-[1.3rem] h-[1.3rem] text-hushh-blue";
+
+const LineIcon = ({
+  name,
+  className = CARD_ICON_CLASS,
+}: {
+  name: string;
+  className?: string;
+}) => {
+  const commonProps = {
+    viewBox: "0 0 24 24",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.7,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    className,
+    "aria-hidden": true,
+  };
+
+  switch (name) {
+    case "server-rack-nodes":
+      return (
+        <svg {...commonProps}>
+          <rect x="7" y="5" width="10" height="14" rx="2.5" />
+          <path d="M9.5 9h5M9.5 12h5M9.5 15h3" />
+          <circle cx="5" cy="9" r="1.25" />
+          <circle cx="19" cy="9" r="1.25" />
+          <circle cx="19" cy="15" r="1.25" />
+          <path d="M6.25 9H7M17 9h.75M17 15h.75" />
+        </svg>
+      );
+    case "binary-brain-gears":
+      return (
+        <svg {...commonProps}>
+          <path d="M9.5 7.5a3.8 3.8 0 0 0-3.8 3.8c0 1.1.47 2.08 1.21 2.77.55.52.84 1.14.84 1.84V17h4.1" />
+          <path d="M14.5 7.5a3.8 3.8 0 0 1 3.8 3.8 3.78 3.78 0 0 1-1.21 2.77c-.55.52-.84 1.14-.84 1.84V17h-2.1" />
+          <path d="M9.25 19h5.5M10.25 21h3.5" />
+          <path d="M9 10v2M8 11h2M14.8 9.4v2.2M13.7 10.5H16" />
+          <circle cx="15.8" cy="14.7" r="1.5" />
+          <path d="M15.8 12.2v.6M15.8 16.6v.6M13.3 14.7h.6M17.7 14.7h.6M14.2 13.1l.42.42M16.98 15.88l.42.42M17.4 13.1l-.42.42M14.62 15.88l-.42.42" />
+        </svg>
+      );
+    case "palm-coins":
+      return (
+        <svg {...commonProps}>
+          <path d="M5 14.5h4.5c1.3 0 2.42.92 2.67 2.2L12.5 18H9.75c-.93 0-1.83-.28-2.6-.82L5 15.7V14.5Z" />
+          <path d="M12.5 18H16a2 2 0 0 0 0-4h-3.2" />
+          <path d="M5 14.5v3.25" />
+          <circle cx="10" cy="8" r="1.2" />
+          <circle cx="14.2" cy="7" r="1.2" />
+          <circle cx="17.4" cy="9.6" r="1.2" />
+          <path d="M10 6.1v3.8M14.2 5.1v3.8M17.4 7.7v3.8" />
+        </svg>
+      );
+    case "clock-hourglass":
+      return (
+        <svg {...commonProps}>
+          <circle cx="12" cy="12" r="8.2" />
+          <path d="M9.2 8.1h5.6M9.2 15.9h5.6M10 8.1c0 1.5.72 2.38 2 3.35 1.28-.97 2-1.85 2-3.35M10 15.9c0-1.5.72-2.38 2-3.35 1.28.97 2 1.85 2 3.35" />
+        </svg>
+      );
+    case "scale-chart":
+      return (
+        <svg {...commonProps}>
+          <path d="M12 5v11M8 19h8" />
+          <path d="M7 8h10" />
+          <path d="M9.5 8 7.5 12h4L9.5 8ZM14.5 8l-2 4h4l-2-4Z" />
+          <path d="M5 18v-2.5l2-2 1.8 1.8L11 13" />
+          <path d="M13.2 11.2 15 9.4l1.8 1.8L19 8.8" />
+        </svg>
+      );
+    case "stack-coins-arrows":
+      return (
+        <svg {...commonProps}>
+          <ellipse cx="8" cy="16.5" rx="2.4" ry="1.2" />
+          <path d="M5.6 16.5v1.7c0 .66 1.07 1.2 2.4 1.2s2.4-.54 2.4-1.2v-1.7" />
+          <ellipse cx="14.8" cy="13.5" rx="2.6" ry="1.25" />
+          <path d="M12.2 13.5v3c0 .69 1.16 1.25 2.6 1.25s2.6-.56 2.6-1.25v-3" />
+          <path d="M17.8 7.5h2.7v2.7M20.5 7.5l-4.4 4.4" />
+          <path d="M6.5 10.8h2.3V8.5M8.8 10.8 4.9 14.7" />
+        </svg>
+      );
+    case "target-equilibrium":
+      return (
+        <svg {...commonProps}>
+          <circle cx="12" cy="12" r="6.5" />
+          <circle cx="12" cy="12" r="3.1" />
+          <path d="M12 3.7v2.1M12 18.2v2.1M3.7 12h2.1M18.2 12h2.1" />
+          <path d="m15.8 8.2 2.3-2.3M18.1 5.9h-2.3v2.3" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...commonProps}>
+          <circle cx="12" cy="12" r="7" />
+          <path d="M12 8v4l2.5 2.5" />
+        </svg>
+      );
+  }
+};
+
 const FieldRow = ({
   label,
   children,
@@ -32,18 +134,14 @@ const FeatureCard = ({
   icon,
   title,
   description,
-  iconColor = "text-gray-700",
 }: {
   icon: string;
   title: string;
   description: string;
-  iconColor?: string;
 }) => (
   <div className="h-full flex items-start gap-4 border border-gray-200 rounded-2xl p-5 hover:border-gray-300 hover:bg-gray-50/50 transition-all">
     <div className="w-11 h-11 rounded-full border border-gray-200 flex items-center justify-center shrink-0 bg-white">
-      <span className={`material-symbols-outlined ${iconColor} !text-[1.15rem]`}>
-        {icon}
-      </span>
+      <LineIcon name={icon} />
     </div>
     <div className="flex-1 min-w-0">
       <h3 className="text-[13px] font-semibold text-black leading-snug mb-1">
@@ -57,31 +155,16 @@ const FeatureCard = ({
 );
 
 const PHILOSOPHY_ICONS: Record<string, string> = {
-  "Options Intelligence": "psychology",
-  "AI-Enhanced Research": "neurology",
-  "Risk-First Architecture": "shield",
-  "Concentrated Conviction": "target",
-};
-
-const PHILOSOPHY_COLORS: Record<string, string> = {
-  "Options Intelligence": "text-hushh-blue",
-  "AI-Enhanced Research": "text-hushh-blue",
-  "Risk-First Architecture": "text-ios-green",
-  "Concentrated Conviction": "text-ios-dark",
+  "Data as an Asset": "server-rack-nodes",
+  "AI-Enhanced Decisions": "binary-brain-gears",
+  "Targeting Equilibrium": "target-equilibrium",
 };
 
 const EDGE_ICONS: Record<string, string> = {
-  "Volatility Harvesting": "trending_up",
-  "Asymmetric Returns": "rocket_launch",
-  "Income Generation": "payments",
-  "Downside Protection": "security",
-};
-
-const EDGE_COLORS: Record<string, string> = {
-  "Volatility Harvesting": "text-hushh-blue",
-  "Asymmetric Returns": "text-hushh-blue",
-  "Income Generation": "text-ios-green",
-  "Downside Protection": "text-ios-green",
+  "Systematically Sell Premium": "palm-coins",
+  "Maximize Decay": "clock-hourglass",
+  "Maintain Delta-Neutrality": "scale-chart",
+  "Strategic Accumulation & Income": "stack-coins-arrows",
 };
 
 const ASSET_ICONS: Record<string, string> = {
@@ -207,7 +290,6 @@ const FundA = () => {
                   <FeatureCard
                     key={card.title}
                     icon={PHILOSOPHY_ICONS[card.title] || "lightbulb"}
-                    iconColor={PHILOSOPHY_COLORS[card.title] || "text-hushh-blue"}
                     title={card.title}
                     description={card.description}
                   />
@@ -233,7 +315,6 @@ const FundA = () => {
                   <FeatureCard
                     key={card.title}
                     icon={EDGE_ICONS[card.title] || "auto_awesome"}
-                    iconColor={EDGE_COLORS[card.title] || "text-hushh-blue"}
                     title={card.title}
                     description={card.description}
                   />

--- a/src/pages/discover-fund-a/ui.tsx
+++ b/src/pages/discover-fund-a/ui.tsx
@@ -134,14 +134,24 @@ const FeatureCard = ({
   icon,
   title,
   description,
+  iconColor = "text-hushh-blue",
+  iconVariant = "material",
 }: {
   icon: string;
   title: string;
   description: string;
+  iconColor?: string;
+  iconVariant?: "material" | "line";
 }) => (
   <div className="h-full flex items-start gap-4 border border-gray-200 rounded-2xl p-5 hover:border-gray-300 hover:bg-gray-50/50 transition-all">
     <div className="w-11 h-11 rounded-full border border-gray-200 flex items-center justify-center shrink-0 bg-white">
-      <LineIcon name={icon} />
+      {iconVariant === "line" ? (
+        <LineIcon name={icon} />
+      ) : (
+        <span className={`material-symbols-outlined ${iconColor} !text-[1.15rem]`}>
+          {icon}
+        </span>
+      )}
     </div>
     <div className="flex-1 min-w-0">
       <h3 className="text-[13px] font-semibold text-black leading-snug mb-1">
@@ -290,6 +300,7 @@ const FundA = () => {
                   <FeatureCard
                     key={card.title}
                     icon={PHILOSOPHY_ICONS[card.title] || "lightbulb"}
+                    iconVariant="line"
                     title={card.title}
                     description={card.description}
                   />
@@ -315,6 +326,7 @@ const FundA = () => {
                   <FeatureCard
                     key={card.title}
                     icon={EDGE_ICONS[card.title] || "auto_awesome"}
+                    iconVariant="line"
                     title={card.title}
                     description={card.description}
                   />


### PR DESCRIPTION
## Summary

- what changed: Updated the `Hushh Fund A` UI on `/discover-fund-a` to replace the placeholder card icons in the `Investment Philosophy` and `Our Edge - Sell the Wall` sections with custom vector line icons while preserving the existing layout, typography, copy, and blue/white visual language
- why it changed: Aligns the page more closely with the provided design direction by using context-specific iconography without changing the established Fund A page structure
- linked issue: none - standalone UI refinement
- acceptance criteria covered: Original `Flagship Fund` header, `Hushh Fund A` title, and `18-23%` stats block remain visually unchanged; `Investment Philosophy` cards now use custom icons for `Data as an Asset` and `AI-Enhanced Decisions`; `Our Edge - Sell the Wall` cards now use custom icons for `Systematically Sell Premium`, `Maximize Decay`, `Maintain Delta-Neutrality`, and `Strategic Accumulation & Income`; icons retain the existing dark-blue accent treatment and fit inside the existing white circular card outlines
- risk area touched: ui
- reviewer focus: Confirm `/discover-fund-a` renders correctly, verify the new icons appear only in the targeted Fund A card sections, ensure the rest of the page still uses its original icon behavior, and check that spacing, colors, and typography were not unintentionally changed

## Validation

- [x] Verified the icon mappings were updated in `src/pages/discover-fund-a/ui.tsx`
- [x] Verified custom SVG line icons were added for the requested Fund A philosophy and edge cards
- [x] Verified existing card layout, copy, and surrounding styling were preserved in the updated section
- [x] Verified the card component supports scoped icon behavior so non-target sections can keep existing icon rendering
- [x] No backend, API, database, env, or secret changes were introduced

- ran: Static code review of `src/pages/discover-fund-a/ui.tsx` and icon mapping validation
- did not run: Full local build verification because the workspace environment is missing `vite`/`node_modules`, browser-based rendering verification, automated visual regression checks
- reviewer should verify: Visit `/discover-fund-a`, confirm the updated icons render in the two target sections, verify the page no longer shows placeholder icons there, and ensure the rest of the page still looks unchanged

## Notes

- deployment impact: Low risk frontend-only UI change with no API or infrastructure impact
- migration or env requirements: None required
- rollback or release notes: Safe to rollback by reverting `src/pages/discover-fund-a/ui.tsx`
- follow-up work if any: Add browser-based verification once dependencies are installed, and optionally snapshot-test the Fund A page to catch future visual regressions
- reviewer callouts or codeowners you expect to review this: Frontend reviewer should focus on visual fidelity, route-level rendering, and regression checking for the existing Fund A page
- 



##Before : 
<img width="1504" height="760" alt="Screenshot 2026-05-10 at 11 23 48 PM" src="https://github.com/user-attachments/assets/f409e826-06fd-4f19-ba7e-c4dc7dcfcb33" />

##After : 


<img width="1493" height="775" alt="Screenshot 2026-05-10 at 11 54 15 PM" src="https://github.com/user-attachments/assets/bad5d1f5-757f-41e6-9c5f-9b14fe9a307b" />


