### PR TITLE
fix: correct career-privacy-policy route typo and broken careers footer link #1215 ✏️

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,7 +181,7 @@ function App() {
             <Route path="/career" element={<Career />} />
             <Route path="/career/*" element={<Career />} />
             <Route path='/privacy-policy' element={<PrivacyPolicy />} />
-            <Route path='/carrer-privacy-policy' element={<CareersPrivacyPolicy />} />
+            <Route path='/career-privacy-policy' element={<CareersPrivacyPolicy />} />
             <Route path="/community" element={
               <CommunityPage />
             } />

--- a/src/auth/routePolicy.ts
+++ b/src/auth/routePolicy.ts
@@ -15,7 +15,7 @@ export const PUBLIC_MARKETING_ROUTE_PREFIXES = [
   "/metrics",
   "/privacy-policy",
   "/faq",
-  "/carrer-privacy-policy",
+  "/career-privacy-policy",
   "/california-privacy-policy",
   "/eu-uk-jobs-privacy-policy",
   "/investor-guide",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -100,7 +100,7 @@ export default function Footer() {
                   Benefits
                 </a>
                 <a 
-                  href="/careers" 
+                  href="/career" 
                   className="py-2 text-gray-300 hover:text-white text-base font-medium flex items-center justify-between group block transition-colors duration-200"
                 >
                   Careers
@@ -161,7 +161,7 @@ export default function Footer() {
               California Privacy Policy
             </a>
             <a 
-              href="/carrer-privacy-policy" 
+              href="/career-privacy-policy" 
               className="py-2 text-gray-300 hover:text-white text-base font-medium flex items-center justify-between group transition-colors duration-200"
             >
               Careers Site Privacy Notice


### PR DESCRIPTION
Closes #1214

## Summary
- **what changed:** Fixed misspelled route `/carrer-privacy-policy` → `/career-privacy-policy` in App.tsx, Footer.tsx, and routePolicy.ts. Also fixed broken footer Careers link from `/careers` → `/career` to match the actual registered route.
- **why it changed:** Both links in the footer were causing 404 errors for every user who clicked them. The typo `carrer` made the Careers Privacy Policy page completely unreachable. The `/careers` link pointed to a non-existent route.
- **linked issue:** No linked issue — bug discovered during codebase audit
- **acceptance criteria covered:** Footer Careers link navigates to `/career` without 404. Footer Careers Site Privacy Notice navigates to `/career-privacy-policy` without 404.
- **risk area touched:** ui
- **reviewer focus:** Verify that both corrected footer links load their respective pages without 404 errors.

## Validation
- **ran:** `npm tsc --noEmit` — 0 type errors. Manual verification confirmed both pages load without 404.
- **reviewer should verify:** Click the Careers and Careers Site Privacy Notice links in the site footer and confirm they navigate correctly to `/career` and `/career-privacy-policy` without returning a 404 page.
- [x] commits are signed off with DCO
- [x] relevant route or smoke checks
- [x] npm tsc --noEmit
- [ ] npm run test
- [ ] npm run build:web
- [ ] npm run env:check
- [ ] npm run lint:ci

## Notes
- No deployment changes required. Pure string corrections in 3 files. Safe to revert independently. No breaking changes.