### PR TITLE
fix(a11y): add descriptive labels to metric card values

### DIFF
--- a/src/pages/metrics/index.tsx
+++ b/src/pages/metrics/index.tsx
@@ -149,7 +149,7 @@ function buildLookerStudioLink(rawUrl?: string) {
   }
 }
 
-function MetricCard({
+export function MetricCard({
   eyebrow,
   label,
   value,
@@ -169,10 +169,15 @@ function MetricCard({
       <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-gray-500">
         {eyebrow}
       </p>
-      <h3 className="mt-3 text-[28px] font-semibold tracking-tight text-black">
+      <h3
+        className="mt-3 text-[28px] font-semibold tracking-tight text-black"
+        aria-label={`${label}: ${value}`}
+      >
         {value}
       </h3>
-      <p className="mt-2 text-sm font-medium text-gray-700">{label}</p>
+      <p className="mt-2 text-sm font-medium text-gray-700" aria-hidden="true">
+        {label}
+      </p>
       {hint ? (
         <p className="mt-1 text-sm leading-6 text-gray-500">{hint}</p>
       ) : null}

--- a/tests/metricsMetricCardA11y.test.ts
+++ b/tests/metricsMetricCardA11y.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { MetricCard } from "../src/pages/metrics";
+
+describe("metrics MetricCard accessibility", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function renderMetricCard() {
+    await act(async () => {
+      root.render(
+        React.createElement(MetricCard, {
+          eyebrow: "Audience",
+          label: "Total users",
+          value: "1,234",
+        })
+      );
+    });
+  }
+
+  it("labels metric values with their visible metric name without repeating the label", async () => {
+    await renderMetricCard();
+
+    const valueHeading = container.querySelector("h3");
+    const visibleLabel = container.querySelector("p.mt-2");
+
+    expect(valueHeading?.getAttribute("aria-label")).toBe("Total users: 1,234");
+    expect(visibleLabel?.textContent).toBe("Total users");
+    expect(visibleLabel?.getAttribute("aria-hidden")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary

- what changed: Added descriptive accessibility labels to targeted metric card values to improve semantic clarity for assistive technologies
- why it changed: Enhances accessibility support by ensuring metric values communicate clearer contextual meaning to screen readers and assistive technologies
- linked issue: none - standalone accessibility enhancement focused on improving semantic metric presentation and assistive technology compatibility
- acceptance criteria covered: Metric card values expose meaningful accessibility semantics existing visual presentation remains unchanged existing interactions continue functioning normally
- risk area touched: ui
- reviewer focus: Confirm metric card values expose accurate descriptive labels verify visual presentation remains unchanged ensure no accessibility or rendering regressions were introduced

## Validation

- [x] Verified metric card values expose descriptive accessibility labels
- [x] Verified existing metric card interactions continue functioning normally
- [x] Verified visual layout and styling remain unchanged
- [x] Verified accessibility semantics improve for assistive technologies
- [x] No runtime rendering or interaction errors introduced

- ran: Manual accessibility inspection browser accessibility tree verification local rendering validation code review for semantic labeling consistency
- did not run: Automated accessibility scanning and assistive technology integration testing can be added in a follow-up PR if maintainers request expanded accessibility coverage
- reviewer should verify: Inspect updated metric cards confirm descriptive accessibility labels are applied correctly verify visual presentation and interaction behavior remain stable across affected surfaces

## Notes

- deployment impact: Low risk frontend accessibility enhancement no backend or API changes purely semantic accessibility improvements for metric presentation surfaces
- migration or env requirements: None required no environment variables or infrastructure changes
- rollback or release notes: Safe to rollback if needed restores previous metric-card semantics without affecting application functionality
- follow-up work if any: Consider introducing shared accessible metric presentation utilities and automated accessibility linting for analytics surfaces in future improvements
- reviewer callouts or codeowners you expect to review this: This is a frontend accessibility enhancement focused on improving semantic clarity and assistive technology compatibility across metric-card experiences