### PR TITLE
fix(onboarding): replace dead /onboarding/step-10 back routes with correct targets

### DIFF
--- a/src/pages/onboarding/MeetCeo.tsx
+++ b/src/pages/onboarding/MeetCeo.tsx
@@ -190,7 +190,7 @@ function MeetCeoPage() {
   };
 
   const handleContinue = () => navigate('/hushh-user-profile');
-  const handleBack = () => navigate('/onboarding/step-10');
+  const handleBack = () => navigate('/onboarding/verify');
 
   /* ── Shimmer Loader ── */
   if (paymentState === 'loading' || paymentState === 'verifying') {

--- a/src/pages/onboarding/meet-ceo/logic.ts
+++ b/src/pages/onboarding/meet-ceo/logic.ts
@@ -200,7 +200,7 @@ export function useMeetCeoLogic() {
   }, [fetchCalendarSlots, paymentState]);
 
   const handleContinue = () => navigate('/hushh-user-profile');
-  const handleBack = () => navigate('/onboarding/step-10');
+  const handleBack = () => navigate('/onboarding/verify');
 
   return {
     paymentState,

--- a/src/pages/onboarding/verify-identity/logic.ts
+++ b/src/pages/onboarding/verify-identity/logic.ts
@@ -178,7 +178,7 @@ export function useVerifyIdentityLogic() {
     navigate('/hushh-user-profile');
   };
 
-  const goBack = () => navigate('/onboarding/step-10');
+  const goBack = () => navigate('/onboarding/step-9');
 
   return {
     loading,


### PR DESCRIPTION
## Summary

* what changed: Replaced stale `/onboarding/step-10` back-navigation targets with valid onboarding routes in Verify Identity and Meet CEO onboarding flows
* why it changed: Prevents authenticated onboarding users from being sent to the app 404 page when using back navigation after onboarding step renumbering consolidated the onboarding flow from 10+ steps down to 9
* linked issue: none - standalone frontend navigation correctness fix for dead onboarding routes after onboarding flow consolidation
* acceptance criteria covered: Verify Identity back navigation lands on `/onboarding/step-9` Meet CEO back navigation lands on `/onboarding/verify` no onboarding back actions navigate to nonexistent routes existing onboarding progression remains unchanged
* risk area touched: ui | navigation
* reviewer focus: Confirm back navigation from Verify Identity and Meet CEO no longer lands on 404 verify updated routes exist in `App.tsx` ensure onboarding progression behavior remains unchanged

## Validation

* [x] Verified `/onboarding/step-10` no longer exists in the repository

* [x] Verified all updated back-navigation targets are registered routes in `App.tsx`

* [x] Verified no remaining onboarding navigation references to `step-10`

* [x] Verified onboarding back-navigation paths align with the current onboarding flow ordering

* [x] Verified no onboarding state logic or route definitions were modified

* ran: Repository-wide route reference verification onboarding flow inspection TypeScript validation lint pipeline build validation manual navigation-path verification

* did not run: Automated onboarding navigation E2E coverage for these specific back-navigation interactions

* reviewer should verify: Navigate through onboarding Verify Identity and Meet CEO screens confirm back actions land on valid onboarding routes and no 404 page is reached

## Notes

* deployment impact: Low risk because this is a narrow frontend navigation correction with no onboarding business-logic changes
* migration or env requirements: None required no environment variables infrastructure or route definitions changed
* rollback or release notes: Safe to rollback if needed restores previous dead-route navigation behavior
* follow-up work if any: Consider consolidating onboarding route targets into shared route constants to reduce future navigation drift
* reviewer callouts or codeowners you expect to review this: Frontend onboarding/navigation maintainers reviewers familiar with onboarding route consolidation history
