### PR TITLE
refactor(ui): Migrate Tabs to Context API for Stability and A11y

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,4 +1,17 @@
-import React, { useState, ReactNode } from 'react';
+import React, { useState, createContext, useContext, ReactNode } from 'react';
+
+interface TabsContextType {
+  activeTab: string;
+  setActiveTab: (value: string) => void;
+}
+
+const TabsContext = createContext<TabsContextType | undefined>(undefined);
+
+const useTabs = () => {
+  const context = useContext(TabsContext);
+  if (!context) throw new Error('Tabs components must be used within <Tabs />');
+  return context;
+};
 
 interface TabsProps {
   defaultValue: string;
@@ -6,56 +19,64 @@ interface TabsProps {
   className?: string;
 }
 
-interface TabsTriggerProps {
-  value: string;
-  children: ReactNode;
-}
-
-interface TabsContentProps {
-  value: string;
-  children: ReactNode;
-}
-
 export const Tabs: React.FC<TabsProps> = ({ defaultValue, children, className }) => {
   const [activeTab, setActiveTab] = useState(defaultValue);
 
   return (
-    <div className={className}>
-      {React.Children.map(children, (child: any) =>
-        child.type === TabsList
-          ? React.cloneElement(child, { activeTab, setActiveTab })
-          : child.type === TabsContent && child.props.value === activeTab
-          ? child
-          : null
-      )}
-    </div>
+    <TabsContext.Provider value={{ activeTab, setActiveTab }}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
   );
 };
 
-export const TabsList: React.FC<{ children: ReactNode; activeTab?: string; setActiveTab?: (value: string) => void }> = ({
+export const TabsList: React.FC<{ children: ReactNode; className?: string }> = ({
   children,
-  activeTab,
-  setActiveTab,
+  className = ""
 }) => (
-  <div className="flex gap-2">
-    {React.Children.map(children, (child: any) =>
-      React.cloneElement(child, { activeTab, setActiveTab })
-    )}
+  <div
+    role="tablist"
+    className={`flex gap-2 p-1 bg-gray-100 rounded-xl ${className}`}
+  >
+    {children}
   </div>
 );
 
-export const TabsTrigger: React.FC<TabsTriggerProps & { activeTab?: string; setActiveTab?: (value: string) => void }> = ({
+export const TabsTrigger: React.FC<{ value: string; children: ReactNode; className?: string }> = ({
   value,
   children,
-  activeTab,
-  setActiveTab,
-}) => (
-  <button
-    onClick={() => setActiveTab?.(value)}
-    className={`px-4 py-2 rounded-lg ${activeTab === value ? 'bg-blue-500 text-white' : 'bg-gray-200 text-black'}`}
-  >
-    {children}
-  </button>
-);
+  className = ""
+}) => {
+  const { activeTab, setActiveTab } = useTabs();
+  const isActive = activeTab === value;
 
-export const TabsContent: React.FC<TabsContentProps> = ({ value, children }) => <div>{children}</div>;
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => setActiveTab(value)}
+      className={`px-4 py-2 text-sm font-medium transition-all duration-200 rounded-lg 
+        ${isActive
+          ? 'bg-white text-blue-600 shadow-sm'
+          : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200/50'
+        } focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${className}`}
+    >
+      {children}
+    </button>
+  );
+};
+
+export const TabsContent: React.FC<{ value: string; children: ReactNode }> = ({ value, children }) => {
+  const { activeTab } = useTabs();
+  if (activeTab !== value) return null;
+
+  return (
+    <div
+      role="tabpanel"
+      className="mt-4 animate-in fade-in slide-in-from-bottom-1 duration-300"
+    >
+      {children}
+
+
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

* what changed: Refactored the `Tabs` component to use the **React Context API** and added **ARIA accessibility roles** (`tablist`, `tab`, `tabpanel`).
* why it changed: To replace the brittle `cloneElement` pattern with a more robust, nestable architecture and improve screen reader support.
* linked issue: none - standalone UI architectural improvement for stability
* acceptance criteria covered: `Tabs` components are now nestable; ARIA roles are correctly implemented; smooth Tailwind transitions added to `TabsContent`.
* risk area touched: ui
* reviewer focus: Verify the `useTabs` hook's error handling and ensure the active state styling updates correctly across all components.

## Validation

* [x] I have tested these changes locally in the browser.
* [x] I have verified no console errors appear.
* [x] The code matches the project's formatting standards.
* ran: npm run build:web, npx tsc --noEmit, npm run test
* did not run: none
* reviewer should verify: Click through the tabs to ensure visibility toggles correctly and inspect the DOM to confirm ARIA attributes are present.

## Notes

* deployment impact: none
* migration or env requirements: none
* rollback or release notes: none
* follow-up work if any: none
* reviewer callouts or codeowners you expect to review this: None