### PR TITLE
fix(ui): improve tabs accessibility and keyboard navigation

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useState, ReactNode, KeyboardEvent } from "react";
 
 interface TabsProps {
   defaultValue: string;
@@ -16,7 +16,11 @@ interface TabsContentProps {
   children: ReactNode;
 }
 
-export const Tabs: React.FC<TabsProps> = ({ defaultValue, children, className }) => {
+export const Tabs: React.FC<TabsProps> = ({
+  defaultValue,
+  children,
+  className,
+}) => {
   const [activeTab, setActiveTab] = useState(defaultValue);
 
   return (
@@ -25,37 +29,120 @@ export const Tabs: React.FC<TabsProps> = ({ defaultValue, children, className })
         child.type === TabsList
           ? React.cloneElement(child, { activeTab, setActiveTab })
           : child.type === TabsContent && child.props.value === activeTab
-          ? child
+          ? React.cloneElement(child, { activeTab })
           : null
       )}
     </div>
   );
 };
 
-export const TabsList: React.FC<{ children: ReactNode; activeTab?: string; setActiveTab?: (value: string) => void }> = ({
-  children,
-  activeTab,
-  setActiveTab,
-}) => (
-  <div className="flex gap-2">
-    {React.Children.map(children, (child: any) =>
-      React.cloneElement(child, { activeTab, setActiveTab })
-    )}
-  </div>
-);
+export const TabsList: React.FC<{
+  children: ReactNode;
+  activeTab?: string;
+  setActiveTab?: (value: string) => void;
+}> = ({ children, activeTab, setActiveTab }) => {
+  const triggers = React.Children.toArray(children);
 
-export const TabsTrigger: React.FC<TabsTriggerProps & { activeTab?: string; setActiveTab?: (value: string) => void }> = ({
+  const handleKeyDown = (
+    e: KeyboardEvent<HTMLElement>,
+    currentIndex: number
+  ) => {
+    let nextIndex = currentIndex;
+
+    switch (e.key) {
+      case "ArrowRight":
+        nextIndex = (currentIndex + 1) % triggers.length;
+        break;
+
+      case "ArrowLeft":
+        nextIndex = (currentIndex - 1 + triggers.length) % triggers.length;
+        break;
+
+      case "Home":
+        nextIndex = 0;
+        break;
+
+      case "End":
+        nextIndex = triggers.length - 1;
+        break;
+
+      default:
+        return;
+    }
+
+    e.preventDefault();
+
+    const nextChild: any = triggers[nextIndex];
+
+    setActiveTab?.(nextChild.props.value);
+
+    const nextButton = document.getElementById(
+      `tab-${nextChild.props.value}`
+    );
+
+    nextButton?.focus();
+  };
+
+  return (
+    <div
+      role="tablist"
+      aria-orientation="horizontal"
+      className="flex gap-2"
+    >
+      {triggers.map((child: any, index) =>
+        React.cloneElement(child, {
+          activeTab,
+          setActiveTab,
+          onKeyDown: (e: KeyboardEvent<HTMLButtonElement>) =>
+            handleKeyDown(e, index),
+        })
+      )}
+    </div>
+  );
+};
+
+export const TabsTrigger: React.FC<
+  TabsTriggerProps & {
+    activeTab?: string;
+    setActiveTab?: (value: string) => void;
+    onKeyDown?: (e: KeyboardEvent<HTMLButtonElement>) => void;
+  }
+> = ({
   value,
   children,
   activeTab,
   setActiveTab,
+  onKeyDown,
 }) => (
   <button
+    type="button"
+    id={`tab-${value}`}
+    role="tab"
+    aria-selected={activeTab === value}
+    aria-controls={`panel-${value}`}
+    tabIndex={activeTab === value ? 0 : -1}
     onClick={() => setActiveTab?.(value)}
-    className={`px-4 py-2 rounded-lg ${activeTab === value ? 'bg-blue-500 text-white' : 'bg-gray-200 text-black'}`}
+    onKeyDown={onKeyDown}
+    className={`px-4 py-2 rounded-lg min-h-[44px] ${
+      activeTab === value
+        ? "bg-blue-500 text-white"
+        : "bg-gray-200 text-black"
+    }`}
   >
     {children}
   </button>
 );
 
-export const TabsContent: React.FC<TabsContentProps> = ({ value, children }) => <div>{children}</div>;
+export const TabsContent: React.FC<
+  TabsContentProps & { activeTab?: string }
+> = ({ value, children, activeTab }) => (
+  <div
+    id={`panel-${value}`}
+    role="tabpanel"
+    aria-labelledby={`tab-${value}`}
+    hidden={activeTab !== value}
+    tabIndex={activeTab === value ? 0 : -1}
+  >
+    {children}
+  </div>
+);


### PR DESCRIPTION
## Summary
- what changed: Improved accessibility and keyboard navigation support for the reusable `tabs.tsx` UI component. Added proper ARIA tab semantics, keyboard navigation support, focus management, accessible tab panel relationships, and improved touch target sizing.
- why it changed: The existing tabs component was visually functional but lacked accessible tab semantics and keyboard interaction support, creating usability and WCAG accessibility issues for keyboard and assistive technology users.
- linked issue: `none - accessibility improvement for reusable tabs component`
- acceptance criteria covered: Added `role="tablist"`, `role="tab"`, and `role="tabpanel"` semantics, implemented keyboard navigation using ArrowLeft, ArrowRight, Home, and End keys, added focus management between tabs, improved active tab accessibility state handling, and increased touch target sizing for better usability.
- risk area touched: `ui`
- reviewer focus: Verify keyboard navigation behavior, focus movement between tabs, ARIA semantics, active tab state behavior, and regression-free rendering for existing tab usage.

## Validation
- [ ] commits are signed off with DCO (`git commit -s`)
- [ ] `npm run test`
- [x] `npx tsc --noEmit`
- [ ] `npm run build:web`
- [ ] `npm run env:check`
- [ ] `npm run lint:ci`
- [x] relevant route or smoke checks
- [ ] security checks when secrets, auth, infra, or deploy paths changed
- ran: Manual keyboard accessibility validation, tab focus navigation testing, and TypeScript validation using `npx tsc --noEmit`.
- did not run: Full automated test suite, CI lint pipeline.
- reviewer should verify: Verify ArrowLeft/ArrowRight/Home/End keyboard navigation behavior, confirm focus moves correctly between tabs, validate active tab accessibility semantics, and ensure existing tab layouts render correctly.

## Notes
- deployment impact: none
- migration or env requirements: none
- rollback or release notes: Revert tabs accessibility enhancements if regressions are identified in existing tab usage.
- follow-up work if any: Potential future enhancement for stricter child typing and optional vertical tab orientation support.
- reviewer callouts or CODEOWNERS you expect to review this: Frontend/UI maintainers.