### PR TITLE
fix(nav): correct broken routes in HushhTechNavDrawer — /philosophy → /about/leadership, /kyc → /a2a-playground

### DIFF
--- a/src/components/hushh-tech-nav-drawer/HushhTechNavDrawer.tsx
+++ b/src/components/hushh-tech-nav-drawer/HushhTechNavDrawer.tsx
@@ -19,10 +19,10 @@ interface NavItem {
 
 const NAV_ITEMS: NavItem[] = [
   { icon: "home", label: "Home", path: "/" },
-  { icon: "menu_book", label: "Our Philosophy", path: "/philosophy" },
+  { icon: "menu_book", label: "Our Philosophy", path: "/about/leadership" },
   { icon: "pie_chart", label: "Fund A", path: "/discover-fund-a" },
   { icon: "groups", label: "Community", path: "/community" },
-  { icon: "verified_user", label: "KYC Studio Alpha", path: "/kyc" },
+  { icon: "verified_user", label: "KYC Studio Alpha", path: "/a2a-playground" },
 ];
 
 const HIGHLIGHT_ITEM: NavItem = {


### PR DESCRIPTION
## Summary

- what changed: Corrected broken HushhTechNavDrawer route targets by updating `/philosophy` to `/about/leadership` and `/kyc` to `/a2a-playground`
- why it changed: Ensures navigation drawer links resolve to existing live routes instead of sending users to unavailable or incorrect paths
- linked issue: none - standalone navigation route correctness fix
- acceptance criteria covered: Updated drawer links navigate to valid routes existing drawer behavior remains unchanged no unrelated navigation structure changes introduced
- risk area touched: ui
- reviewer focus: Confirm updated HushhTechNavDrawer links navigate correctly verify drawer behavior and visual presentation remain unchanged

## Validation

- [x] Verified `/about/leadership` route resolves correctly
- [x] Verified `/a2a-playground` route resolves correctly
- [x] Verified drawer navigation behavior remains unchanged
- [x] Verified no visual UI regressions introduced
- [x] No runtime navigation errors introduced

- ran: Manual drawer navigation verification local route checks code review for route target consistency
- did not run: Automated navigation integration tests can be added in a follow-up PR if maintainers request expanded route coverage
- reviewer should verify: Open HushhTechNavDrawer and confirm the updated items navigate to `/about/leadership` and `/a2a-playground` correctly

## Notes

- deployment impact: Low risk frontend navigation correction no backend or API changes
- migration or env requirements: None required
- rollback or release notes: Safe to rollback if needed restores previous drawer route targets
- follow-up work if any: Consider adding route existence checks for drawer navigation items
- reviewer callouts or codeowners you expect to review this: This is a bounded frontend navigation correctness fix focused only on broken drawer route targets